### PR TITLE
Feat/search page UI upgrade

### DIFF
--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -79,7 +79,7 @@ jobs:
         env:
           MAPS_API_KEY: $ {{ secrets.PLACES_API_KEY }}
           PLACES_API_KEY: ${{ secrets.PLACES_API_KEY }}
-        run: echo PLACES_API_KEY=\"$PLACES_API_KEY\" > ./local.properties
+        run: echo PLACES_API_KEY=\$PLACES_API_KEY\ > ./local.properties
 
       - name: Grant execute permission for gradlew
         run: |

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -57,7 +57,7 @@ jobs:
         env:
           PLACES_API_KEY: ${{ secrets.PLACES_API_KEY }}
           MAPS_API_KEY: $ {{ secrets.PLACES_API_KEY }}
-        run: echo PLACES_API_KEY=\"$PLACES_API_KEY\" > ../../local.properties
+        run: echo PLACES_API_KEY=\"$PLACES_API_KEY\" > ./local.properties
 
       - name: Build APK
         run: |

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -57,7 +57,7 @@ jobs:
         env:
           PLACES_API_KEY: ${{ secrets.PLACES_API_KEY }}
           MAPS_API_KEY: $ {{ secrets.PLACES_API_KEY }}
-        run: echo PLACES_API_KEY=\"$PLACES_API_KEY\" > ./local.properties
+        run: echo PLACES_API_KEY=\$PLACES_API_KEY\ > ./local.properties
 
       - name: Build APK
         run: |

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -22,7 +22,6 @@ android {
         localProperties.load(FileInputStream(localPropertiesFile))
     }
 
-    val mapsApiKey: String = localProperties.getProperty("MAPS_API_KEY") ?: ""
     val placesApiKey = localProperties.getProperty("PLACES_API_KEY") ?: ""
 
     defaultConfig {
@@ -31,7 +30,7 @@ android {
         targetSdk = 34
         versionCode = 1
         versionName = "1.0"
-        buildConfigField ("String", "PLACES_API_KEY", placesApiKey)
+        buildConfigField ("String", "PLACES_API_KEY", "\"${placesApiKey}\"")
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables {

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -37,7 +37,7 @@ android {
         vectorDrawables {
             useSupportLibrary = true
         }
-        manifestPlaceholders["MAPS_API_KEY"] = mapsApiKey
+        manifestPlaceholders["PLACES_API_KEY"] = placesApiKey
     }
 
     buildTypes {
@@ -188,6 +188,7 @@ dependencies {
     implementation(libs.test.core.ktx)
     implementation(libs.androidx.navigation.testing)
     implementation(libs.firebase.storage.ktx)
+    implementation(libs.androidx.foundation.android)
 
     // Testing Unit
     testImplementation(libs.junit) {

--- a/app/src/androidTest/java/com/android/voyageur/ui/search/SearchScreenTest.kt
+++ b/app/src/androidTest/java/com/android/voyageur/ui/search/SearchScreenTest.kt
@@ -3,7 +3,6 @@ package com.android.voyageur.ui.search
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithTag
-import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.performTextInput
 import com.android.voyageur.model.place.PlacesRepository
@@ -102,16 +101,16 @@ class SearchScreenTest {
   }
 
   @Test
-    fun testNoResultsFoundPlaces() {
-        val searchQuery = "test"
-        `when`(placesRepository.searchPlaces(eq(searchQuery), any(), any())).thenAnswer {
-        val onSuccess = it.arguments[1] as (List<Place>) -> Unit
-        onSuccess(emptyList())
-        }
-        composeTestRule.onNodeWithTag("filterButton_PLACES").performClick()
-        composeTestRule.onNodeWithTag("searchTextField").performTextInput(searchQuery)
-        composeTestRule.onNodeWithTag("noResults").assertIsDisplayed()
+  fun testNoResultsFoundPlaces() {
+    val searchQuery = "test"
+    `when`(placesRepository.searchPlaces(eq(searchQuery), any(), any())).thenAnswer {
+      val onSuccess = it.arguments[1] as (List<Place>) -> Unit
+      onSuccess(emptyList())
     }
+    composeTestRule.onNodeWithTag("filterButton_PLACES").performClick()
+    composeTestRule.onNodeWithTag("searchTextField").performTextInput(searchQuery)
+    composeTestRule.onNodeWithTag("noResults").assertIsDisplayed()
+  }
 
   @Test
   fun testToggleToMapViewButton() {

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -26,7 +26,7 @@
         </activity>
         <meta-data
             android:name="com.google.android.geo.API_KEY"
-            android:value="${MAPS_API_KEY}" />
+            android:value="${PLACES_API_KEY}" />
     </application>
 
 </manifest>

--- a/app/src/main/java/com/android/voyageur/model/place/GooglePlacesRepository.kt
+++ b/app/src/main/java/com/android/voyageur/model/place/GooglePlacesRepository.kt
@@ -53,6 +53,7 @@ class GooglePlacesRepository(private val placesClient: PlacesClient) : PlacesRep
             Place.Field.OPENING_HOURS,
             Place.Field.RATING,
             Place.Field.USER_RATINGS_TOTAL,
+            Place.Field.LAT_LNG,
             Place.Field.PRICE_LEVEL)
     placeIds.forEach { placeId ->
       val request = FetchPlaceRequest.builder(placeId, placeFields).build()

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -76,6 +76,7 @@ uiToolingPreviewAndroid = "1.7.3"
 navigationTesting = "2.8.2"
 firebaseStorageKtx = "21.0.1"
 testng = "6.9.6"
+foundationAndroid = "1.7.5"
 
 [libraries]
 androidx-activity-compose = { module = "androidx.activity:activity-compose", version.ref = "activityCompose" }
@@ -137,6 +138,7 @@ androidx-ui-tooling-preview-android = { group = "androidx.compose.ui", name = "u
 androidx-navigation-testing = { group = "androidx.navigation", name = "navigation-testing", version.ref = "navigationTesting" }
 firebase-storage-ktx = { group = "com.google.firebase", name = "firebase-storage-ktx", version.ref = "firebaseStorageKtx" }
 testng = { group = "org.testng", name = "testng", version.ref = "testng" }
+androidx-foundation-android = { group = "androidx.compose.foundation", name = "foundation-android", version.ref = "foundationAndroid" }
 
 
 [plugins]


### PR DESCRIPTION
## Summary

Refined the Search Page to look like the Mockup provided in the figma.

## Changes
- **Screens/UI:** 2 tabs are now present (Users and Places), also when in places tab we can toggle between map view and list view, also changed what composables are show for each user and each place.
- **Repositories:** Added lat_lng Place field in the Places API request to be able to display a pin in the map view for each place.

## Checklist

Ensure all / most of these are checked before the pull request is submitted.
- [x] This PR resolves #59 ` (if applicable).
- [x] Tests have been added for new functionality.
- [x] Screenshots or UI changes have been attached.

##  Testing
- **Manual Testing:**
    - [x] Tested on emulator / physical device.
- **Unit Tests**
    - [x] Added units tests for this

##  Related Issues/Tickets

Closes #59

## Screenshots (if applicable)
![image](https://github.com/user-attachments/assets/8ed9ab03-720e-4cb7-8429-6bf47c21e920)

![image](https://github.com/user-attachments/assets/05cd9e75-2c39-4ee4-9ec9-bc16ac0efd32)WON

![image](https://github.com/user-attachments/assets/d543f977-b22f-4bf6-a3de-b15a9db1de0a)
