### PR TITLE
feat(UserViewModel): debounce user search requests

### DIFF
--- a/app/src/main/java/com/android/voyageur/ui/search/SearchScreen.kt
+++ b/app/src/main/java/com/android/voyageur/ui/search/SearchScreen.kt
@@ -78,7 +78,7 @@ fun SearchScreen(
                         value = searchQuery,
                         onValueChange = {
                           searchQuery = it
-                          userViewModel.searchUsers(searchQuery.text)
+                          userViewModel.setQuery(searchQuery.text)
                         },
                         modifier = Modifier.weight(1f).padding(8.dp).testTag("searchTextField"),
                         textStyle = LocalTextStyle.current.copy(fontSize = 18.sp),

--- a/app/src/test/java/com/android/voyageur/model/user/UserViewModelTest.kt
+++ b/app/src/test/java/com/android/voyageur/model/user/UserViewModelTest.kt
@@ -2,7 +2,14 @@ package com.android.voyageur.model.user
 
 import androidx.test.core.app.ApplicationProvider
 import com.google.firebase.FirebaseApp
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.After
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -11,24 +18,54 @@ import org.mockito.Mockito.mock
 import org.mockito.Mockito.`when`
 import org.mockito.kotlin.any
 import org.mockito.kotlin.eq
+import org.mockito.kotlin.never
 import org.mockito.kotlin.verify
 import org.robolectric.RobolectricTestRunner
 
+@OptIn(ExperimentalCoroutinesApi::class)
 @RunWith(RobolectricTestRunner::class)
 class UserViewModelTest {
   private lateinit var userRepository: UserRepository
   private lateinit var userViewModel: UserViewModel
+  private val testDispatcher = UnconfinedTestDispatcher()
 
   private val user = User("1", "name", "email", "password", "phone")
 
   @Before
   fun setUp() {
+    Dispatchers.setMain(testDispatcher)
+
     // Initialize Firebase if necessary
     if (FirebaseApp.getApps(ApplicationProvider.getApplicationContext()).isEmpty()) {
       FirebaseApp.initializeApp(ApplicationProvider.getApplicationContext())
     }
     userRepository = mock(UserRepository::class.java)
     userViewModel = UserViewModel(userRepository)
+  }
+
+  @After
+  fun tearDown() {
+    Dispatchers.resetMain()
+  }
+
+  @Test
+  fun setQueryUpdatesQuery() {
+    val query = "test"
+    userViewModel.setQuery(query)
+    assert(userViewModel.query.value == query)
+  }
+
+  @Test
+  fun setQueryTriggersSearchAfterDelay() = runTest {
+    val query1 = "test1"
+    val query2 = "test2"
+    userViewModel.setQuery(query1)
+    assert(userViewModel.query.value == query1)
+    verify(userRepository, never()).searchUsers(eq(query1), any(), any())
+    userViewModel.setQuery(query2)
+    // Wait for debounce delay
+    delay(200)
+    verify(userRepository).searchUsers(eq(query2), any(), any())
   }
 
   @Test


### PR DESCRIPTION
## Summary

- Added debounce feature to user search requests by adding a setQuery method that sets the query and triggers the search after a delay.
- Added unit tests for the new functionality.

## Changes

- **Models:** modified the UserViewModel by adding the new setQuery function
- **Screens/UI:** In SearchScreen each time the user types in the search bar now it calls the setQuery function

## Checklist

Ensure all / most of these are checked before the pull request is submitted.
- [ ] This PR resolves #`<issue number>` (if applicable).
- [ ] Tests have been added for new functionality.

##  Testing

Tested Manually to check searchScreen still works as expected, also added unit tests
- **Manual Testing:**
    - [ ] Tested on emulator / physical device.
- **Unit Tests**
    - [ ] Added units tests for this

##  Related Issues/Tickets

Closes #66 