### PR TITLE
Feat/tab bar for trip

### DIFF
--- a/app/src/androidTest/java/com/android/voyageur/ui/e2e/EndToEndTest.kt
+++ b/app/src/androidTest/java/com/android/voyageur/ui/e2e/EndToEndTest.kt
@@ -89,11 +89,7 @@ class E2ETest {
         composable(Route.OVERVIEW) { OverviewScreen(tripsViewModel, navigation) }
         composable(Route.PROFILE) { ProfileScreen(userViewModel, navigation) }
         composable(Route.SEARCH) { SearchScreen(userViewModel, navigation) }
-        composable(Route.SCHEDULE) { ByDayScreen(tripsViewModel, navigation) }
-        composable(Route.ACTIVITIES) { ActivitiesScreen(tripsViewModel, navigation) }
-        composable(Route.SETTINGS) { SettingsScreen(tripsViewModel, navigation) }
         composable(Screen.ADD_TRIP) { AddTripScreen(tripsViewModel, navigation) }
-        composable(Screen.BY_DAY) { ByDayScreen(tripsViewModel, navigation) }
         composable(Screen.OVERVIEW) { OverviewScreen(tripsViewModel, navigation) }
         composable(Screen.PROFILE) { ProfileScreen(userViewModel, navigation) }
         composable(Screen.SEARCH) { SearchScreen(userViewModel, navigation) }

--- a/app/src/androidTest/java/com/android/voyageur/ui/e2e/EndToEndTest.kt
+++ b/app/src/androidTest/java/com/android/voyageur/ui/e2e/EndToEndTest.kt
@@ -19,6 +19,7 @@ import com.android.voyageur.ui.overview.AddTripScreen
 import com.android.voyageur.ui.overview.OverviewScreen
 import com.android.voyageur.ui.profile.ProfileScreen
 import com.android.voyageur.ui.search.SearchScreen
+import com.android.voyageur.ui.trip.TopTabs
 import com.google.android.gms.tasks.Task
 import com.google.firebase.auth.AuthResult
 import com.google.firebase.auth.FirebaseAuth
@@ -86,10 +87,12 @@ class E2ETest {
         composable(Route.OVERVIEW) { OverviewScreen(tripsViewModel, navigation) }
         composable(Route.PROFILE) { ProfileScreen(userViewModel, navigation) }
         composable(Route.SEARCH) { SearchScreen(userViewModel, navigation) }
+        composable(Route.TOP_TABS) { TopTabs(tripsViewModel, navigation) }
         composable(Screen.ADD_TRIP) { AddTripScreen(tripsViewModel, navigation) }
         composable(Screen.OVERVIEW) { OverviewScreen(tripsViewModel, navigation) }
         composable(Screen.PROFILE) { ProfileScreen(userViewModel, navigation) }
         composable(Screen.SEARCH) { SearchScreen(userViewModel, navigation) }
+        composable(Screen.TOP_TABS) { TopTabs(tripsViewModel, navigation) }
       }
     }
     composeTestRule.onNodeWithTag("overviewScreen").assertIsDisplayed()
@@ -117,18 +120,11 @@ class E2ETest {
     composeTestRule.onNodeWithTag("cardItem").performClick()
 
     assert(tripsViewModel.selectedTrip.value == mockTrip)
+    composeTestRule.onNodeWithTag("topTabs").assertIsDisplayed()
 
     composeTestRule.onNodeWithTag("byDayScreen").assertIsDisplayed()
-    composeTestRule.onNodeWithTag("backToOverviewButton").assertIsDisplayed()
-    composeTestRule.onNodeWithTag("backToOverviewButton").performClick()
-    composeTestRule
-        .onNodeWithTag("overviewScreen")
-        .assertIsDisplayed() // check if we are back on overview
 
     composeTestRule.onNodeWithText("Search").performClick() // go on search bar
     composeTestRule.onNodeWithTag("searchScreen").assertIsDisplayed()
-
-    composeTestRule.onNodeWithText("Overview").performClick() // go on overview in the bottom bar
-    composeTestRule.onNodeWithTag("overviewScreen").assertIsDisplayed()
   }
 }

--- a/app/src/androidTest/java/com/android/voyageur/ui/e2e/EndToEndTest.kt
+++ b/app/src/androidTest/java/com/android/voyageur/ui/e2e/EndToEndTest.kt
@@ -19,9 +19,6 @@ import com.android.voyageur.ui.overview.AddTripScreen
 import com.android.voyageur.ui.overview.OverviewScreen
 import com.android.voyageur.ui.profile.ProfileScreen
 import com.android.voyageur.ui.search.SearchScreen
-import com.android.voyageur.ui.trip.activities.ActivitiesScreen
-import com.android.voyageur.ui.trip.schedule.ByDayScreen
-import com.android.voyageur.ui.trip.settings.SettingsScreen
 import com.google.android.gms.tasks.Task
 import com.google.firebase.auth.AuthResult
 import com.google.firebase.auth.FirebaseAuth

--- a/app/src/androidTest/java/com/android/voyageur/ui/overview/OverviewScreenTest.kt
+++ b/app/src/androidTest/java/com/android/voyageur/ui/overview/OverviewScreenTest.kt
@@ -146,7 +146,7 @@ class OverviewScreenTest {
 
     // Verify the trip is selected and navigation to the BY_DAY screen is called
     assert(tripViewModel.selectedTrip.value == mockTrip)
-    verify(navigationActions).navigateTo(screen = Screen.BY_DAY)
+    verify(navigationActions).navigateTo(screen = Screen.TOP_TABS)
   }
 
   @Test

--- a/app/src/androidTest/java/com/android/voyageur/ui/trip/TobTabsTest.kt
+++ b/app/src/androidTest/java/com/android/voyageur/ui/trip/TobTabsTest.kt
@@ -1,0 +1,85 @@
+package com.android.voyageur.ui.trip
+
+import androidx.compose.ui.test.*
+import androidx.compose.ui.test.junit4.createComposeRule
+import com.android.voyageur.model.trip.Trip
+import com.android.voyageur.model.trip.TripRepository
+import com.android.voyageur.model.trip.TripsViewModel
+import com.android.voyageur.ui.navigation.NavigationActions
+import com.android.voyageur.ui.navigation.Route
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.mockito.Mockito.mock
+import org.mockito.Mockito.`when`
+
+class TopTabsTest {
+  val sampleTrip = Trip(name = "Sample Trip")
+
+  private lateinit var tripRepository: TripRepository
+  private lateinit var navigationActions: NavigationActions
+  private lateinit var tripsViewModel: TripsViewModel
+
+  @get:Rule val composeTestRule = createComposeRule()
+
+  @Before
+  fun setUp() {
+    tripRepository = mock(TripRepository::class.java)
+    navigationActions = mock(NavigationActions::class.java)
+    tripsViewModel = TripsViewModel(tripRepository)
+
+    `when`(navigationActions.currentRoute()).thenReturn(Route.TOP_TABS)
+  }
+
+  @Test
+  fun displayTextWhenNoTripSelected() {
+    composeTestRule.setContent { TopTabs(tripsViewModel, navigationActions) }
+
+    // Verify that the "No trip selected" text is displayed
+    composeTestRule.onNodeWithText("No trip selected. Should not happen").assertIsDisplayed()
+  }
+
+  @Test
+  fun topAppBar_DisplaysTripName() {
+    tripsViewModel.selectTrip(sampleTrip)
+    composeTestRule.setContent { TopTabs(tripsViewModel, navigationActions) }
+
+    // Verify that the TopAppBar displays the trip name
+    composeTestRule.onNodeWithTag("topBar").assertIsDisplayed()
+    composeTestRule.onNodeWithText("Sample Trip").assertIsDisplayed()
+  }
+
+  @Test
+  fun tabRow_DisplaysTabsCorrectly() {
+    tripsViewModel.selectTrip(sampleTrip)
+    composeTestRule.setContent { TopTabs(tripsViewModel, navigationActions) }
+
+    // Verify that each tab is displayed with the correct title
+    composeTestRule.onNodeWithTag("tabRow").assertIsDisplayed()
+    composeTestRule.onNodeWithText("Schedule").assertIsDisplayed()
+    composeTestRule.onNodeWithText("Activities").assertIsDisplayed()
+    composeTestRule.onNodeWithText("Settings").assertIsDisplayed()
+  }
+
+  @Test
+  fun tabRow_SwitchesContentOnTabClick() {
+    tripsViewModel.selectTrip(sampleTrip)
+    composeTestRule.setContent { TopTabs(tripsViewModel, navigationActions) }
+
+    // Initially, the first tab (Schedule) should be selected
+    composeTestRule.onNodeWithText("Schedule").assertIsSelected()
+
+    // Verify that ByDayScreen content is shown initially
+    composeTestRule.onNodeWithTag("byDayScreen").assertIsDisplayed()
+
+    // Switch to the "Activities" tab and verify
+    composeTestRule.onNodeWithText("Activities").performClick()
+    composeTestRule.onNodeWithText("Activities").assertIsSelected()
+    composeTestRule.onNodeWithTag("activitiesScreen").assertIsDisplayed()
+
+    // Switch to the "Settings" tab and verify
+    composeTestRule.onNodeWithText("Settings").performClick()
+    composeTestRule.onNodeWithText("Settings").assertIsSelected()
+    composeTestRule.onNodeWithTag("settingsScreen").assertIsDisplayed()
+  }
+}

--- a/app/src/androidTest/java/com/android/voyageur/ui/trip/activities/ActivitiesScreenTest.kt
+++ b/app/src/androidTest/java/com/android/voyageur/ui/trip/activities/ActivitiesScreenTest.kt
@@ -1,91 +1,41 @@
 package com.android.voyageur.ui.trip.activities
 
-import androidx.compose.ui.test.assertHasClickAction
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.assertTextContains
 import androidx.compose.ui.test.junit4.createComposeRule
-import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
-import androidx.compose.ui.test.performClick
 import com.android.voyageur.model.trip.Trip
-import com.android.voyageur.model.trip.TripRepository
-import com.android.voyageur.model.trip.TripsViewModel
-import com.android.voyageur.ui.navigation.LIST_TRIP_LEVEL_DESTINATION
+import com.android.voyageur.ui.navigation.LIST_TOP_LEVEL_DESTINATION
 import com.android.voyageur.ui.navigation.NavigationActions
-import com.android.voyageur.ui.navigation.Route
-import com.android.voyageur.ui.navigation.Screen
-import com.android.voyageur.ui.navigation.TopLevelDestinations.SCHEDULE
-import com.android.voyageur.ui.navigation.TopLevelDestinations.SETTINGS
-import com.android.voyageur.ui.trip.schedule.ByDayScreen
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.mockito.Mockito.mock
-import org.mockito.Mockito.`when`
-import org.mockito.kotlin.verify
 
 class ActivitiesScreenTest {
-  private lateinit var tripRepository: TripRepository
+  private val sampleTrip = Trip(name = "Sample Trip")
+
   private lateinit var navigationActions: NavigationActions
-  private lateinit var tripsViewModel: TripsViewModel
 
   @get:Rule val composeTestRule = createComposeRule()
 
   @Before
   fun setUp() {
-    tripRepository = mock(TripRepository::class.java)
     navigationActions = mock(NavigationActions::class.java)
-    tripsViewModel = TripsViewModel(tripRepository)
-
-    `when`(navigationActions.currentRoute()).thenReturn(Route.ACTIVITIES)
-  }
-
-  @Test
-  fun displayTextWhenNoTripSelected() {
-    composeTestRule.setContent { ActivitiesScreen(tripsViewModel, navigationActions) }
-
-    composeTestRule.onNodeWithText("No ToDo selected. Should not happen").assertIsDisplayed()
   }
 
   @Test
   fun hasRequiredComponents() {
-    tripsViewModel.selectTrip(Trip(name = "Sample Trip"))
-    composeTestRule.setContent { ActivitiesScreen(tripsViewModel, navigationActions) }
+    composeTestRule.setContent { ActivitiesScreen(sampleTrip, navigationActions) }
     composeTestRule.onNodeWithTag("activitiesScreen").assertIsDisplayed()
     composeTestRule.onNodeWithTag("bottomNavigationMenu").assertIsDisplayed()
-    composeTestRule.onNodeWithTag("topBar").assertIsDisplayed()
-  }
-
-  @Test
-  fun displaysTopBarCorrectly() {
-    tripsViewModel.selectTrip(Trip(name = "Sample Trip"))
-    composeTestRule.setContent { ActivitiesScreen(tripsViewModel, navigationActions) }
-
-    // Check that the top bar with the title is displayed
-    composeTestRule.onNodeWithText("Activities:").assertIsDisplayed()
-
-    // Check that the Home icon button is displayed and clickable
-    composeTestRule.onNodeWithTag("backToOverviewButton").assertIsDisplayed().assertHasClickAction()
-    composeTestRule.onNodeWithContentDescription("Home").assertIsDisplayed().assertHasClickAction()
-  }
-
-  @Test
-  fun navigatesToOverviewOnHomeIconClick() {
-    tripsViewModel.selectTrip(Trip(name = "Sample Trip"))
-    composeTestRule.setContent { ActivitiesScreen(tripsViewModel, navigationActions) }
-
-    // Simulate a click on the Home icon button
-    composeTestRule.onNodeWithContentDescription("Home").performClick()
-
-    // Verify that the navigation to the Overview screen was triggered
-    verify(navigationActions).navigateTo(Screen.OVERVIEW)
+    composeTestRule.onNodeWithTag("emptyActivitiesPrompt").assertIsDisplayed()
   }
 
   @Test
   fun displaysCorrectTripName() {
-    tripsViewModel.selectTrip(Trip(name = "Sample Trip"))
-    composeTestRule.setContent { ActivitiesScreen(tripsViewModel, navigationActions) }
+    composeTestRule.setContent { ActivitiesScreen(sampleTrip, navigationActions) }
     composeTestRule
         .onNodeWithTag("emptyActivitiesPrompt")
         .assertTextContains(
@@ -94,29 +44,15 @@ class ActivitiesScreenTest {
 
   @Test
   fun displaysBottomNavigationCorrectly() {
-    tripsViewModel.selectTrip(Trip(name = "Sample Trip"))
-    composeTestRule.setContent { ActivitiesScreen(tripsViewModel, navigationActions) }
+    //    tripsViewModel.selectTrip(Trip(name = "Sample Trip"))
+    composeTestRule.setContent { ActivitiesScreen(sampleTrip, navigationActions) }
 
     // Check that the bottom navigation menu is displayed
     composeTestRule.onNodeWithTag("bottomNavigationMenu").assertIsDisplayed()
 
     // Verify that the bottom navigation has items with correct actions
-    LIST_TRIP_LEVEL_DESTINATION.forEach { destination ->
+    LIST_TOP_LEVEL_DESTINATION.forEach { destination ->
       composeTestRule.onNodeWithText(destination.textId).assertExists()
     }
-  }
-
-  @Test
-  fun bottomNavigationMenu_navigatesToSelectedTab() {
-    tripsViewModel.selectTrip(Trip(name = "Sample Trip"))
-    composeTestRule.setContent { ByDayScreen(tripsViewModel, navigationActions) }
-
-    // Select the "Schedule" tab
-    composeTestRule.onNodeWithTag("Schedule").performClick()
-    verify(navigationActions).navigateTo(SCHEDULE)
-
-    // Select the "Settings" tab
-    composeTestRule.onNodeWithTag("Settings").performClick()
-    verify(navigationActions).navigateTo(SETTINGS)
   }
 }

--- a/app/src/androidTest/java/com/android/voyageur/ui/trip/schedule/ByDayScreenTest.kt
+++ b/app/src/androidTest/java/com/android/voyageur/ui/trip/schedule/ByDayScreenTest.kt
@@ -1,90 +1,41 @@
 package com.android.voyageur.ui.trip.schedule
 
-import androidx.compose.ui.test.assertHasClickAction
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.assertTextContains
 import androidx.compose.ui.test.junit4.createComposeRule
-import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
-import androidx.compose.ui.test.performClick
 import com.android.voyageur.model.trip.Trip
-import com.android.voyageur.model.trip.TripRepository
-import com.android.voyageur.model.trip.TripsViewModel
-import com.android.voyageur.ui.navigation.LIST_TRIP_LEVEL_DESTINATION
+import com.android.voyageur.ui.navigation.LIST_TOP_LEVEL_DESTINATION
 import com.android.voyageur.ui.navigation.NavigationActions
-import com.android.voyageur.ui.navigation.Route
-import com.android.voyageur.ui.navigation.Screen
-import com.android.voyageur.ui.navigation.TopLevelDestinations.ACTIVITIES
-import com.android.voyageur.ui.navigation.TopLevelDestinations.SETTINGS
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.mockito.Mockito.mock
-import org.mockito.Mockito.`when`
-import org.mockito.kotlin.verify
 
 class ByDayScreenTest {
-  private lateinit var tripRepository: TripRepository
+  private val sampleTrip = Trip(name = "Sample Trip")
+
   private lateinit var navigationActions: NavigationActions
-  private lateinit var tripsViewModel: TripsViewModel
 
   @get:Rule val composeTestRule = createComposeRule()
 
   @Before
   fun setUp() {
-    tripRepository = mock(TripRepository::class.java)
     navigationActions = mock(NavigationActions::class.java)
-    tripsViewModel = TripsViewModel(tripRepository)
-
-    `when`(navigationActions.currentRoute()).thenReturn(Route.SCHEDULE)
-  }
-
-  @Test
-  fun displayTextWhenNoTripSelected() {
-    composeTestRule.setContent { ByDayScreen(tripsViewModel, navigationActions) }
-
-    composeTestRule.onNodeWithText("No ToDo selected. Should not happen").assertIsDisplayed()
   }
 
   @Test
   fun hasRequiredComponents() {
-    tripsViewModel.selectTrip(Trip(name = "Sample Trip"))
-    composeTestRule.setContent { ByDayScreen(tripsViewModel, navigationActions) }
+    composeTestRule.setContent { ByDayScreen(sampleTrip, navigationActions) }
     composeTestRule.onNodeWithTag("byDayScreen").assertIsDisplayed()
     composeTestRule.onNodeWithTag("bottomNavigationMenu").assertIsDisplayed()
-    composeTestRule.onNodeWithTag("topBar").assertIsDisplayed()
-  }
-
-  @Test
-  fun displaysTopBarCorrectly() {
-    tripsViewModel.selectTrip(Trip(name = "Sample Trip"))
-    composeTestRule.setContent { ByDayScreen(tripsViewModel, navigationActions) }
-
-    // Check that the top bar with the title is displayed
-    composeTestRule.onNodeWithText("Schedule ByDay:").assertIsDisplayed()
-
-    // Check that the Home icon button is displayed and clickable
-    composeTestRule.onNodeWithTag("backToOverviewButton").assertIsDisplayed().assertHasClickAction()
-    composeTestRule.onNodeWithContentDescription("Home").assertIsDisplayed().assertHasClickAction()
-  }
-
-  @Test
-  fun navigatesToOverviewOnHomeIconClick() {
-    tripsViewModel.selectTrip(Trip(name = "Sample Trip"))
-    composeTestRule.setContent { ByDayScreen(tripsViewModel, navigationActions) }
-
-    // Simulate a click on the Home icon button
-    composeTestRule.onNodeWithContentDescription("Home").performClick()
-
-    // Verify that the navigation to the Overview screen was triggered
-    verify(navigationActions).navigateTo(Screen.OVERVIEW)
+    composeTestRule.onNodeWithTag("emptyByDayPrompt").assertIsDisplayed()
   }
 
   @Test
   fun displaysCorrectTripName() {
-    tripsViewModel.selectTrip(Trip(name = "Sample Trip"))
-    composeTestRule.setContent { ByDayScreen(tripsViewModel, navigationActions) }
+    composeTestRule.setContent { ByDayScreen(sampleTrip, navigationActions) }
     composeTestRule
         .onNodeWithTag("emptyByDayPrompt")
         .assertTextContains(
@@ -93,29 +44,15 @@ class ByDayScreenTest {
 
   @Test
   fun displaysBottomNavigationCorrectly() {
-    tripsViewModel.selectTrip(Trip(name = "Sample Trip"))
-    composeTestRule.setContent { ByDayScreen(tripsViewModel, navigationActions) }
+    //    tripsViewModel.selectTrip(Trip(name = "Sample Trip"))
+    composeTestRule.setContent { ByDayScreen(sampleTrip, navigationActions) }
 
     // Check that the bottom navigation menu is displayed
     composeTestRule.onNodeWithTag("bottomNavigationMenu").assertIsDisplayed()
 
     // Verify that the bottom navigation has items with correct actions
-    LIST_TRIP_LEVEL_DESTINATION.forEach { destination ->
+    LIST_TOP_LEVEL_DESTINATION.forEach { destination ->
       composeTestRule.onNodeWithText(destination.textId).assertExists()
     }
-  }
-
-  @Test
-  fun bottomNavigationMenu_navigatesToSelectedTab() {
-    tripsViewModel.selectTrip(Trip(name = "Sample Trip"))
-    composeTestRule.setContent { ByDayScreen(tripsViewModel, navigationActions) }
-
-    // Select the "Activities" tab
-    composeTestRule.onNodeWithTag("Activities").performClick()
-    verify(navigationActions).navigateTo(ACTIVITIES)
-
-    // Select the "Settings" tab
-    composeTestRule.onNodeWithTag("Settings").performClick()
-    verify(navigationActions).navigateTo(SETTINGS)
   }
 }

--- a/app/src/androidTest/java/com/android/voyageur/ui/trip/settings/SettingsScreenTest.kt
+++ b/app/src/androidTest/java/com/android/voyageur/ui/trip/settings/SettingsScreenTest.kt
@@ -1,91 +1,41 @@
 package com.android.voyageur.ui.trip.settings
 
-import androidx.compose.ui.test.assertHasClickAction
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.assertTextContains
 import androidx.compose.ui.test.junit4.createComposeRule
-import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
-import androidx.compose.ui.test.performClick
 import com.android.voyageur.model.trip.Trip
-import com.android.voyageur.model.trip.TripRepository
-import com.android.voyageur.model.trip.TripsViewModel
-import com.android.voyageur.ui.navigation.LIST_TRIP_LEVEL_DESTINATION
+import com.android.voyageur.ui.navigation.LIST_TOP_LEVEL_DESTINATION
 import com.android.voyageur.ui.navigation.NavigationActions
-import com.android.voyageur.ui.navigation.Route
-import com.android.voyageur.ui.navigation.Screen
-import com.android.voyageur.ui.navigation.TopLevelDestinations.ACTIVITIES
-import com.android.voyageur.ui.navigation.TopLevelDestinations.SCHEDULE
-import com.android.voyageur.ui.trip.schedule.ByDayScreen
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.mockito.Mockito.mock
-import org.mockito.Mockito.`when`
-import org.mockito.kotlin.verify
 
 class SettingsScreenTest {
-  private lateinit var tripRepository: TripRepository
+  private val sampleTrip = Trip(name = "Sample Trip")
+
   private lateinit var navigationActions: NavigationActions
-  private lateinit var tripsViewModel: TripsViewModel
 
   @get:Rule val composeTestRule = createComposeRule()
 
   @Before
   fun setUp() {
-    tripRepository = mock(TripRepository::class.java)
     navigationActions = mock(NavigationActions::class.java)
-    tripsViewModel = TripsViewModel(tripRepository)
-
-    `when`(navigationActions.currentRoute()).thenReturn(Route.SETTINGS)
-  }
-
-  @Test
-  fun displayTextWhenNoTripSelected() {
-    composeTestRule.setContent { SettingsScreen(tripsViewModel, navigationActions) }
-
-    composeTestRule.onNodeWithText("No ToDo selected. Should not happen").assertIsDisplayed()
   }
 
   @Test
   fun hasRequiredComponents() {
-    tripsViewModel.selectTrip(Trip(name = "Sample Trip"))
-    composeTestRule.setContent { SettingsScreen(tripsViewModel, navigationActions) }
+    composeTestRule.setContent { SettingsScreen(sampleTrip, navigationActions) }
     composeTestRule.onNodeWithTag("settingsScreen").assertIsDisplayed()
     composeTestRule.onNodeWithTag("bottomNavigationMenu").assertIsDisplayed()
-    composeTestRule.onNodeWithTag("topBar").assertIsDisplayed()
-  }
-
-  @Test
-  fun displaysTopBarCorrectly() {
-    tripsViewModel.selectTrip(Trip(name = "Sample Trip"))
-    composeTestRule.setContent { SettingsScreen(tripsViewModel, navigationActions) }
-
-    // Check that the top bar with the title is displayed
-    composeTestRule.onNodeWithText("Settings:").assertIsDisplayed()
-
-    // Check that the Home icon button is displayed and clickable
-    composeTestRule.onNodeWithTag("backToOverviewButton").assertIsDisplayed().assertHasClickAction()
-    composeTestRule.onNodeWithContentDescription("Home").assertIsDisplayed().assertHasClickAction()
-  }
-
-  @Test
-  fun navigatesToOverviewOnHomeIconClick() {
-    tripsViewModel.selectTrip(Trip(name = "Sample Trip"))
-    composeTestRule.setContent { SettingsScreen(tripsViewModel, navigationActions) }
-
-    // Simulate a click on the Home icon button
-    composeTestRule.onNodeWithContentDescription("Home").performClick()
-
-    // Verify that the navigation to the Overview screen was triggered
-    verify(navigationActions).navigateTo(Screen.OVERVIEW)
+    composeTestRule.onNodeWithTag("emptySettingsPrompt").assertIsDisplayed()
   }
 
   @Test
   fun displaysCorrectTripName() {
-    tripsViewModel.selectTrip(Trip(name = "Sample Trip"))
-    composeTestRule.setContent { SettingsScreen(tripsViewModel, navigationActions) }
+    composeTestRule.setContent { SettingsScreen(sampleTrip, navigationActions) }
     composeTestRule
         .onNodeWithTag("emptySettingsPrompt")
         .assertTextContains(
@@ -94,29 +44,15 @@ class SettingsScreenTest {
 
   @Test
   fun displaysBottomNavigationCorrectly() {
-    tripsViewModel.selectTrip(Trip(name = "Sample Trip"))
-    composeTestRule.setContent { SettingsScreen(tripsViewModel, navigationActions) }
+    //    tripsViewModel.selectTrip(Trip(name = "Sample Trip"))
+    composeTestRule.setContent { SettingsScreen(sampleTrip, navigationActions) }
 
     // Check that the bottom navigation menu is displayed
     composeTestRule.onNodeWithTag("bottomNavigationMenu").assertIsDisplayed()
 
     // Verify that the bottom navigation has items with correct actions
-    LIST_TRIP_LEVEL_DESTINATION.forEach { destination ->
+    LIST_TOP_LEVEL_DESTINATION.forEach { destination ->
       composeTestRule.onNodeWithText(destination.textId).assertExists()
     }
-  }
-
-  @Test
-  fun bottomNavigationMenu_navigatesToSelectedTab() {
-    tripsViewModel.selectTrip(Trip(name = "Sample Trip"))
-    composeTestRule.setContent { ByDayScreen(tripsViewModel, navigationActions) }
-
-    // Select the "Schedule" tab
-    composeTestRule.onNodeWithTag("Schedule").performClick()
-    verify(navigationActions).navigateTo(SCHEDULE)
-
-    // Select the "Activities" tab
-    composeTestRule.onNodeWithTag("Activities").performClick()
-    verify(navigationActions).navigateTo(ACTIVITIES)
   }
 }

--- a/app/src/main/java/com/android/voyageur/App.kt
+++ b/app/src/main/java/com/android/voyageur/App.kt
@@ -17,9 +17,6 @@ import com.android.voyageur.ui.overview.OverviewScreen
 import com.android.voyageur.ui.profile.ProfileScreen
 import com.android.voyageur.ui.search.SearchScreen
 import com.android.voyageur.ui.trip.TopTabs
-import com.android.voyageur.ui.trip.activities.ActivitiesScreen
-import com.android.voyageur.ui.trip.schedule.ByDayScreen
-import com.android.voyageur.ui.trip.settings.SettingsScreen
 
 @Composable
 fun VoyageurApp() {
@@ -55,8 +52,8 @@ fun VoyageurApp() {
       composable(Screen.PROFILE) { ProfileScreen(userViewModel, navigationActions) }
     }
 
-      navigation(startDestination = Screen.TOP_TABS, route = Route.TOP_TABS) {
-          composable(Screen.TOP_TABS) { TopTabs(tripsViewModel, navigationActions) }
-      }
+    navigation(startDestination = Screen.TOP_TABS, route = Route.TOP_TABS) {
+      composable(Screen.TOP_TABS) { TopTabs(tripsViewModel, navigationActions) }
+    }
   }
 }

--- a/app/src/main/java/com/android/voyageur/App.kt
+++ b/app/src/main/java/com/android/voyageur/App.kt
@@ -16,6 +16,7 @@ import com.android.voyageur.ui.overview.AddTripScreen
 import com.android.voyageur.ui.overview.OverviewScreen
 import com.android.voyageur.ui.profile.ProfileScreen
 import com.android.voyageur.ui.search.SearchScreen
+import com.android.voyageur.ui.trip.TopTabs
 import com.android.voyageur.ui.trip.activities.ActivitiesScreen
 import com.android.voyageur.ui.trip.schedule.ByDayScreen
 import com.android.voyageur.ui.trip.settings.SettingsScreen
@@ -53,14 +54,9 @@ fun VoyageurApp() {
     ) {
       composable(Screen.PROFILE) { ProfileScreen(userViewModel, navigationActions) }
     }
-    navigation(startDestination = Screen.BY_DAY, route = Route.SCHEDULE) {
-      composable(Screen.BY_DAY) { ByDayScreen(tripsViewModel, navigationActions) }
-    }
-    navigation(startDestination = Screen.ACTIVITIES, route = Route.ACTIVITIES) {
-      composable(Screen.ACTIVITIES) { ActivitiesScreen(tripsViewModel, navigationActions) }
-    }
-    navigation(startDestination = Screen.SETTINGS, route = Route.SETTINGS) {
-      composable(Screen.SETTINGS) { SettingsScreen(tripsViewModel, navigationActions) }
-    }
+
+      navigation(startDestination = Screen.TOP_TABS, route = Route.TOP_TABS) {
+          composable(Screen.TOP_TABS) { TopTabs(tripsViewModel, navigationActions) }
+      }
   }
 }

--- a/app/src/main/java/com/android/voyageur/ui/navigation/BottomNavigationMenu.kt
+++ b/app/src/main/java/com/android/voyageur/ui/navigation/BottomNavigationMenu.kt
@@ -3,6 +3,7 @@ package com.android.voyageur.ui.navigation
 //noinspection UsingMaterialAndMaterial3Libraries
 //noinspection UsingMaterialAndMaterial3Libraries
 
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.shape.RoundedCornerShape
@@ -10,12 +11,19 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.NavigationBar
 import androidx.compose.material3.NavigationBarItem
+import androidx.compose.material3.TabRow
+import androidx.compose.material3.Tab
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.unit.dp
+import com.android.voyageur.ui.profile.ProfileScreen
+import com.android.voyageur.ui.trip.activities.ActivitiesScreen
+import com.android.voyageur.ui.trip.schedule.ByDayScreen
 
 @Composable
 fun BottomNavigationMenu(

--- a/app/src/main/java/com/android/voyageur/ui/navigation/BottomNavigationMenu.kt
+++ b/app/src/main/java/com/android/voyageur/ui/navigation/BottomNavigationMenu.kt
@@ -3,7 +3,6 @@ package com.android.voyageur.ui.navigation
 //noinspection UsingMaterialAndMaterial3Libraries
 //noinspection UsingMaterialAndMaterial3Libraries
 
-import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.shape.RoundedCornerShape
@@ -11,25 +10,18 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.NavigationBar
 import androidx.compose.material3.NavigationBarItem
-import androidx.compose.material3.TabRow
-import androidx.compose.material3.Tab
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.unit.dp
-import com.android.voyageur.ui.profile.ProfileScreen
-import com.android.voyageur.ui.trip.activities.ActivitiesScreen
-import com.android.voyageur.ui.trip.schedule.ByDayScreen
 
 @Composable
 fun BottomNavigationMenu(
     onTabSelect: (TopLevelDestination) -> Unit,
     tabList: List<TopLevelDestination>,
-    selectedItem: String
+    selectedItem: String?
 ) {
   NavigationBar(
       modifier = Modifier.fillMaxWidth().height(60.dp).testTag("bottomNavigationMenu"),

--- a/app/src/main/java/com/android/voyageur/ui/navigation/NavigationActions.kt
+++ b/app/src/main/java/com/android/voyageur/ui/navigation/NavigationActions.kt
@@ -15,9 +15,7 @@ object Route {
   const val SEARCH = "Search"
   const val PROFILE = "Profile"
   const val AUTH = "Auth"
-  const val SCHEDULE = "Schedule"
-  const val ACTIVITIES = "Activities"
-  const val SETTINGS = "Settings"
+    const val TOP_TABS = "TopTabs"
 }
 
 object Screen {
@@ -26,11 +24,7 @@ object Screen {
   const val PROFILE = "Profile Screen"
   const val AUTH = "SignIn Screen"
   const val ADD_TRIP = "Add Trip Screen"
-  const val BY_DAY = "By Day Screen"
-  const val BY_WEEK = "By Week Screen" // TODO: Add ByWeek screen
-  const val ACTIVITIES = "Activities Screen"
-  const val ADD_ACTIVITY = "Add Activity Screen" // TODO: Add AddActivity screen
-  const val SETTINGS = "Settings Screen"
+    const val TOP_TABS = "Top Tabs Screen"
 }
 
 data class TopLevelDestination(
@@ -46,22 +40,10 @@ object TopLevelDestinations {
       TopLevelDestination(route = Route.SEARCH, icon = Icons.Outlined.Search, textId = "Search")
   val PROFILE =
       TopLevelDestination(route = Route.PROFILE, icon = Icons.Outlined.Person, textId = "Profile")
-  val SCHEDULE =
-      TopLevelDestination(Route.SCHEDULE, icon = Icons.Outlined.DateRange, textId = "Schedule")
-  val ACTIVITIES =
-      TopLevelDestination(Route.ACTIVITIES, icon = Icons.Outlined.Search, textId = "Activities")
-  val SETTINGS =
-      TopLevelDestination(Route.SETTINGS, icon = Icons.Outlined.Settings, textId = "Settings")
 }
 
 val LIST_TOP_LEVEL_DESTINATION =
     listOf(TopLevelDestinations.OVERVIEW, TopLevelDestinations.SEARCH, TopLevelDestinations.PROFILE)
-
-val LIST_TRIP_LEVEL_DESTINATION =
-    listOf(
-        TopLevelDestinations.SCHEDULE,
-        TopLevelDestinations.ACTIVITIES,
-        TopLevelDestinations.SETTINGS)
 
 open class NavigationActions(
     private val navController: NavHostController,

--- a/app/src/main/java/com/android/voyageur/ui/navigation/NavigationActions.kt
+++ b/app/src/main/java/com/android/voyageur/ui/navigation/NavigationActions.kt
@@ -1,11 +1,9 @@
 package com.android.voyageur.ui.navigation
 
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.outlined.DateRange
 import androidx.compose.material.icons.outlined.Menu
 import androidx.compose.material.icons.outlined.Person
 import androidx.compose.material.icons.outlined.Search
-import androidx.compose.material.icons.outlined.Settings
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.navigation.NavGraph.Companion.findStartDestination
 import androidx.navigation.NavHostController
@@ -15,7 +13,7 @@ object Route {
   const val SEARCH = "Search"
   const val PROFILE = "Profile"
   const val AUTH = "Auth"
-    const val TOP_TABS = "TopTabs"
+  const val TOP_TABS = "TopTabs"
 }
 
 object Screen {
@@ -24,7 +22,7 @@ object Screen {
   const val PROFILE = "Profile Screen"
   const val AUTH = "SignIn Screen"
   const val ADD_TRIP = "Add Trip Screen"
-    const val TOP_TABS = "Top Tabs Screen"
+  const val TOP_TABS = "Top Tabs Screen"
 }
 
 data class TopLevelDestination(

--- a/app/src/main/java/com/android/voyageur/ui/overview/Overview.kt
+++ b/app/src/main/java/com/android/voyageur/ui/overview/Overview.kt
@@ -113,7 +113,7 @@ fun TripItem(tripsViewModel: TripsViewModel, trip: Trip, navigationActions: Navi
   val dateRange = trip.startDate.toDateString() + "-" + trip.endDate.toDateString()
   Card(
       onClick = {
-        navigationActions.navigateTo(Screen.BY_DAY)
+        navigationActions.navigateTo(Screen.TOP_TABS)
         tripsViewModel.selectTrip(trip)
       },
       modifier =

--- a/app/src/main/java/com/android/voyageur/ui/trip/Tabs.kt
+++ b/app/src/main/java/com/android/voyageur/ui/trip/Tabs.kt
@@ -1,0 +1,72 @@
+package com.android.voyageur.ui.trip
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Tab
+import androidx.compose.material3.TabRow
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import com.android.voyageur.model.trip.TripsViewModel
+import com.android.voyageur.ui.navigation.NavigationActions
+import com.android.voyageur.ui.trip.activities.ActivitiesScreen
+import com.android.voyageur.ui.trip.schedule.ByDayScreen
+import com.android.voyageur.ui.trip.settings.SettingsScreen
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.testTag
+import com.android.voyageur.ui.navigation.BottomNavigationMenu
+import com.android.voyageur.ui.navigation.LIST_TOP_LEVEL_DESTINATION
+
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun TopTabs(tripsViewModel: TripsViewModel, navigationActions: NavigationActions) {
+    // Define tab items
+    val tabs = listOf("Schedule", "Activities", "Settings")
+
+    // Remember the currently selected tab index
+    var selectedTabIndex by remember { mutableIntStateOf(0) }
+
+    val trip =
+        tripsViewModel.selectedTrip.collectAsState().value
+            ?: return Text(text = "No ToDo selected. Should not happen", color = Color.Red)
+
+    // Column for top tabs and content
+    Column {
+        TopAppBar(
+            modifier = Modifier.testTag("topBar"),
+            title = { Text(trip.name) },
+        )
+        // TabRow composable for creating top tabs
+        TabRow(
+            selectedTabIndex = selectedTabIndex,
+            modifier = Modifier.fillMaxWidth().testTag("tabRow"),
+        ) {
+            // Create each tab with a Tab composable
+            tabs.forEachIndexed { index, title ->
+                Tab(
+                    selected = selectedTabIndex == index,
+                    onClick = { selectedTabIndex = index },
+                    text = { Text(title) }
+                )
+            }
+        }
+
+        // Display content based on selected tab
+        when (selectedTabIndex) {
+            0 -> ByDayScreen(tripsViewModel, navigationActions)
+            1 -> ActivitiesScreen(tripsViewModel, navigationActions)
+            2 -> SettingsScreen(tripsViewModel, navigationActions)
+        }
+
+
+    }
+}

--- a/app/src/main/java/com/android/voyageur/ui/trip/Tabs.kt
+++ b/app/src/main/java/com/android/voyageur/ui/trip/Tabs.kt
@@ -6,67 +6,60 @@ import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Tab
 import androidx.compose.material3.TabRow
 import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.testTag
 import com.android.voyageur.model.trip.TripsViewModel
 import com.android.voyageur.ui.navigation.NavigationActions
 import com.android.voyageur.ui.trip.activities.ActivitiesScreen
 import com.android.voyageur.ui.trip.schedule.ByDayScreen
 import com.android.voyageur.ui.trip.settings.SettingsScreen
-import androidx.compose.material3.TopAppBar
-import androidx.compose.runtime.collectAsState
-import androidx.compose.runtime.mutableIntStateOf
-import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.platform.testTag
-import com.android.voyageur.ui.navigation.BottomNavigationMenu
-import com.android.voyageur.ui.navigation.LIST_TOP_LEVEL_DESTINATION
-
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun TopTabs(tripsViewModel: TripsViewModel, navigationActions: NavigationActions) {
-    // Define tab items
-    val tabs = listOf("Schedule", "Activities", "Settings")
+  // Define tab items
+  val tabs = listOf("Schedule", "Activities", "Settings")
 
-    // Remember the currently selected tab index
-    var selectedTabIndex by remember { mutableIntStateOf(0) }
+  // Remember the currently selected tab index
+  var selectedTabIndex by remember { mutableIntStateOf(0) }
 
-    val trip =
-        tripsViewModel.selectedTrip.collectAsState().value
-            ?: return Text(text = "No ToDo selected. Should not happen", color = Color.Red)
+  val trip =
+      tripsViewModel.selectedTrip.collectAsState().value
+          ?: return Text(text = "No trip selected. Should not happen", color = Color.Red)
 
-    // Column for top tabs and content
-    Column {
-        TopAppBar(
-            modifier = Modifier.testTag("topBar"),
-            title = { Text(trip.name) },
-        )
-        // TabRow composable for creating top tabs
-        TabRow(
-            selectedTabIndex = selectedTabIndex,
-            modifier = Modifier.fillMaxWidth().testTag("tabRow"),
-        ) {
-            // Create each tab with a Tab composable
-            tabs.forEachIndexed { index, title ->
-                Tab(
-                    selected = selectedTabIndex == index,
-                    onClick = { selectedTabIndex = index },
-                    text = { Text(title) }
-                )
-            }
-        }
-
-        // Display content based on selected tab
-        when (selectedTabIndex) {
-            0 -> ByDayScreen(tripsViewModel, navigationActions)
-            1 -> ActivitiesScreen(tripsViewModel, navigationActions)
-            2 -> SettingsScreen(tripsViewModel, navigationActions)
-        }
-
-
+  // Column for top tabs and content
+  Column {
+    TopAppBar(
+        modifier = Modifier.testTag("topBar"),
+        title = { Text(trip.name) },
+    )
+    // TabRow composable for creating top tabs
+    TabRow(
+        selectedTabIndex = selectedTabIndex,
+        modifier = Modifier.fillMaxWidth().testTag("tabRow"),
+    ) {
+      // Create each tab with a Tab composable
+      tabs.forEachIndexed { index, title ->
+        Tab(
+            selected = selectedTabIndex == index,
+            onClick = { selectedTabIndex = index },
+            text = { Text(title) })
+      }
     }
+
+    // Display content based on selected tab
+    when (selectedTabIndex) {
+      0 -> ByDayScreen(trip, navigationActions)
+      1 -> ActivitiesScreen(trip, navigationActions)
+      2 -> SettingsScreen(trip, navigationActions)
+    }
+  }
 }

--- a/app/src/main/java/com/android/voyageur/ui/trip/Tabs.kt
+++ b/app/src/main/java/com/android/voyageur/ui/trip/Tabs.kt
@@ -36,7 +36,7 @@ fun TopTabs(tripsViewModel: TripsViewModel, navigationActions: NavigationActions
           ?: return Text(text = "No trip selected. Should not happen", color = Color.Red)
 
   // Column for top tabs and content
-  Column {
+  Column(modifier = Modifier.testTag("topTabs")) {
     TopAppBar(
         modifier = Modifier.testTag("topBar"),
         title = { Text(trip.name) },

--- a/app/src/main/java/com/android/voyageur/ui/trip/activities/Activities.kt
+++ b/app/src/main/java/com/android/voyageur/ui/trip/activities/Activities.kt
@@ -16,7 +16,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.testTag
 import com.android.voyageur.model.trip.TripsViewModel
 import com.android.voyageur.ui.navigation.BottomNavigationMenu
-import com.android.voyageur.ui.navigation.LIST_TRIP_LEVEL_DESTINATION
+import com.android.voyageur.ui.navigation.LIST_TOP_LEVEL_DESTINATION
 import com.android.voyageur.ui.navigation.NavigationActions
 import com.android.voyageur.ui.navigation.Screen
 
@@ -33,22 +33,10 @@ fun ActivitiesScreen(
   Scaffold(
       // TODO: Final implementation of ActivitiesScreen
       modifier = Modifier.testTag("activitiesScreen"),
-      topBar = {
-        TopAppBar(
-            modifier = Modifier.testTag("topBar"),
-            title = { Text("Activities:") },
-            navigationIcon = {
-              IconButton(
-                  modifier = Modifier.testTag("backToOverviewButton"),
-                  onClick = { navigationActions.navigateTo(Screen.OVERVIEW) }) {
-                    Icon(imageVector = Icons.Outlined.Home, contentDescription = "Home")
-                  }
-            })
-      },
       bottomBar = {
         BottomNavigationMenu(
             onTabSelect = { route -> navigationActions.navigateTo(route) },
-            tabList = LIST_TRIP_LEVEL_DESTINATION,
+            tabList = LIST_TOP_LEVEL_DESTINATION,
             selectedItem = navigationActions.currentRoute())
       },
       content = { pd ->

--- a/app/src/main/java/com/android/voyageur/ui/trip/activities/Activities.kt
+++ b/app/src/main/java/com/android/voyageur/ui/trip/activities/Activities.kt
@@ -1,34 +1,26 @@
 package com.android.voyageur.ui.trip.activities
 
 import androidx.compose.foundation.layout.padding
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.outlined.Home
 import androidx.compose.material3.ExperimentalMaterial3Api
-import androidx.compose.material3.Icon
-import androidx.compose.material3.IconButton
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
-import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.collectAsState
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.testTag
-import com.android.voyageur.model.trip.TripsViewModel
+import com.android.voyageur.model.trip.Trip
 import com.android.voyageur.ui.navigation.BottomNavigationMenu
 import com.android.voyageur.ui.navigation.LIST_TOP_LEVEL_DESTINATION
 import com.android.voyageur.ui.navigation.NavigationActions
-import com.android.voyageur.ui.navigation.Screen
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun ActivitiesScreen(
-    tripsViewModel: TripsViewModel,
+    trip: Trip,
     navigationActions: NavigationActions,
 ) {
-  val trip =
-      tripsViewModel.selectedTrip.collectAsState().value
-          ?: return Text(text = "No ToDo selected. Should not happen", color = Color.Red)
+  //  val trip =
+  //      tripsViewModel.selectedTrip.collectAsState().value
+  //          ?: return Text(text = "No ToDo selected. Should not happen", color = Color.Red)
 
   Scaffold(
       // TODO: Final implementation of ActivitiesScreen

--- a/app/src/main/java/com/android/voyageur/ui/trip/schedule/ByDay.kt
+++ b/app/src/main/java/com/android/voyageur/ui/trip/schedule/ByDay.kt
@@ -1,34 +1,23 @@
 package com.android.voyageur.ui.trip.schedule
 
 import androidx.compose.foundation.layout.padding
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.outlined.Home
 import androidx.compose.material3.ExperimentalMaterial3Api
-import androidx.compose.material3.Icon
-import androidx.compose.material3.IconButton
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
-import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.collectAsState
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.testTag
-import com.android.voyageur.model.trip.TripsViewModel
+import com.android.voyageur.model.trip.Trip
 import com.android.voyageur.ui.navigation.BottomNavigationMenu
 import com.android.voyageur.ui.navigation.LIST_TOP_LEVEL_DESTINATION
 import com.android.voyageur.ui.navigation.NavigationActions
-import com.android.voyageur.ui.navigation.Screen
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun ByDayScreen(
-    tripsViewModel: TripsViewModel,
+    trip: Trip,
     navigationActions: NavigationActions,
 ) {
-  val trip =
-      tripsViewModel.selectedTrip.collectAsState().value
-          ?: return Text(text = "No ToDo selected. Should not happen", color = Color.Red)
   Scaffold(
       // TODO: Final implementation of ByDayScreen
       modifier = Modifier.testTag("byDayScreen"),

--- a/app/src/main/java/com/android/voyageur/ui/trip/schedule/ByDay.kt
+++ b/app/src/main/java/com/android/voyageur/ui/trip/schedule/ByDay.kt
@@ -16,7 +16,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.testTag
 import com.android.voyageur.model.trip.TripsViewModel
 import com.android.voyageur.ui.navigation.BottomNavigationMenu
-import com.android.voyageur.ui.navigation.LIST_TRIP_LEVEL_DESTINATION
+import com.android.voyageur.ui.navigation.LIST_TOP_LEVEL_DESTINATION
 import com.android.voyageur.ui.navigation.NavigationActions
 import com.android.voyageur.ui.navigation.Screen
 
@@ -32,22 +32,10 @@ fun ByDayScreen(
   Scaffold(
       // TODO: Final implementation of ByDayScreen
       modifier = Modifier.testTag("byDayScreen"),
-      topBar = {
-        TopAppBar(
-            modifier = Modifier.testTag("topBar"),
-            title = { Text("Schedule ByDay:") },
-            navigationIcon = {
-              IconButton(
-                  modifier = Modifier.testTag("backToOverviewButton"),
-                  onClick = { navigationActions.navigateTo(Screen.OVERVIEW) }) {
-                    Icon(imageVector = Icons.Outlined.Home, contentDescription = "Home")
-                  }
-            })
-      },
       bottomBar = {
         BottomNavigationMenu(
             onTabSelect = { route -> navigationActions.navigateTo(route) },
-            tabList = LIST_TRIP_LEVEL_DESTINATION,
+            tabList = LIST_TOP_LEVEL_DESTINATION,
             selectedItem = navigationActions.currentRoute())
       },
       content = { pd ->

--- a/app/src/main/java/com/android/voyageur/ui/trip/settings/Settings.kt
+++ b/app/src/main/java/com/android/voyageur/ui/trip/settings/Settings.kt
@@ -17,7 +17,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.testTag
 import com.android.voyageur.model.trip.TripsViewModel
 import com.android.voyageur.ui.navigation.BottomNavigationMenu
-import com.android.voyageur.ui.navigation.LIST_TRIP_LEVEL_DESTINATION
+import com.android.voyageur.ui.navigation.LIST_TOP_LEVEL_DESTINATION
 import com.android.voyageur.ui.navigation.NavigationActions
 import com.android.voyageur.ui.navigation.Screen
 
@@ -34,22 +34,10 @@ fun SettingsScreen(
   Scaffold(
       // TODO: Final implementation of SettingsScreen
       modifier = Modifier.testTag("settingsScreen"),
-      topBar = {
-        TopAppBar(
-            modifier = Modifier.testTag("topBar"),
-            title = { Text("Settings:") },
-            navigationIcon = {
-              IconButton(
-                  modifier = Modifier.testTag("backToOverviewButton"),
-                  onClick = { navigationActions.navigateTo(Screen.OVERVIEW) }) {
-                    Icon(imageVector = Icons.Outlined.Home, contentDescription = "Home")
-                  }
-            })
-      },
       bottomBar = {
         BottomNavigationMenu(
             onTabSelect = { route -> navigationActions.navigateTo(route) },
-            tabList = LIST_TRIP_LEVEL_DESTINATION,
+            tabList = LIST_TOP_LEVEL_DESTINATION,
             selectedItem = navigationActions.currentRoute())
       },
       content = { pd ->

--- a/app/src/main/java/com/android/voyageur/ui/trip/settings/Settings.kt
+++ b/app/src/main/java/com/android/voyageur/ui/trip/settings/Settings.kt
@@ -1,35 +1,24 @@
 package com.android.voyageur.ui.trip.settings
 
 import androidx.compose.foundation.layout.padding
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.outlined.Home
 import androidx.compose.material3.ExperimentalMaterial3Api
-import androidx.compose.material3.Icon
-import androidx.compose.material3.IconButton
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
-import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.testTag
-import com.android.voyageur.model.trip.TripsViewModel
+import com.android.voyageur.model.trip.Trip
 import com.android.voyageur.ui.navigation.BottomNavigationMenu
 import com.android.voyageur.ui.navigation.LIST_TOP_LEVEL_DESTINATION
 import com.android.voyageur.ui.navigation.NavigationActions
-import com.android.voyageur.ui.navigation.Screen
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun SettingsScreen(
-    tripsViewModel: TripsViewModel,
+    trip: Trip,
     navigationActions: NavigationActions,
 ) {
-  val trip =
-      tripsViewModel.selectedTrip.collectAsState().value
-          ?: return Text(text = "No ToDo selected. Should not happen", color = Color.Red)
 
   Scaffold(
       // TODO: Final implementation of SettingsScreen


### PR DESCRIPTION
## Summary

This feature replaces the per-trip navigation that was using a bottom bar to a navigation that uses tabs at the top of the screen. This is more UI friendly since the changing bottom bar was creating confusion, and now the user can directly use the navigation  bar when they're viewing a certain trip.

Now, when someone presses on a trip, the name of the trip is displayed on the top bar and right below are 3 tabs that point to 3 different screens: Schedule, Activities and Settings.

## Changes
- **Screens/UI:** The Schedule/ Activities/ Settings screens remained mostly the same. However, now there's a TopBar screen which displays the3 screens below the tabs depending on the tab selected

## Checklist
- [x] This PR resolves #96
- [x] Tests have been added for new functionality.
- [x] Screenshots or UI changes have been attached (if applicable).
- [ ] Documentation has been updated (if applicable).

##  Testing

Explain how this feature was tested and what kind of testing (unit, integration, UI) has been done. Mention platforms or configurations used for testing.
- **Manual Testing:**
    - [x] Tested on emulator / physical device.
- **Unit Tests**
    - [x] Added units tests for this

## Screenshots (if applicable)

![Screenshot_20241031_013039](https://github.com/user-attachments/assets/66a823ef-e9f5-425a-8f53-96434f112516)

