### PR TITLE
fix: Solve the AddTrip participant list when input is empty.

### DIFF
--- a/app/src/main/java/com/android/voyageur/ui/overview/AddTrip.kt
+++ b/app/src/main/java/com/android/voyageur/ui/overview/AddTrip.kt
@@ -148,12 +148,16 @@ fun AddTripScreen(
                         calendar.set(
                             endParts[2].toInt(), endParts[1].toInt() - 1, endParts[0].toInt())
                         val endTimestamp = Timestamp(calendar.time)
-
+                        var participantList = emptyList<String>()
+                        // This ensures a participant is not added as an empty string
+                        if (participants.isNotEmpty()) {
+                          participantList = participants.split(",").map { it.trim() }.toList()
+                        }
                         val trip =
                             Trip(
                                 id = tripsViewModel.getNewTripId(),
                                 creator = Firebase.auth.uid.orEmpty(),
-                                participants = participants.split(",").map { it.trim() }.toList(),
+                                participants = participantList,
                                 description = description,
                                 name = name,
                                 locations =


### PR DESCRIPTION
## Summary

This PR aims to fix a bug, which currently allows the user to leave the participant field as empty, but instead of setting the participant list as an empty list, it puts an empty string as a participant. This causes the Overview screen to fail when a card is trying to display the box with the participant's first letter. Further, if the text field is left empty, there should be an empty list, not an empty string set as the participant list.

## Changes

- **Screens/UI:** Changes the participant list in AddTrip Screen.
- **Bug Fixes/Improvements:**  Now the participant list is an emptyList(), not an empty string if the text field is left empty.

## 💡 Additional Context

This issue was previously resolved in PR #73, but for some reason it got overwritten in main, so I am fixing it again.
