### PR TITLE
feat(ui:search-page): add functionality to SearchScreen

### DIFF
--- a/app/src/androidTest/java/com/android/voyageur/ui/search/SearchScreenTest.kt
+++ b/app/src/androidTest/java/com/android/voyageur/ui/search/SearchScreenTest.kt
@@ -3,6 +3,11 @@ package com.android.voyageur.ui.search
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performTextInput
+import com.android.voyageur.model.user.User
+import com.android.voyageur.model.user.UserRepository
+import com.android.voyageur.model.user.UserViewModel
 import com.android.voyageur.ui.navigation.NavigationActions
 import com.android.voyageur.ui.navigation.Route
 import org.junit.Before
@@ -10,27 +15,85 @@ import org.junit.Rule
 import org.junit.Test
 import org.mockito.Mockito.mock
 import org.mockito.Mockito.`when`
+import org.mockito.kotlin.any
+import org.mockito.kotlin.eq
 
 class SearchScreenTest {
   private lateinit var navigationActions: NavigationActions
+  private lateinit var userViewModel: UserViewModel
+  private lateinit var userRepository: UserRepository
 
   @get:Rule val composeTestRule = createComposeRule()
 
   @Before
   fun setUp() {
     navigationActions = mock(NavigationActions::class.java)
+    userRepository = mock(UserRepository::class.java)
+    userViewModel = UserViewModel(userRepository)
     `when`(navigationActions.currentRoute()).thenReturn(Route.SEARCH)
-    composeTestRule.setContent { SearchScreen(navigationActions) }
+    composeTestRule.setContent { SearchScreen(userViewModel, navigationActions) }
   }
 
   @Test
-  fun displayTextWhenNotFinalized() {
-    composeTestRule.onNodeWithTag("emptySearchPrompt").assertIsDisplayed()
-  }
-
-  @Test
-  fun hasRequiredComponents() {
+  fun testInitialState() {
     composeTestRule.onNodeWithTag("searchScreen").assertIsDisplayed()
-    composeTestRule.onNodeWithTag("bottomNavigationMenu").assertIsDisplayed()
+    composeTestRule.onNodeWithTag("searchScreenContent").assertIsDisplayed()
+    composeTestRule.onNodeWithTag("searchBar").assertIsDisplayed()
+    composeTestRule.onNodeWithTag("searchTextField").assertIsDisplayed()
+    composeTestRule.onNodeWithTag("filterIcon").assertIsDisplayed()
+  }
+
+  @Test
+  fun testFilterIconButtonDisplaysFilterButtons() {
+    composeTestRule.onNodeWithTag("filterIcon").performClick()
+    composeTestRule.onNodeWithTag("filterButton_Users").assertIsDisplayed()
+    composeTestRule.onNodeWithTag("filterButton_Locations").assertIsDisplayed()
+    composeTestRule.onNodeWithTag("filterButton_All").assertIsDisplayed()
+  }
+
+  @Test
+  fun testSearchFunctionality() {
+    val searchQuery = "test"
+    val mockUserList = listOf(User(id = "1", name = "Test User", email = "test@example.com"))
+    `when`(userRepository.searchUsers(eq(searchQuery), any(), any())).thenAnswer {
+      val onSuccess = it.arguments[1] as (List<User>) -> Unit
+      onSuccess(mockUserList)
+    }
+    composeTestRule.onNodeWithTag("searchTextField").performTextInput(searchQuery)
+    composeTestRule.onNodeWithTag("userItem_1").assertIsDisplayed()
+  }
+
+  @Test
+  fun testFilterFunctionality() {
+    val searchQuery = "test"
+    val mockUserList = listOf(User(id = "1", name = "Test User", email = "test@example.com"))
+    `when`(userRepository.searchUsers(eq(searchQuery), any(), any())).thenAnswer {
+      val onSuccess = it.arguments[1] as (List<User>) -> Unit
+      onSuccess(mockUserList)
+    }
+    composeTestRule.onNodeWithTag("searchTextField").performTextInput(searchQuery)
+
+    composeTestRule.onNodeWithTag("filterIcon").performClick()
+    composeTestRule.onNodeWithTag("filterRow").assertIsDisplayed()
+    composeTestRule.onNodeWithTag("filterButton_Users").assertIsDisplayed()
+    composeTestRule.onNodeWithTag("filterButton_Locations").assertIsDisplayed()
+    composeTestRule.onNodeWithTag("filterButton_All").assertIsDisplayed()
+
+    // For now we are only testing the filter functionality for users as the locations search is not
+    // implemented yet
+    // when filtering for locations, a message is displayed saying that the feature is not
+    // implemented yet
+    composeTestRule.onNodeWithTag("filterButton_Users").performClick()
+    composeTestRule.onNodeWithTag("userItem_1").assertIsDisplayed()
+    composeTestRule.onNodeWithTag("placesPending").assertDoesNotExist()
+
+    composeTestRule.onNodeWithTag("filterButton_Locations").performClick()
+    composeTestRule.onNodeWithTag("userItem_1").assertDoesNotExist()
+    composeTestRule.onNodeWithTag("placesPending").assertIsDisplayed()
+
+    composeTestRule.onNodeWithTag("filterButton_All").performClick()
+    composeTestRule.onNodeWithTag("userItem_1").assertIsDisplayed()
+    // when filtering for all, the message for locations is not displayed
+    composeTestRule.onNodeWithTag("placesPending").assertDoesNotExist()
   }
 }

--- a/app/src/androidTest/java/com/android/voyageur/ui/search/SearchScreenTest.kt
+++ b/app/src/androidTest/java/com/android/voyageur/ui/search/SearchScreenTest.kt
@@ -96,4 +96,15 @@ class SearchScreenTest {
     // when filtering for all, the message for locations is not displayed
     composeTestRule.onNodeWithTag("placesPending").assertDoesNotExist()
   }
+
+  @Test
+  fun testNoResultsFound() {
+    val searchQuery = "test"
+    `when`(userRepository.searchUsers(eq(searchQuery), any(), any())).thenAnswer {
+      val onSuccess = it.arguments[1] as (List<User>) -> Unit
+      onSuccess(emptyList())
+    }
+    composeTestRule.onNodeWithTag("searchTextField").performTextInput(searchQuery)
+    composeTestRule.onNodeWithTag("noResults").assertIsDisplayed()
+  }
 }

--- a/app/src/main/java/com/android/voyageur/App.kt
+++ b/app/src/main/java/com/android/voyageur/App.kt
@@ -42,7 +42,7 @@ fun VoyageurApp() {
         startDestination = Screen.SEARCH,
         route = Route.SEARCH,
     ) {
-      composable(Screen.SEARCH) { SearchScreen(navigationActions) }
+      composable(Screen.SEARCH) { SearchScreen(userViewModel, navigationActions) }
     }
     navigation(
         startDestination = Screen.PROFILE,

--- a/app/src/main/java/com/android/voyageur/ui/search/SearchScreen.kt
+++ b/app/src/main/java/com/android/voyageur/ui/search/SearchScreen.kt
@@ -122,26 +122,38 @@ fun SearchScreen(
                           .padding(16.dp)
                           .background(Color.LightGray, shape = MaterialTheme.shapes.large)
                           .testTag("searchResults")) {
-                    when (selectedFilter) {
-                      FilterType.USERS -> {
-                        items(searchedUsers) { user ->
-                          UserSearchResultItem(user, Modifier.testTag("userItem_${user.id}"))
-                        }
+                    // Display no results found message if searchedUsers is empty
+                    // Will consider locations once Places API is integrated
+                    if (searchedUsers.isEmpty()) {
+                      item {
+                        Text(
+                            text = "No results found",
+                            color = Color.Black,
+                            fontSize = 18.sp,
+                            modifier = Modifier.padding(16.dp).testTag("noResults"))
                       }
-                      FilterType.PLACES -> {
-                        item {
-                          Text(
-                              text = "Places API integration pending",
-                              color = Color.Black,
-                              fontSize = 18.sp,
-                              modifier = Modifier.padding(16.dp).testTag("placesPending"))
+                    } else {
+                      when (selectedFilter) {
+                        FilterType.USERS -> {
+                          items(searchedUsers) { user ->
+                            UserSearchResultItem(user, Modifier.testTag("userItem_${user.id}"))
+                          }
                         }
-                      }
-                      FilterType.ALL -> {
-                        items(searchedUsers) { user ->
-                          UserSearchResultItem(user, Modifier.testTag("userItem_${user.id}"))
+                        FilterType.PLACES -> {
+                          item {
+                            Text(
+                                text = "Places API integration pending",
+                                color = Color.Black,
+                                fontSize = 18.sp,
+                                modifier = Modifier.padding(16.dp).testTag("placesPending"))
+                          }
                         }
-                        // Display places once Places API is integrated
+                        FilterType.ALL -> {
+                          items(searchedUsers) { user ->
+                            UserSearchResultItem(user, Modifier.testTag("userItem_${user.id}"))
+                          }
+                          // Display places once Places API is integrated
+                        }
                       }
                     }
                   }

--- a/app/src/main/java/com/android/voyageur/ui/search/SearchScreen.kt
+++ b/app/src/main/java/com/android/voyageur/ui/search/SearchScreen.kt
@@ -1,19 +1,45 @@
 package com.android.voyageur.ui.search
 
-import androidx.compose.foundation.layout.padding
-import androidx.compose.material3.Scaffold
-import androidx.compose.material3.Text
-import androidx.compose.runtime.Composable
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.text.BasicTextField
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.List
+import androidx.compose.material.icons.filled.Search
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.text.input.TextFieldValue
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import coil.compose.rememberAsyncImagePainter
+import com.android.voyageur.model.user.User
+import com.android.voyageur.model.user.UserViewModel
 import com.android.voyageur.ui.navigation.BottomNavigationMenu
 import com.android.voyageur.ui.navigation.LIST_TOP_LEVEL_DESTINATION
 import com.android.voyageur.ui.navigation.NavigationActions
 
 @Composable
 fun SearchScreen(
+    userViewModel: UserViewModel,
     navigationActions: NavigationActions,
 ) {
+  var searchQuery by remember { mutableStateOf(TextFieldValue("")) }
+  var selectedFilter by remember { mutableStateOf(FilterType.ALL) }
+  var showFilters by remember { mutableStateOf(false) }
+  val searchedUsers by userViewModel.searchedUsers.collectAsState()
+
+  // make the search query call when the screen is first launched
+  userViewModel.searchUsers(searchQuery.text)
 
   Scaffold(
       modifier = Modifier.testTag("searchScreen"),
@@ -24,8 +50,148 @@ fun SearchScreen(
             selectedItem = navigationActions.currentRoute())
       },
       content = { pd ->
-        Text(
-            modifier = Modifier.padding(pd).testTag("emptySearchPrompt"),
-            text = "You aren't able to search for anything yet.")
+        Column(
+            modifier =
+                Modifier.padding(pd)
+                    .fillMaxSize()
+                    .background(Color.White)
+                    .testTag("searchScreenContent")) {
+              Spacer(modifier = Modifier.height(24.dp))
+              Text(
+                  text = "Search",
+                  color = Color.Black,
+                  style = MaterialTheme.typography.bodyLarge,
+                  fontSize = 24.sp,
+                  modifier = Modifier.padding(start = 16.dp, bottom = 8.dp))
+
+              Row(
+                  modifier =
+                      Modifier.padding(horizontal = 16.dp)
+                          .fillMaxWidth()
+                          .background(Color.LightGray, shape = MaterialTheme.shapes.medium)
+                          .padding(8.dp)
+                          .testTag("searchBar"),
+                  verticalAlignment = Alignment.CenterVertically) {
+                    Icon(Icons.Default.Search, contentDescription = null)
+                    Spacer(modifier = Modifier.width(8.dp))
+                    BasicTextField(
+                        value = searchQuery,
+                        onValueChange = {
+                          searchQuery = it
+                          userViewModel.searchUsers(searchQuery.text)
+                        },
+                        modifier = Modifier.weight(1f).padding(8.dp).testTag("searchTextField"),
+                        textStyle = LocalTextStyle.current.copy(fontSize = 18.sp),
+                    )
+                    Icon(
+                        Icons.Default.List,
+                        contentDescription = null,
+                        modifier =
+                            Modifier.clickable { showFilters = !showFilters }.testTag("filterIcon"))
+                  }
+              if (showFilters) {
+                Row(
+                    modifier =
+                        Modifier.fillMaxWidth()
+                            .padding(horizontal = 16.dp, vertical = 8.dp)
+                            .testTag("filterRow"),
+                    horizontalArrangement = Arrangement.SpaceEvenly) {
+                      FilterButton("Users", selectedFilter == FilterType.USERS) {
+                        selectedFilter = FilterType.USERS
+                      }
+                      FilterButton("Locations", selectedFilter == FilterType.PLACES) {
+                        selectedFilter = FilterType.PLACES
+                      }
+                      FilterButton("All", selectedFilter == FilterType.ALL) {
+                        selectedFilter = FilterType.ALL
+                      }
+                    }
+              }
+
+              Spacer(modifier = Modifier.height(16.dp))
+
+              Text(
+                  text = "Search result",
+                  color = Color.Black,
+                  fontSize = 18.sp,
+                  modifier = Modifier.padding(horizontal = 16.dp))
+
+              LazyColumn(
+                  modifier =
+                      Modifier.fillMaxSize()
+                          .padding(16.dp)
+                          .background(Color.LightGray, shape = MaterialTheme.shapes.large)
+                          .testTag("searchResults")) {
+                    when (selectedFilter) {
+                      FilterType.USERS -> {
+                        items(searchedUsers) { user ->
+                          UserSearchResultItem(user, Modifier.testTag("userItem_${user.id}"))
+                        }
+                      }
+                      FilterType.PLACES -> {
+                        item {
+                          Text(
+                              text = "Places API integration pending",
+                              color = Color.Black,
+                              fontSize = 18.sp,
+                              modifier = Modifier.padding(16.dp).testTag("placesPending"))
+                        }
+                      }
+                      FilterType.ALL -> {
+                        items(searchedUsers) { user ->
+                          UserSearchResultItem(user, Modifier.testTag("userItem_${user.id}"))
+                        }
+                        // Display places once Places API is integrated
+                      }
+                    }
+                  }
+            }
       })
+}
+
+@Composable
+fun FilterButton(label: String, isSelected: Boolean, onClick: () -> Unit) {
+  Button(
+      onClick = onClick,
+      colors =
+          ButtonDefaults.buttonColors(
+              containerColor =
+                  if (isSelected) MaterialTheme.colorScheme.primary else Color.LightGray,
+              contentColor = Color.White),
+      modifier = Modifier.padding(8.dp).testTag("filterButton_$label")) {
+        Text(text = label)
+      }
+}
+
+@Composable
+fun UserSearchResultItem(user: User, modifier: Modifier = Modifier) {
+  Row(modifier = modifier.fillMaxWidth().padding(vertical = 8.dp)) {
+    Image(
+        painter = rememberAsyncImagePainter(model = user.profilePicture),
+        contentDescription = null,
+        modifier =
+            Modifier.size(60.dp)
+                .background(Color.LightGray, shape = MaterialTheme.shapes.small)
+                .clip(CircleShape)
+                .testTag("userProfilePicture_${user.id}"))
+    Spacer(modifier = Modifier.width(16.dp))
+    Column {
+      Text(
+          text = user.name,
+          fontSize = 16.sp,
+          color = Color.Black,
+          modifier = Modifier.testTag("userName_${user.id}"))
+      Spacer(modifier = Modifier.height(4.dp))
+      Text(
+          text = user.email,
+          color = Color.Black,
+          modifier = Modifier.testTag("userEmail_${user.id}"))
+    }
+  }
+}
+
+enum class FilterType {
+  USERS,
+  PLACES,
+  ALL
 }

--- a/app/src/main/java/com/android/voyageur/ui/search/SearchScreen.kt
+++ b/app/src/main/java/com/android/voyageur/ui/search/SearchScreen.kt
@@ -72,7 +72,7 @@ fun SearchScreen(
                           .padding(8.dp)
                           .testTag("searchBar"),
                   verticalAlignment = Alignment.CenterVertically) {
-                    Icon(Icons.Default.Search, contentDescription = null)
+                    Icon(Icons.Default.Search, contentDescription = "Search Icon")
                     Spacer(modifier = Modifier.width(8.dp))
                     BasicTextField(
                         value = searchQuery,
@@ -85,7 +85,7 @@ fun SearchScreen(
                     )
                     Icon(
                         Icons.Default.List,
-                        contentDescription = null,
+                        contentDescription = "Icon to show filters once clicked",
                         modifier =
                             Modifier.clickable { showFilters = !showFilters }.testTag("filterIcon"))
                   }
@@ -168,7 +168,7 @@ fun UserSearchResultItem(user: User, modifier: Modifier = Modifier) {
   Row(modifier = modifier.fillMaxWidth().padding(vertical = 8.dp)) {
     Image(
         painter = rememberAsyncImagePainter(model = user.profilePicture),
-        contentDescription = null,
+        contentDescription = "${user.name}'s profile picture",
         modifier =
             Modifier.size(60.dp)
                 .background(Color.LightGray, shape = MaterialTheme.shapes.small)


### PR DESCRIPTION
## Summary

- Implement search functionality in SearchScreen, allowing users to search for other users by their name, searching for locations will be implemented in a future commit
- Implmented filtering for search results, allowing users to filter for users, location, or all (currently filtering for locations displays a message that the functionality is not yet implemented)
- Added tests for the search and filter functionalities in SearchScreen
- Note that support for searching for locations will be added in the future as we need to integrate the Google Places API first

## Changes

- **Screens/UI:** Implemented functionality in the search screen, see recording below for the changes.

## Checklist

Ensure all / most of these are checked before the pull request is submitted.
- [x] This PR resolves #57 .
- [x] Tests have been added for new functionality.
- [x] Screenshots or UI changes have been attached .

##  Testing

This feature was tested manually using an emulated device and also UI test were implemented to check functionality
- **Manual Testing:**
    - [x] Tested on emulator / physical device.
- **UI Tests**
    - [x] Added ui tests for this

##  Related Issues/Tickets

- An issue was create to integrate the Google Places API into application #58 
- After integrating Places API add functionality in Search Page #59 

## Screenshots (if applicable)
Video recording of new search page:

https://github.com/user-attachments/assets/808c2272-220b-4b61-8189-bde5bb79fc58



