### PR TITLE
Feat/navigation within trip

### DIFF
--- a/app/src/androidTest/java/com/android/voyageur/ui/overview/OverviewScreenTest.kt
+++ b/app/src/androidTest/java/com/android/voyageur/ui/overview/OverviewScreenTest.kt
@@ -74,12 +74,12 @@ class OverviewScreenTest {
 
   @Test
   fun clickingTripCardNavigatesToTripDetails() {
-    val mockTrip = Trip(
-      id = "1",
-      creator = "Andreea",
-      participants = listOf("Alex", "Mihai"),
-      name = "Paris Trip"
-    )
+    val mockTrip =
+        Trip(
+            id = "1",
+            creator = "Andreea",
+            participants = listOf("Alex", "Mihai"),
+            name = "Paris Trip")
     val mockTrips = listOf(mockTrip)
 
     // Simulate getting the mock trip from the repository

--- a/app/src/androidTest/java/com/android/voyageur/ui/overview/OverviewScreenTest.kt
+++ b/app/src/androidTest/java/com/android/voyageur/ui/overview/OverviewScreenTest.kt
@@ -73,6 +73,31 @@ class OverviewScreenTest {
   }
 
   @Test
+  fun clickingTripCardNavigatesToTripDetails() {
+    val mockTrip = Trip(
+      id = "1",
+      creator = "Andreea",
+      participants = listOf("Alex", "Mihai"),
+      name = "Paris Trip"
+    )
+    val mockTrips = listOf(mockTrip)
+
+    // Simulate getting the mock trip from the repository
+    `when`(tripRepository.getTrips(any(), any(), any())).then {
+      it.getArgument<(List<Trip>) -> Unit>(1)(mockTrips)
+    }
+
+    tripViewModel.getTrips()
+
+    // Simulate clicking the trip card
+    composeTestRule.onNodeWithTag("cardItem").performClick()
+
+    // Verify the trip is selected and navigation to the BY_DAY screen is called
+    assert(tripViewModel.selectedTrip.value == mockTrip)
+    verify(navigationActions).navigateTo(screen = Screen.BY_DAY)
+  }
+
+  @Test
   fun createTripButtonCallsNavActions() {
     composeTestRule.onNodeWithTag("overviewScreen").assertIsDisplayed()
     composeTestRule.onNodeWithTag("createTripButton").assertIsDisplayed()

--- a/app/src/androidTest/java/com/android/voyageur/ui/trip/activities/ActivitiesScreenTest.kt
+++ b/app/src/androidTest/java/com/android/voyageur/ui/trip/activities/ActivitiesScreenTest.kt
@@ -36,13 +36,19 @@ class ActivitiesScreenTest {
     tripsViewModel = TripsViewModel(tripRepository)
 
     `when`(navigationActions.currentRoute()).thenReturn(Route.ACTIVITIES)
-    val sampleTrip = Trip(name = "Sample Trip")
-    tripsViewModel.selectTrip(sampleTrip)
-    composeTestRule.setContent { ActivitiesScreen(tripsViewModel, navigationActions) }
+  }
+
+  @Test
+  fun displayTextWhenNoTripSelected() {
+        composeTestRule.setContent { ActivitiesScreen(tripsViewModel, navigationActions) }
+
+    composeTestRule.onNodeWithText("No ToDo selected. Should not happen").assertIsDisplayed()
   }
 
   @Test
   fun hasRequiredComponents() {
+    tripsViewModel.selectTrip(Trip(name = "Sample Trip"))
+    composeTestRule.setContent { ActivitiesScreen(tripsViewModel, navigationActions) }
     composeTestRule.onNodeWithTag("activitiesScreen").assertIsDisplayed()
     composeTestRule.onNodeWithTag("bottomNavigationMenu").assertIsDisplayed()
     composeTestRule.onNodeWithTag("topBar").assertIsDisplayed()
@@ -50,6 +56,8 @@ class ActivitiesScreenTest {
 
   @Test
   fun displaysTopBarCorrectly() {
+    tripsViewModel.selectTrip(Trip(name = "Sample Trip"))
+    composeTestRule.setContent { ActivitiesScreen(tripsViewModel, navigationActions) }
 
     // Check that the top bar with the title is displayed
     composeTestRule.onNodeWithText("Activities:").assertIsDisplayed()
@@ -61,6 +69,8 @@ class ActivitiesScreenTest {
 
   @Test
   fun navigatesToOverviewOnHomeIconClick() {
+    tripsViewModel.selectTrip(Trip(name = "Sample Trip"))
+    composeTestRule.setContent { ActivitiesScreen(tripsViewModel, navigationActions) }
 
     // Simulate a click on the Home icon button
     composeTestRule.onNodeWithContentDescription("Home").performClick()
@@ -71,6 +81,8 @@ class ActivitiesScreenTest {
 
   @Test
   fun displaysCorrectTripName() {
+    tripsViewModel.selectTrip(Trip(name = "Sample Trip"))
+    composeTestRule.setContent { ActivitiesScreen(tripsViewModel, navigationActions) }
     composeTestRule
         .onNodeWithTag("emptyActivitiesPrompt")
         .assertTextContains(
@@ -79,6 +91,8 @@ class ActivitiesScreenTest {
 
   @Test
   fun displaysBottomNavigationCorrectly() {
+    tripsViewModel.selectTrip(Trip(name = "Sample Trip"))
+    composeTestRule.setContent { ActivitiesScreen(tripsViewModel, navigationActions) }
 
     // Check that the bottom navigation menu is displayed
     composeTestRule.onNodeWithTag("bottomNavigationMenu").assertIsDisplayed()

--- a/app/src/androidTest/java/com/android/voyageur/ui/trip/activities/ActivitiesScreenTest.kt
+++ b/app/src/androidTest/java/com/android/voyageur/ui/trip/activities/ActivitiesScreenTest.kt
@@ -15,6 +15,9 @@ import com.android.voyageur.ui.navigation.LIST_TRIP_LEVEL_DESTINATION
 import com.android.voyageur.ui.navigation.NavigationActions
 import com.android.voyageur.ui.navigation.Route
 import com.android.voyageur.ui.navigation.Screen
+import com.android.voyageur.ui.navigation.TopLevelDestinations.SCHEDULE
+import com.android.voyageur.ui.navigation.TopLevelDestinations.SETTINGS
+import com.android.voyageur.ui.trip.schedule.ByDayScreen
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
@@ -40,7 +43,7 @@ class ActivitiesScreenTest {
 
   @Test
   fun displayTextWhenNoTripSelected() {
-        composeTestRule.setContent { ActivitiesScreen(tripsViewModel, navigationActions) }
+    composeTestRule.setContent { ActivitiesScreen(tripsViewModel, navigationActions) }
 
     composeTestRule.onNodeWithText("No ToDo selected. Should not happen").assertIsDisplayed()
   }
@@ -101,5 +104,19 @@ class ActivitiesScreenTest {
     LIST_TRIP_LEVEL_DESTINATION.forEach { destination ->
       composeTestRule.onNodeWithText(destination.textId).assertExists()
     }
+  }
+
+  @Test
+  fun bottomNavigationMenu_navigatesToSelectedTab() {
+    tripsViewModel.selectTrip(Trip(name = "Sample Trip"))
+    composeTestRule.setContent { ByDayScreen(tripsViewModel, navigationActions) }
+
+    // Select the "Schedule" tab
+    composeTestRule.onNodeWithTag("Schedule").performClick()
+    verify(navigationActions).navigateTo(SCHEDULE)
+
+    // Select the "Settings" tab
+    composeTestRule.onNodeWithTag("Settings").performClick()
+    verify(navigationActions).navigateTo(SETTINGS)
   }
 }

--- a/app/src/androidTest/java/com/android/voyageur/ui/trip/activities/ActivitiesScreenTest.kt
+++ b/app/src/androidTest/java/com/android/voyageur/ui/trip/activities/ActivitiesScreenTest.kt
@@ -1,0 +1,91 @@
+package com.android.voyageur.ui.trip.activities
+
+import androidx.compose.ui.test.assertHasClickAction
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.assertTextContains
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithContentDescription
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import com.android.voyageur.model.trip.Trip
+import com.android.voyageur.model.trip.TripRepository
+import com.android.voyageur.model.trip.TripsViewModel
+import com.android.voyageur.ui.navigation.LIST_TRIP_LEVEL_DESTINATION
+import com.android.voyageur.ui.navigation.NavigationActions
+import com.android.voyageur.ui.navigation.Route
+import com.android.voyageur.ui.navigation.Screen
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.mockito.Mockito.mock
+import org.mockito.Mockito.`when`
+import org.mockito.kotlin.verify
+
+class ActivitiesScreenTest {
+  private lateinit var tripRepository: TripRepository
+  private lateinit var navigationActions: NavigationActions
+  private lateinit var tripsViewModel: TripsViewModel
+
+  @get:Rule val composeTestRule = createComposeRule()
+
+  @Before
+  fun setUp() {
+    tripRepository = mock(TripRepository::class.java)
+    navigationActions = mock(NavigationActions::class.java)
+    tripsViewModel = TripsViewModel(tripRepository)
+
+    `when`(navigationActions.currentRoute()).thenReturn(Route.ACTIVITIES)
+    val sampleTrip = Trip(name = "Sample Trip")
+    tripsViewModel.selectTrip(sampleTrip)
+    composeTestRule.setContent { ActivitiesScreen(tripsViewModel, navigationActions) }
+  }
+
+  @Test
+  fun hasRequiredComponents() {
+    composeTestRule.onNodeWithTag("activitiesScreen").assertIsDisplayed()
+    composeTestRule.onNodeWithTag("bottomNavigationMenu").assertIsDisplayed()
+    composeTestRule.onNodeWithTag("topBar").assertIsDisplayed()
+  }
+
+  @Test
+  fun displaysTopBarCorrectly() {
+
+    // Check that the top bar with the title is displayed
+    composeTestRule.onNodeWithText("Activities:").assertIsDisplayed()
+
+    // Check that the Home icon button is displayed and clickable
+    composeTestRule.onNodeWithTag("backToOverviewButton").assertIsDisplayed().assertHasClickAction()
+    composeTestRule.onNodeWithContentDescription("Home").assertIsDisplayed().assertHasClickAction()
+  }
+
+  @Test
+  fun navigatesToOverviewOnHomeIconClick() {
+
+    // Simulate a click on the Home icon button
+    composeTestRule.onNodeWithContentDescription("Home").performClick()
+
+    // Verify that the navigation to the Overview screen was triggered
+    verify(navigationActions).navigateTo(Screen.OVERVIEW)
+  }
+
+  @Test
+  fun displaysCorrectTripName() {
+    composeTestRule
+        .onNodeWithTag("emptyActivitiesPrompt")
+        .assertTextContains(
+            "You're viewing the Activities screen for Sample Trip, but it's not implemented yet.")
+  }
+
+  @Test
+  fun displaysBottomNavigationCorrectly() {
+
+    // Check that the bottom navigation menu is displayed
+    composeTestRule.onNodeWithTag("bottomNavigationMenu").assertIsDisplayed()
+
+    // Verify that the bottom navigation has items with correct actions
+    LIST_TRIP_LEVEL_DESTINATION.forEach { destination ->
+      composeTestRule.onNodeWithText(destination.textId).assertExists()
+    }
+  }
+}

--- a/app/src/androidTest/java/com/android/voyageur/ui/trip/schedule/ByDayScreenTest.kt
+++ b/app/src/androidTest/java/com/android/voyageur/ui/trip/schedule/ByDayScreenTest.kt
@@ -1,0 +1,91 @@
+package com.android.voyageur.ui.trip.schedule
+
+import androidx.compose.ui.test.assertHasClickAction
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.assertTextContains
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithContentDescription
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import com.android.voyageur.model.trip.Trip
+import com.android.voyageur.model.trip.TripRepository
+import com.android.voyageur.model.trip.TripsViewModel
+import com.android.voyageur.ui.navigation.LIST_TRIP_LEVEL_DESTINATION
+import com.android.voyageur.ui.navigation.NavigationActions
+import com.android.voyageur.ui.navigation.Route
+import com.android.voyageur.ui.navigation.Screen
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.mockito.Mockito.mock
+import org.mockito.Mockito.`when`
+import org.mockito.kotlin.verify
+
+class ByDayScreenTest {
+  private lateinit var tripRepository: TripRepository
+  private lateinit var navigationActions: NavigationActions
+  private lateinit var tripsViewModel: TripsViewModel
+
+  @get:Rule val composeTestRule = createComposeRule()
+
+  @Before
+  fun setUp() {
+    tripRepository = mock(TripRepository::class.java)
+    navigationActions = mock(NavigationActions::class.java)
+    tripsViewModel = TripsViewModel(tripRepository)
+
+    `when`(navigationActions.currentRoute()).thenReturn(Route.SCHEDULE)
+    val sampleTrip = Trip(name = "Sample Trip")
+    tripsViewModel.selectTrip(sampleTrip)
+    composeTestRule.setContent { ByDayScreen(tripsViewModel, navigationActions) }
+  }
+
+  @Test
+  fun hasRequiredComponents() {
+    composeTestRule.onNodeWithTag("byDayScreen").assertIsDisplayed()
+    composeTestRule.onNodeWithTag("bottomNavigationMenu").assertIsDisplayed()
+    composeTestRule.onNodeWithTag("topBar").assertIsDisplayed()
+  }
+
+  @Test
+  fun displaysTopBarCorrectly() {
+
+    // Check that the top bar with the title is displayed
+    composeTestRule.onNodeWithText("Schedule ByDay:").assertIsDisplayed()
+
+    // Check that the Home icon button is displayed and clickable
+    composeTestRule.onNodeWithTag("backToOverviewButton").assertIsDisplayed().assertHasClickAction()
+    composeTestRule.onNodeWithContentDescription("Home").assertIsDisplayed().assertHasClickAction()
+  }
+
+  @Test
+  fun navigatesToOverviewOnHomeIconClick() {
+
+    // Simulate a click on the Home icon button
+    composeTestRule.onNodeWithContentDescription("Home").performClick()
+
+    // Verify that the navigation to the Overview screen was triggered
+    verify(navigationActions).navigateTo(Screen.OVERVIEW)
+  }
+
+  @Test
+  fun displaysCorrectTripName() {
+    composeTestRule
+        .onNodeWithTag("emptyByDayPrompt")
+        .assertTextContains(
+            "You're viewing the ByDay screen for Sample Trip, but it's not implemented yet.")
+  }
+
+  @Test
+  fun displaysBottomNavigationCorrectly() {
+
+    // Check that the bottom navigation menu is displayed
+    composeTestRule.onNodeWithTag("bottomNavigationMenu").assertIsDisplayed()
+
+    // Verify that the bottom navigation has items with correct actions
+    LIST_TRIP_LEVEL_DESTINATION.forEach { destination ->
+      composeTestRule.onNodeWithText(destination.textId).assertExists()
+    }
+  }
+}

--- a/app/src/androidTest/java/com/android/voyageur/ui/trip/schedule/ByDayScreenTest.kt
+++ b/app/src/androidTest/java/com/android/voyageur/ui/trip/schedule/ByDayScreenTest.kt
@@ -15,6 +15,7 @@ import com.android.voyageur.ui.navigation.LIST_TRIP_LEVEL_DESTINATION
 import com.android.voyageur.ui.navigation.NavigationActions
 import com.android.voyageur.ui.navigation.Route
 import com.android.voyageur.ui.navigation.Screen
+import com.android.voyageur.ui.trip.activities.ActivitiesScreen
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
@@ -36,13 +37,19 @@ class ByDayScreenTest {
     tripsViewModel = TripsViewModel(tripRepository)
 
     `when`(navigationActions.currentRoute()).thenReturn(Route.SCHEDULE)
-    val sampleTrip = Trip(name = "Sample Trip")
-    tripsViewModel.selectTrip(sampleTrip)
+  }
+
+  @Test
+  fun displayTextWhenNoTripSelected() {
     composeTestRule.setContent { ByDayScreen(tripsViewModel, navigationActions) }
+
+    composeTestRule.onNodeWithText("No ToDo selected. Should not happen").assertIsDisplayed()
   }
 
   @Test
   fun hasRequiredComponents() {
+    tripsViewModel.selectTrip(Trip(name = "Sample Trip"))
+    composeTestRule.setContent { ByDayScreen(tripsViewModel, navigationActions) }
     composeTestRule.onNodeWithTag("byDayScreen").assertIsDisplayed()
     composeTestRule.onNodeWithTag("bottomNavigationMenu").assertIsDisplayed()
     composeTestRule.onNodeWithTag("topBar").assertIsDisplayed()
@@ -50,6 +57,8 @@ class ByDayScreenTest {
 
   @Test
   fun displaysTopBarCorrectly() {
+    tripsViewModel.selectTrip(Trip(name = "Sample Trip"))
+    composeTestRule.setContent { ByDayScreen(tripsViewModel, navigationActions) }
 
     // Check that the top bar with the title is displayed
     composeTestRule.onNodeWithText("Schedule ByDay:").assertIsDisplayed()
@@ -61,6 +70,8 @@ class ByDayScreenTest {
 
   @Test
   fun navigatesToOverviewOnHomeIconClick() {
+    tripsViewModel.selectTrip(Trip(name = "Sample Trip"))
+    composeTestRule.setContent { ByDayScreen(tripsViewModel, navigationActions) }
 
     // Simulate a click on the Home icon button
     composeTestRule.onNodeWithContentDescription("Home").performClick()
@@ -71,6 +82,8 @@ class ByDayScreenTest {
 
   @Test
   fun displaysCorrectTripName() {
+    tripsViewModel.selectTrip(Trip(name = "Sample Trip"))
+    composeTestRule.setContent { ByDayScreen(tripsViewModel, navigationActions) }
     composeTestRule
         .onNodeWithTag("emptyByDayPrompt")
         .assertTextContains(
@@ -79,6 +92,8 @@ class ByDayScreenTest {
 
   @Test
   fun displaysBottomNavigationCorrectly() {
+    tripsViewModel.selectTrip(Trip(name = "Sample Trip"))
+    composeTestRule.setContent { ByDayScreen(tripsViewModel, navigationActions) }
 
     // Check that the bottom navigation menu is displayed
     composeTestRule.onNodeWithTag("bottomNavigationMenu").assertIsDisplayed()

--- a/app/src/androidTest/java/com/android/voyageur/ui/trip/schedule/ByDayScreenTest.kt
+++ b/app/src/androidTest/java/com/android/voyageur/ui/trip/schedule/ByDayScreenTest.kt
@@ -15,7 +15,8 @@ import com.android.voyageur.ui.navigation.LIST_TRIP_LEVEL_DESTINATION
 import com.android.voyageur.ui.navigation.NavigationActions
 import com.android.voyageur.ui.navigation.Route
 import com.android.voyageur.ui.navigation.Screen
-import com.android.voyageur.ui.trip.activities.ActivitiesScreen
+import com.android.voyageur.ui.navigation.TopLevelDestinations.ACTIVITIES
+import com.android.voyageur.ui.navigation.TopLevelDestinations.SETTINGS
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
@@ -102,5 +103,19 @@ class ByDayScreenTest {
     LIST_TRIP_LEVEL_DESTINATION.forEach { destination ->
       composeTestRule.onNodeWithText(destination.textId).assertExists()
     }
+  }
+
+  @Test
+  fun bottomNavigationMenu_navigatesToSelectedTab() {
+    tripsViewModel.selectTrip(Trip(name = "Sample Trip"))
+    composeTestRule.setContent { ByDayScreen(tripsViewModel, navigationActions) }
+
+    // Select the "Activities" tab
+    composeTestRule.onNodeWithTag("Activities").performClick()
+    verify(navigationActions).navigateTo(ACTIVITIES)
+
+    // Select the "Settings" tab
+    composeTestRule.onNodeWithTag("Settings").performClick()
+    verify(navigationActions).navigateTo(SETTINGS)
   }
 }

--- a/app/src/androidTest/java/com/android/voyageur/ui/trip/settings/SettingsScreenTest.kt
+++ b/app/src/androidTest/java/com/android/voyageur/ui/trip/settings/SettingsScreenTest.kt
@@ -15,7 +15,9 @@ import com.android.voyageur.ui.navigation.LIST_TRIP_LEVEL_DESTINATION
 import com.android.voyageur.ui.navigation.NavigationActions
 import com.android.voyageur.ui.navigation.Route
 import com.android.voyageur.ui.navigation.Screen
-import com.android.voyageur.ui.trip.activities.ActivitiesScreen
+import com.android.voyageur.ui.navigation.TopLevelDestinations.ACTIVITIES
+import com.android.voyageur.ui.navigation.TopLevelDestinations.SCHEDULE
+import com.android.voyageur.ui.trip.schedule.ByDayScreen
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
@@ -102,5 +104,19 @@ class SettingsScreenTest {
     LIST_TRIP_LEVEL_DESTINATION.forEach { destination ->
       composeTestRule.onNodeWithText(destination.textId).assertExists()
     }
+  }
+
+  @Test
+  fun bottomNavigationMenu_navigatesToSelectedTab() {
+    tripsViewModel.selectTrip(Trip(name = "Sample Trip"))
+    composeTestRule.setContent { ByDayScreen(tripsViewModel, navigationActions) }
+
+    // Select the "Schedule" tab
+    composeTestRule.onNodeWithTag("Schedule").performClick()
+    verify(navigationActions).navigateTo(SCHEDULE)
+
+    // Select the "Activities" tab
+    composeTestRule.onNodeWithTag("Activities").performClick()
+    verify(navigationActions).navigateTo(ACTIVITIES)
   }
 }

--- a/app/src/androidTest/java/com/android/voyageur/ui/trip/settings/SettingsScreenTest.kt
+++ b/app/src/androidTest/java/com/android/voyageur/ui/trip/settings/SettingsScreenTest.kt
@@ -15,6 +15,7 @@ import com.android.voyageur.ui.navigation.LIST_TRIP_LEVEL_DESTINATION
 import com.android.voyageur.ui.navigation.NavigationActions
 import com.android.voyageur.ui.navigation.Route
 import com.android.voyageur.ui.navigation.Screen
+import com.android.voyageur.ui.trip.activities.ActivitiesScreen
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
@@ -36,13 +37,19 @@ class SettingsScreenTest {
     tripsViewModel = TripsViewModel(tripRepository)
 
     `when`(navigationActions.currentRoute()).thenReturn(Route.SETTINGS)
-    val sampleTrip = Trip(name = "Sample Trip")
-    tripsViewModel.selectTrip(sampleTrip)
+  }
+
+  @Test
+  fun displayTextWhenNoTripSelected() {
     composeTestRule.setContent { SettingsScreen(tripsViewModel, navigationActions) }
+
+    composeTestRule.onNodeWithText("No ToDo selected. Should not happen").assertIsDisplayed()
   }
 
   @Test
   fun hasRequiredComponents() {
+    tripsViewModel.selectTrip(Trip(name = "Sample Trip"))
+    composeTestRule.setContent { SettingsScreen(tripsViewModel, navigationActions) }
     composeTestRule.onNodeWithTag("settingsScreen").assertIsDisplayed()
     composeTestRule.onNodeWithTag("bottomNavigationMenu").assertIsDisplayed()
     composeTestRule.onNodeWithTag("topBar").assertIsDisplayed()
@@ -50,6 +57,8 @@ class SettingsScreenTest {
 
   @Test
   fun displaysTopBarCorrectly() {
+    tripsViewModel.selectTrip(Trip(name = "Sample Trip"))
+    composeTestRule.setContent { SettingsScreen(tripsViewModel, navigationActions) }
 
     // Check that the top bar with the title is displayed
     composeTestRule.onNodeWithText("Settings:").assertIsDisplayed()
@@ -61,6 +70,8 @@ class SettingsScreenTest {
 
   @Test
   fun navigatesToOverviewOnHomeIconClick() {
+    tripsViewModel.selectTrip(Trip(name = "Sample Trip"))
+    composeTestRule.setContent { SettingsScreen(tripsViewModel, navigationActions) }
 
     // Simulate a click on the Home icon button
     composeTestRule.onNodeWithContentDescription("Home").performClick()
@@ -71,6 +82,8 @@ class SettingsScreenTest {
 
   @Test
   fun displaysCorrectTripName() {
+    tripsViewModel.selectTrip(Trip(name = "Sample Trip"))
+    composeTestRule.setContent { SettingsScreen(tripsViewModel, navigationActions) }
     composeTestRule
         .onNodeWithTag("emptySettingsPrompt")
         .assertTextContains(
@@ -79,6 +92,8 @@ class SettingsScreenTest {
 
   @Test
   fun displaysBottomNavigationCorrectly() {
+    tripsViewModel.selectTrip(Trip(name = "Sample Trip"))
+    composeTestRule.setContent { SettingsScreen(tripsViewModel, navigationActions) }
 
     // Check that the bottom navigation menu is displayed
     composeTestRule.onNodeWithTag("bottomNavigationMenu").assertIsDisplayed()

--- a/app/src/androidTest/java/com/android/voyageur/ui/trip/settings/SettingsScreenTest.kt
+++ b/app/src/androidTest/java/com/android/voyageur/ui/trip/settings/SettingsScreenTest.kt
@@ -1,0 +1,91 @@
+package com.android.voyageur.ui.trip.settings
+
+import androidx.compose.ui.test.assertHasClickAction
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.assertTextContains
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithContentDescription
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import com.android.voyageur.model.trip.Trip
+import com.android.voyageur.model.trip.TripRepository
+import com.android.voyageur.model.trip.TripsViewModel
+import com.android.voyageur.ui.navigation.LIST_TRIP_LEVEL_DESTINATION
+import com.android.voyageur.ui.navigation.NavigationActions
+import com.android.voyageur.ui.navigation.Route
+import com.android.voyageur.ui.navigation.Screen
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.mockito.Mockito.mock
+import org.mockito.Mockito.`when`
+import org.mockito.kotlin.verify
+
+class SettingsScreenTest {
+  private lateinit var tripRepository: TripRepository
+  private lateinit var navigationActions: NavigationActions
+  private lateinit var tripsViewModel: TripsViewModel
+
+  @get:Rule val composeTestRule = createComposeRule()
+
+  @Before
+  fun setUp() {
+    tripRepository = mock(TripRepository::class.java)
+    navigationActions = mock(NavigationActions::class.java)
+    tripsViewModel = TripsViewModel(tripRepository)
+
+    `when`(navigationActions.currentRoute()).thenReturn(Route.SETTINGS)
+    val sampleTrip = Trip(name = "Sample Trip")
+    tripsViewModel.selectTrip(sampleTrip)
+    composeTestRule.setContent { SettingsScreen(tripsViewModel, navigationActions) }
+  }
+
+  @Test
+  fun hasRequiredComponents() {
+    composeTestRule.onNodeWithTag("settingsScreen").assertIsDisplayed()
+    composeTestRule.onNodeWithTag("bottomNavigationMenu").assertIsDisplayed()
+    composeTestRule.onNodeWithTag("topBar").assertIsDisplayed()
+  }
+
+  @Test
+  fun displaysTopBarCorrectly() {
+
+    // Check that the top bar with the title is displayed
+    composeTestRule.onNodeWithText("Settings:").assertIsDisplayed()
+
+    // Check that the Home icon button is displayed and clickable
+    composeTestRule.onNodeWithTag("backToOverviewButton").assertIsDisplayed().assertHasClickAction()
+    composeTestRule.onNodeWithContentDescription("Home").assertIsDisplayed().assertHasClickAction()
+  }
+
+  @Test
+  fun navigatesToOverviewOnHomeIconClick() {
+
+    // Simulate a click on the Home icon button
+    composeTestRule.onNodeWithContentDescription("Home").performClick()
+
+    // Verify that the navigation to the Overview screen was triggered
+    verify(navigationActions).navigateTo(Screen.OVERVIEW)
+  }
+
+  @Test
+  fun displaysCorrectTripName() {
+    composeTestRule
+        .onNodeWithTag("emptySettingsPrompt")
+        .assertTextContains(
+            "You're viewing the Settings screen for Sample Trip, but it's not implemented yet.")
+  }
+
+  @Test
+  fun displaysBottomNavigationCorrectly() {
+
+    // Check that the bottom navigation menu is displayed
+    composeTestRule.onNodeWithTag("bottomNavigationMenu").assertIsDisplayed()
+
+    // Verify that the bottom navigation has items with correct actions
+    LIST_TRIP_LEVEL_DESTINATION.forEach { destination ->
+      composeTestRule.onNodeWithText(destination.textId).assertExists()
+    }
+  }
+}

--- a/app/src/main/java/com/android/voyageur/App.kt
+++ b/app/src/main/java/com/android/voyageur/App.kt
@@ -16,6 +16,9 @@ import com.android.voyageur.ui.overview.AddTripScreen
 import com.android.voyageur.ui.overview.OverviewScreen
 import com.android.voyageur.ui.profile.ProfileScreen
 import com.android.voyageur.ui.search.SearchScreen
+import com.android.voyageur.ui.trip.activities.ActivitiesScreen
+import com.android.voyageur.ui.trip.schedule.ByDayScreen
+import com.android.voyageur.ui.trip.settings.SettingsScreen
 
 @Composable
 fun VoyageurApp() {
@@ -49,6 +52,15 @@ fun VoyageurApp() {
         route = Route.PROFILE,
     ) {
       composable(Screen.PROFILE) { ProfileScreen(userViewModel, navigationActions) }
+    }
+    navigation(startDestination = Screen.BY_DAY, route = Route.SCHEDULE) {
+      composable(Screen.BY_DAY) { ByDayScreen(tripsViewModel, navigationActions) }
+    }
+    navigation(startDestination = Screen.ACTIVITIES, route = Route.ACTIVITIES) {
+      composable(Screen.ACTIVITIES) { ActivitiesScreen(tripsViewModel, navigationActions) }
+    }
+    navigation(startDestination = Screen.SETTINGS, route = Route.SETTINGS) {
+      composable(Screen.SETTINGS) { SettingsScreen(tripsViewModel, navigationActions) }
     }
   }
 }

--- a/app/src/main/java/com/android/voyageur/model/trip/TripsViewModel.kt
+++ b/app/src/main/java/com/android/voyageur/model/trip/TripsViewModel.kt
@@ -3,37 +3,21 @@ package com.android.voyageur.model.trip
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
 import com.google.firebase.Firebase
-import com.google.firebase.Timestamp
 import com.google.firebase.auth.auth
 import com.google.firebase.firestore.firestore
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 
-class TripsViewModel(
+open class TripsViewModel(
     private val tripsRepository: TripRepository,
 ) : ViewModel() {
   private val _trips = MutableStateFlow<List<Trip>>(emptyList())
   val trips: StateFlow<List<Trip>> = _trips.asStateFlow()
 
   // useful for updating trip
-  private val _selectedTrip =
-      // initializing with empty trip
-      MutableStateFlow(
-          Trip(
-              "",
-              "",
-              emptyList(),
-              "",
-              "",
-              emptyList(),
-              Timestamp.now(),
-              Timestamp.now(),
-              emptyList(),
-              TripType.TOURISM,
-          ),
-      )
-  var selectedTrip: StateFlow<Trip> = _selectedTrip
+  private val _selectedTrip = MutableStateFlow<Trip?>(null)
+  open val selectedTrip: StateFlow<Trip?> = _selectedTrip.asStateFlow()
 
   init {
     tripsRepository.init {

--- a/app/src/main/java/com/android/voyageur/ui/navigation/NavigationActions.kt
+++ b/app/src/main/java/com/android/voyageur/ui/navigation/NavigationActions.kt
@@ -1,9 +1,11 @@
 package com.android.voyageur.ui.navigation
 
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.outlined.DateRange
 import androidx.compose.material.icons.outlined.Menu
 import androidx.compose.material.icons.outlined.Person
 import androidx.compose.material.icons.outlined.Search
+import androidx.compose.material.icons.outlined.Settings
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.navigation.NavGraph.Companion.findStartDestination
 import androidx.navigation.NavHostController
@@ -13,6 +15,9 @@ object Route {
   const val SEARCH = "Search"
   const val PROFILE = "Profile"
   const val AUTH = "Auth"
+  const val SCHEDULE = "Schedule"
+  const val ACTIVITIES = "Activities"
+  const val SETTINGS = "Settings"
 }
 
 object Screen {
@@ -21,6 +26,11 @@ object Screen {
   const val PROFILE = "Profile Screen"
   const val AUTH = "SignIn Screen"
   const val ADD_TRIP = "Add Trip Screen"
+  const val BY_DAY = "By Day Screen"
+  const val BY_WEEK = "By Week Screen" // TODO: Add ByWeek screen
+  const val ACTIVITIES = "Activities Screen"
+  const val ADD_ACTIVITY = "Add Activity Screen" // TODO: Add AddActivity screen
+  const val SETTINGS = "Settings Screen"
 }
 
 data class TopLevelDestination(
@@ -36,10 +46,22 @@ object TopLevelDestinations {
       TopLevelDestination(route = Route.SEARCH, icon = Icons.Outlined.Search, textId = "Search")
   val PROFILE =
       TopLevelDestination(route = Route.PROFILE, icon = Icons.Outlined.Person, textId = "Profile")
+  val SCHEDULE =
+      TopLevelDestination(Route.SCHEDULE, icon = Icons.Outlined.DateRange, textId = "Schedule")
+  val ACTIVITIES =
+      TopLevelDestination(Route.ACTIVITIES, icon = Icons.Outlined.Search, textId = "Activities")
+  val SETTINGS =
+      TopLevelDestination(Route.SETTINGS, icon = Icons.Outlined.Settings, textId = "Settings")
 }
 
 val LIST_TOP_LEVEL_DESTINATION =
     listOf(TopLevelDestinations.OVERVIEW, TopLevelDestinations.SEARCH, TopLevelDestinations.PROFILE)
+
+val LIST_TRIP_LEVEL_DESTINATION =
+    listOf(
+        TopLevelDestinations.SCHEDULE,
+        TopLevelDestinations.ACTIVITIES,
+        TopLevelDestinations.SETTINGS)
 
 open class NavigationActions(
     private val navController: NavHostController,

--- a/app/src/main/java/com/android/voyageur/ui/overview/Overview.kt
+++ b/app/src/main/java/com/android/voyageur/ui/overview/Overview.kt
@@ -84,7 +84,6 @@ fun OverviewScreen(
 
 @Composable
 fun TripItem(tripsViewModel: TripsViewModel, trip: Trip, navigationActions: NavigationActions) {
-  // TODO: add a clickable once we implement the Schedule screens
   Card(
       onClick = {
         navigationActions.navigateTo(Screen.BY_DAY)

--- a/app/src/main/java/com/android/voyageur/ui/overview/Overview.kt
+++ b/app/src/main/java/com/android/voyageur/ui/overview/Overview.kt
@@ -69,7 +69,10 @@ fun OverviewScreen(
             LazyColumn(modifier = Modifier.testTag("lazyColumn")) {
               sortedTrips.forEach { trip ->
                 item {
-                  TripItem(trip = trip)
+                  TripItem(
+                      tripsViewModel = tripsViewModel,
+                      trip = trip,
+                      navigationActions = navigationActions)
                   Spacer(modifier = Modifier.height(16.dp))
                 }
               }
@@ -80,9 +83,13 @@ fun OverviewScreen(
 }
 
 @Composable
-fun TripItem(trip: Trip) {
+fun TripItem(tripsViewModel: TripsViewModel, trip: Trip, navigationActions: NavigationActions) {
   // TODO: add a clickable once we implement the Schedule screens
   Card(
+      onClick = {
+        navigationActions.navigateTo(Screen.BY_DAY)
+        tripsViewModel.selectTrip(trip)
+      },
       modifier = Modifier.fillMaxSize().testTag("cardItem"),
       content = {
         Text(

--- a/app/src/main/java/com/android/voyageur/ui/trip/activities/Activities.kt
+++ b/app/src/main/java/com/android/voyageur/ui/trip/activities/Activities.kt
@@ -26,10 +26,12 @@ fun ActivitiesScreen(
     tripsViewModel: TripsViewModel,
     navigationActions: NavigationActions,
 ) {
-  val trip = tripsViewModel.selectedTrip.collectAsState().value ?: return Text(text = "No ToDo selected. Should not happen", color = Color.Red)
+  val trip =
+      tripsViewModel.selectedTrip.collectAsState().value
+          ?: return Text(text = "No ToDo selected. Should not happen", color = Color.Red)
 
-    Scaffold(
-        //TODO: Final implementation of ActivitiesScreen
+  Scaffold(
+      // TODO: Final implementation of ActivitiesScreen
       modifier = Modifier.testTag("activitiesScreen"),
       topBar = {
         TopAppBar(

--- a/app/src/main/java/com/android/voyageur/ui/trip/activities/Activities.kt
+++ b/app/src/main/java/com/android/voyageur/ui/trip/activities/Activities.kt
@@ -12,6 +12,7 @@ import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.testTag
 import com.android.voyageur.model.trip.TripsViewModel
 import com.android.voyageur.ui.navigation.BottomNavigationMenu
@@ -25,9 +26,10 @@ fun ActivitiesScreen(
     tripsViewModel: TripsViewModel,
     navigationActions: NavigationActions,
 ) {
-  val trip = tripsViewModel.selectedTrip.collectAsState().value
+  val trip = tripsViewModel.selectedTrip.collectAsState().value ?: return Text(text = "No ToDo selected. Should not happen", color = Color.Red)
 
-  Scaffold(
+    Scaffold(
+        //TODO: Final implementation of ActivitiesScreen
       modifier = Modifier.testTag("activitiesScreen"),
       topBar = {
         TopAppBar(
@@ -51,6 +53,6 @@ fun ActivitiesScreen(
         Text(
             modifier = Modifier.padding(pd).testTag("emptyActivitiesPrompt"),
             text =
-                "You're viewing the Activities screen for ${trip?.name}, but it's not implemented yet.")
+                "You're viewing the Activities screen for ${trip.name}, but it's not implemented yet.")
       })
 }

--- a/app/src/main/java/com/android/voyageur/ui/trip/activities/Activities.kt
+++ b/app/src/main/java/com/android/voyageur/ui/trip/activities/Activities.kt
@@ -1,0 +1,54 @@
+package com.android.voyageur.ui.trip.activities
+
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.outlined.Home
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
+import com.android.voyageur.model.trip.TripsViewModel
+import com.android.voyageur.ui.navigation.BottomNavigationMenu
+import com.android.voyageur.ui.navigation.LIST_TRIP_LEVEL_DESTINATION
+import com.android.voyageur.ui.navigation.NavigationActions
+import com.android.voyageur.ui.navigation.Screen
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun ActivitiesScreen(
+    tripsViewModel: TripsViewModel,
+    navigationActions: NavigationActions,
+) {
+  val trip by tripsViewModel.selectedTrip.collectAsState()
+
+  Scaffold(
+      modifier = Modifier.testTag("activitiesScreen"),
+      topBar = {
+        TopAppBar(
+            title = { Text("Activities") },
+            navigationIcon = {
+              IconButton(onClick = { navigationActions.navigateTo(Screen.OVERVIEW) }) {
+                Icon(imageVector = Icons.Outlined.Home, contentDescription = "Home")
+              }
+            })
+      },
+      bottomBar = {
+        BottomNavigationMenu(
+            onTabSelect = { route -> navigationActions.navigateTo(route) },
+            tabList = LIST_TRIP_LEVEL_DESTINATION,
+            selectedItem = navigationActions.currentRoute())
+      },
+      content = { pd ->
+        Text(
+            modifier = Modifier.padding(pd).testTag("emptyActivitiesPrompt"),
+            text =
+                "You're viewing the the Activities screen for ${trip.name}, but it's not implemented yet.")
+      })
+}

--- a/app/src/main/java/com/android/voyageur/ui/trip/activities/Activities.kt
+++ b/app/src/main/java/com/android/voyageur/ui/trip/activities/Activities.kt
@@ -11,7 +11,6 @@ import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
-import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.testTag
 import com.android.voyageur.model.trip.TripsViewModel
@@ -26,17 +25,20 @@ fun ActivitiesScreen(
     tripsViewModel: TripsViewModel,
     navigationActions: NavigationActions,
 ) {
-  val trip by tripsViewModel.selectedTrip.collectAsState()
+  val trip = tripsViewModel.selectedTrip.collectAsState().value
 
   Scaffold(
       modifier = Modifier.testTag("activitiesScreen"),
       topBar = {
         TopAppBar(
-            title = { Text("Activities") },
+            modifier = Modifier.testTag("topBar"),
+            title = { Text("Activities:") },
             navigationIcon = {
-              IconButton(onClick = { navigationActions.navigateTo(Screen.OVERVIEW) }) {
-                Icon(imageVector = Icons.Outlined.Home, contentDescription = "Home")
-              }
+              IconButton(
+                  modifier = Modifier.testTag("backToOverviewButton"),
+                  onClick = { navigationActions.navigateTo(Screen.OVERVIEW) }) {
+                    Icon(imageVector = Icons.Outlined.Home, contentDescription = "Home")
+                  }
             })
       },
       bottomBar = {
@@ -49,6 +51,6 @@ fun ActivitiesScreen(
         Text(
             modifier = Modifier.padding(pd).testTag("emptyActivitiesPrompt"),
             text =
-                "You're viewing the the Activities screen for ${trip.name}, but it's not implemented yet.")
+                "You're viewing the Activities screen for ${trip?.name}, but it's not implemented yet.")
       })
 }

--- a/app/src/main/java/com/android/voyageur/ui/trip/schedule/ByDay.kt
+++ b/app/src/main/java/com/android/voyageur/ui/trip/schedule/ByDay.kt
@@ -12,6 +12,7 @@ import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.testTag
 import com.android.voyageur.model.trip.TripsViewModel
 import com.android.voyageur.ui.navigation.BottomNavigationMenu
@@ -25,8 +26,9 @@ fun ByDayScreen(
     tripsViewModel: TripsViewModel,
     navigationActions: NavigationActions,
 ) {
-  val trip = tripsViewModel.selectedTrip.collectAsState().value
+    val trip = tripsViewModel.selectedTrip.collectAsState().value ?: return Text(text = "No ToDo selected. Should not happen", color = Color.Red)
   Scaffold(
+      //TODO: Final implementation of ByDayScreen
       modifier = Modifier.testTag("byDayScreen"),
       topBar = {
         TopAppBar(
@@ -50,6 +52,6 @@ fun ByDayScreen(
         Text(
             modifier = Modifier.padding(pd).testTag("emptyByDayPrompt"),
             text =
-                "You're viewing the ByDay screen for ${trip?.name}, but it's not implemented yet.")
+                "You're viewing the ByDay screen for ${trip.name}, but it's not implemented yet.")
       })
 }

--- a/app/src/main/java/com/android/voyageur/ui/trip/schedule/ByDay.kt
+++ b/app/src/main/java/com/android/voyageur/ui/trip/schedule/ByDay.kt
@@ -1,0 +1,53 @@
+package com.android.voyageur.ui.trip.schedule
+
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.outlined.Home
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
+import com.android.voyageur.model.trip.TripsViewModel
+import com.android.voyageur.ui.navigation.BottomNavigationMenu
+import com.android.voyageur.ui.navigation.LIST_TRIP_LEVEL_DESTINATION
+import com.android.voyageur.ui.navigation.NavigationActions
+import com.android.voyageur.ui.navigation.Screen
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun ByDayScreen(
+    tripsViewModel: TripsViewModel,
+    navigationActions: NavigationActions,
+) {
+  val trip by tripsViewModel.selectedTrip.collectAsState()
+  Scaffold(
+      modifier = Modifier.testTag("byDayScreen"),
+      topBar = {
+        TopAppBar(
+            title = { Text("Schedule ByDay") },
+            navigationIcon = {
+              IconButton(onClick = { navigationActions.navigateTo(Screen.OVERVIEW) }) {
+                Icon(imageVector = Icons.Outlined.Home, contentDescription = "Home")
+              }
+            })
+      },
+      bottomBar = {
+        BottomNavigationMenu(
+            onTabSelect = { route -> navigationActions.navigateTo(route) },
+            tabList = LIST_TRIP_LEVEL_DESTINATION,
+            selectedItem = navigationActions.currentRoute())
+      },
+      content = { pd ->
+        Text(
+            modifier = Modifier.padding(pd).testTag("emptyByDayPrompt"),
+            text =
+                "You're viewing the the ByDay screen for ${trip.name}, but it's not implemented yet.")
+      })
+}

--- a/app/src/main/java/com/android/voyageur/ui/trip/schedule/ByDay.kt
+++ b/app/src/main/java/com/android/voyageur/ui/trip/schedule/ByDay.kt
@@ -11,7 +11,6 @@ import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
-import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.testTag
 import com.android.voyageur.model.trip.TripsViewModel
@@ -26,16 +25,19 @@ fun ByDayScreen(
     tripsViewModel: TripsViewModel,
     navigationActions: NavigationActions,
 ) {
-  val trip by tripsViewModel.selectedTrip.collectAsState()
+  val trip = tripsViewModel.selectedTrip.collectAsState().value
   Scaffold(
       modifier = Modifier.testTag("byDayScreen"),
       topBar = {
         TopAppBar(
-            title = { Text("Schedule ByDay") },
+            modifier = Modifier.testTag("topBar"),
+            title = { Text("Schedule ByDay:") },
             navigationIcon = {
-              IconButton(onClick = { navigationActions.navigateTo(Screen.OVERVIEW) }) {
-                Icon(imageVector = Icons.Outlined.Home, contentDescription = "Home")
-              }
+              IconButton(
+                  modifier = Modifier.testTag("backToOverviewButton"),
+                  onClick = { navigationActions.navigateTo(Screen.OVERVIEW) }) {
+                    Icon(imageVector = Icons.Outlined.Home, contentDescription = "Home")
+                  }
             })
       },
       bottomBar = {
@@ -48,6 +50,6 @@ fun ByDayScreen(
         Text(
             modifier = Modifier.padding(pd).testTag("emptyByDayPrompt"),
             text =
-                "You're viewing the the ByDay screen for ${trip.name}, but it's not implemented yet.")
+                "You're viewing the ByDay screen for ${trip?.name}, but it's not implemented yet.")
       })
 }

--- a/app/src/main/java/com/android/voyageur/ui/trip/schedule/ByDay.kt
+++ b/app/src/main/java/com/android/voyageur/ui/trip/schedule/ByDay.kt
@@ -26,9 +26,11 @@ fun ByDayScreen(
     tripsViewModel: TripsViewModel,
     navigationActions: NavigationActions,
 ) {
-    val trip = tripsViewModel.selectedTrip.collectAsState().value ?: return Text(text = "No ToDo selected. Should not happen", color = Color.Red)
+  val trip =
+      tripsViewModel.selectedTrip.collectAsState().value
+          ?: return Text(text = "No ToDo selected. Should not happen", color = Color.Red)
   Scaffold(
-      //TODO: Final implementation of ByDayScreen
+      // TODO: Final implementation of ByDayScreen
       modifier = Modifier.testTag("byDayScreen"),
       topBar = {
         TopAppBar(

--- a/app/src/main/java/com/android/voyageur/ui/trip/settings/Settings.kt
+++ b/app/src/main/java/com/android/voyageur/ui/trip/settings/Settings.kt
@@ -1,0 +1,54 @@
+package com.android.voyageur.ui.trip.settings
+
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.outlined.Home
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
+import com.android.voyageur.model.trip.TripsViewModel
+import com.android.voyageur.ui.navigation.BottomNavigationMenu
+import com.android.voyageur.ui.navigation.LIST_TRIP_LEVEL_DESTINATION
+import com.android.voyageur.ui.navigation.NavigationActions
+import com.android.voyageur.ui.navigation.Screen
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun SettingsScreen(
+    tripsViewModel: TripsViewModel,
+    navigationActions: NavigationActions,
+) {
+  val trip by tripsViewModel.selectedTrip.collectAsState()
+
+  Scaffold(
+      modifier = Modifier.testTag("settingsScreen"),
+      topBar = {
+        TopAppBar(
+            title = { Text("Settings") },
+            navigationIcon = {
+              IconButton(onClick = { navigationActions.navigateTo(Screen.OVERVIEW) }) {
+                Icon(imageVector = Icons.Outlined.Home, contentDescription = "Home")
+              }
+            })
+      },
+      bottomBar = {
+        BottomNavigationMenu(
+            onTabSelect = { route -> navigationActions.navigateTo(route) },
+            tabList = LIST_TRIP_LEVEL_DESTINATION,
+            selectedItem = navigationActions.currentRoute())
+      },
+      content = { pd ->
+        Text(
+            modifier = Modifier.padding(pd).testTag("emptySettingsPrompt"),
+            text =
+                "You're viewing the the Settings screen for ${trip.name}, but it's not implemented yet.")
+      })
+}

--- a/app/src/main/java/com/android/voyageur/ui/trip/settings/Settings.kt
+++ b/app/src/main/java/com/android/voyageur/ui/trip/settings/Settings.kt
@@ -27,10 +27,12 @@ fun SettingsScreen(
     tripsViewModel: TripsViewModel,
     navigationActions: NavigationActions,
 ) {
-    val trip = tripsViewModel.selectedTrip.collectAsState().value ?: return Text(text = "No ToDo selected. Should not happen", color = Color.Red)
+  val trip =
+      tripsViewModel.selectedTrip.collectAsState().value
+          ?: return Text(text = "No ToDo selected. Should not happen", color = Color.Red)
 
   Scaffold(
-      //TODO: Final implementation of SettingsScreen
+      // TODO: Final implementation of SettingsScreen
       modifier = Modifier.testTag("settingsScreen"),
       topBar = {
         TopAppBar(

--- a/app/src/main/java/com/android/voyageur/ui/trip/settings/Settings.kt
+++ b/app/src/main/java/com/android/voyageur/ui/trip/settings/Settings.kt
@@ -32,11 +32,14 @@ fun SettingsScreen(
       modifier = Modifier.testTag("settingsScreen"),
       topBar = {
         TopAppBar(
-            title = { Text("Settings") },
+            modifier = Modifier.testTag("topBar"),
+            title = { Text("Settings:") },
             navigationIcon = {
-              IconButton(onClick = { navigationActions.navigateTo(Screen.OVERVIEW) }) {
-                Icon(imageVector = Icons.Outlined.Home, contentDescription = "Home")
-              }
+              IconButton(
+                  modifier = Modifier.testTag("backToOverviewButton"),
+                  onClick = { navigationActions.navigateTo(Screen.OVERVIEW) }) {
+                    Icon(imageVector = Icons.Outlined.Home, contentDescription = "Home")
+                  }
             })
       },
       bottomBar = {
@@ -49,6 +52,6 @@ fun SettingsScreen(
         Text(
             modifier = Modifier.padding(pd).testTag("emptySettingsPrompt"),
             text =
-                "You're viewing the the Settings screen for ${trip.name}, but it's not implemented yet.")
+                "You're viewing the Settings screen for ${trip?.name}, but it's not implemented yet.")
       })
 }

--- a/app/src/main/java/com/android/voyageur/ui/trip/settings/Settings.kt
+++ b/app/src/main/java/com/android/voyageur/ui/trip/settings/Settings.kt
@@ -13,6 +13,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.testTag
 import com.android.voyageur.model.trip.TripsViewModel
 import com.android.voyageur.ui.navigation.BottomNavigationMenu
@@ -26,9 +27,10 @@ fun SettingsScreen(
     tripsViewModel: TripsViewModel,
     navigationActions: NavigationActions,
 ) {
-  val trip by tripsViewModel.selectedTrip.collectAsState()
+    val trip = tripsViewModel.selectedTrip.collectAsState().value ?: return Text(text = "No ToDo selected. Should not happen", color = Color.Red)
 
   Scaffold(
+      //TODO: Final implementation of SettingsScreen
       modifier = Modifier.testTag("settingsScreen"),
       topBar = {
         TopAppBar(
@@ -52,6 +54,6 @@ fun SettingsScreen(
         Text(
             modifier = Modifier.padding(pd).testTag("emptySettingsPrompt"),
             text =
-                "You're viewing the Settings screen for ${trip?.name}, but it's not implemented yet.")
+                "You're viewing the Settings screen for ${trip.name}, but it's not implemented yet.")
       })
 }


### PR DESCRIPTION
## Summary

This feature allows users to view 3 new screens when clicking on a trip from the Overview screen, and then navigating through them using another bottom navigation bar. To come back to the Overview/Search/Settings screens users can click on a "Home" button.
* Schedule: The schedule tab is initially the ByDay Screen, not yet implemented. This will display activities grouped by days. 
* Activities: This screen will display all activities in chronological order, but also the draft ones that don't have a date/time assigned yet.
* Settings: This screen will allow users to change trip details such as trip dates or participants. 

## Changes

- **Screens/UI:** On the Overview screen, when clicking on a trip you are taken to ByDay Screen (Schedule On the New Navigation bar). This navigation bar has: Schedule, Activities, Settings. To go back to the Overview Screens from any of them, click on the Home Button on the top left of the screen
- **Bug Fixes/Improvements:** Modified some TripViewModel fields that needed to be val, like in the bootcamp, and replaced the default empty selected trip with null.

## Checklist

Ensure all / most of these are checked before the pull request is submitted.
- [x] This PR resolves #`<issue number>` (if applicable).
- [x] Tests have been added for new functionality.
- [x] Screenshots or UI changes have been attached (if applicable).
- [ ] Documentation has been updated (if applicable).

##  Testing

- **Manual Testing:**
    - [x] Tested on emulator / physical device.
- **Unit Tests**
    - [x] Added units tests for this

##  Related Issues/Tickets

Closes #54 and #55 

## Screenshots (if applicable)

![image](https://github.com/user-attachments/assets/878d8954-628b-4bd4-a86b-e2575e56f316)

