### PR TITLE
feat: add edit mode

### DIFF
--- a/app/src/androidTest/java/com/android/voyageur/ui/overview/AddTripTest.kt
+++ b/app/src/androidTest/java/com/android/voyageur/ui/overview/AddTripTest.kt
@@ -59,7 +59,6 @@ class AddTripScreenTest {
 
   @Test
   fun addTripScreen_inputsUpdateState() {
-
     composeTestRule.setContent { AddTripScreen(tripsViewModel, navigationActions) }
 
     composeTestRule.onNodeWithTag("inputTripTitle").performTextInput("London")
@@ -188,6 +187,65 @@ class AddTripScreenTest {
     verify(navigationActions).goBack()
   }
 
+  @Test
+  fun addTripScreen_imageSelection() {
+    composeTestRule.setContent { AddTripScreen(tripsViewModel, navigationActions) }
+    composeTestRule.onNodeWithText("Select Image from Gallery").performClick()
+    // Assuming gallery selection simulated
+    // Add verification that the imageUri state is updated
+  }
+
+  @Test
+  fun addTripScreen_invalidStartDate() {
+    composeTestRule.setContent { AddTripScreen(tripsViewModel, navigationActions) }
+    // Simulate setting a past start date
+    composeTestRule.onNodeWithTag("inputStartDate").performClick()
+    composeTestRule.onNodeWithText("OK").performClick()
+    composeTestRule.onNodeWithTag("tripSave").assertIsNotEnabled()
+  }
+
+  @Test
+  fun addTripScreen_endDateBeforeStartDate() {
+    composeTestRule.setContent { AddTripScreen(tripsViewModel, navigationActions) }
+    // Simulate setting a start date and an earlier end date
+    composeTestRule.onNodeWithTag("inputStartDate").performClick()
+    composeTestRule.onNodeWithText("OK").performClick()
+    composeTestRule.onNodeWithTag("inputEndDate").performClick()
+    composeTestRule.onNodeWithText("OK").performClick()
+    composeTestRule.onNodeWithTag("tripSave").assertIsNotEnabled()
+  }
+
+  @Test
+  fun addTripScreen_editMode() {
+    val trip =
+        Trip(
+            id = "editTripId",
+            creator = "mockUserId",
+            description = "Existing trip",
+            name = "Existing Trip",
+            locations = listOf(Location(country = "France", city = "Paris")),
+            startDate = Timestamp(Date()),
+            endDate = Timestamp(Date()),
+            activities = listOf(),
+            type = TripType.TOURISM,
+            imageUri = "someUri")
+    tripsViewModel.selectTrip(trip)
+    composeTestRule.setContent {
+      AddTripScreen(tripsViewModel, navigationActions, isEditMode = true)
+    }
+
+    composeTestRule.onNodeWithTag("inputTripTitle").assertTextContains("Existing Trip")
+    composeTestRule.onNodeWithTag("inputTripDescription").assertTextContains("Existing trip")
+    composeTestRule.onNodeWithTag("tripTypeTourism").assertIsSelected()
+  }
+
+  @Test
+  fun addTripScreen_displayDatePickerModal() {
+    composeTestRule.setContent { AddTripScreen(tripsViewModel, navigationActions) }
+    composeTestRule.onNodeWithTag("inputStartDate").performClick()
+    composeTestRule.onNodeWithText("OK").assertExists() // Checks if date picker dialog appears
+  }
+
   private fun convertToTimestamp(dateString: String): Timestamp? {
     val calendar = GregorianCalendar(TimeZone.getTimeZone("UTC"))
     val dateParts = dateString.split("/")
@@ -207,14 +265,11 @@ class AddTripScreenTest {
   @Test
   fun convertToTimestamp_validDate() {
     val dateString = "01/01/2024"
-
     val utcCalendar = GregorianCalendar(TimeZone.getTimeZone("UTC"))
     utcCalendar.set(2024, 0, 1, 0, 0, 0)
     utcCalendar.set(GregorianCalendar.MILLISECOND, 0)
     val expectedTimestamp = Timestamp(utcCalendar.time)
-
     val result = convertToTimestamp(dateString)
-
     assert(result != null)
     assert(expectedTimestamp.seconds == result?.seconds)
   }
@@ -223,7 +278,6 @@ class AddTripScreenTest {
   fun convertToTimestamp_invalidDate() {
     val dateString = "invalid"
     val result = convertToTimestamp(dateString)
-
     assert(result == null)
   }
 }

--- a/app/src/androidTest/java/com/android/voyageur/ui/overview/AddTripTest.kt
+++ b/app/src/androidTest/java/com/android/voyageur/ui/overview/AddTripTest.kt
@@ -240,6 +240,39 @@ class AddTripScreenTest {
   }
 
   @Test
+  fun addTripScreen_editMode_updatesTrip() {
+    // Set up a sample trip to simulate editing
+    val trip =
+        Trip(
+            id = "editTripId",
+            creator = "mockUserId",
+            description = "Existing trip",
+            name = "Existing Trip",
+            locations = listOf(Location(country = "France", city = "Paris")),
+            startDate = Timestamp(Date()),
+            endDate = Timestamp(Date()),
+            activities = listOf(),
+            type = TripType.TOURISM,
+            imageUri = "someUri")
+
+    // Set the selected trip in the ViewModel to the sample trip to simulate edit mode
+    tripsViewModel.selectTrip(trip)
+
+    // Set up the test content
+    composeTestRule.setContent {
+      AddTripScreen(
+          tripsViewModel = tripsViewModel, navigationActions = navigationActions, isEditMode = true)
+    }
+
+    // Modify some fields to simulate an edit
+    composeTestRule.onNodeWithTag("inputTripTitle").performTextInput("Updated Trip Title")
+    composeTestRule.onNodeWithTag("inputTripDescription").performTextInput("Updated Description")
+
+    // Click the save button to trigger updateTrip
+    composeTestRule.onNodeWithTag("tripSave").performClick()
+  }
+
+  @Test
   fun addTripScreen_displayDatePickerModal() {
     composeTestRule.setContent { AddTripScreen(tripsViewModel, navigationActions) }
     composeTestRule.onNodeWithTag("inputStartDate").performClick()

--- a/app/src/androidTest/java/com/android/voyageur/ui/trip/settings/SettingsScreenTest.kt
+++ b/app/src/androidTest/java/com/android/voyageur/ui/trip/settings/SettingsScreenTest.kt
@@ -6,46 +6,63 @@ import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
 import com.android.voyageur.model.trip.Trip
+import com.android.voyageur.model.trip.TripsViewModel
 import com.android.voyageur.ui.navigation.LIST_TOP_LEVEL_DESTINATION
 import com.android.voyageur.ui.navigation.NavigationActions
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.mockito.Mockito.mock
+import org.mockito.Mockito.`when`
 
 class SettingsScreenTest {
-  private val sampleTrip = Trip(name = "Sample Trip")
 
+  private val sampleTrip = Trip(name = "Sample Trip")
   private lateinit var navigationActions: NavigationActions
+  private lateinit var tripsViewModel: TripsViewModel
 
   @get:Rule val composeTestRule = createComposeRule()
 
   @Before
   fun setUp() {
     navigationActions = mock(NavigationActions::class.java)
+    tripsViewModel = mock(TripsViewModel::class.java)
+
+    // Mock selectedTrip as StateFlow
+    val tripStateFlow: StateFlow<Trip?> = MutableStateFlow(sampleTrip)
+    `when`(tripsViewModel.selectedTrip).thenReturn(tripStateFlow)
   }
 
   @Test
   fun hasRequiredComponents() {
-    composeTestRule.setContent { SettingsScreen(sampleTrip, navigationActions) }
+    composeTestRule.setContent {
+      SettingsScreen(
+          trip = sampleTrip, navigationActions = navigationActions, tripsViewModel = tripsViewModel)
+    }
+
     composeTestRule.onNodeWithTag("settingsScreen").assertIsDisplayed()
     composeTestRule.onNodeWithTag("bottomNavigationMenu").assertIsDisplayed()
-    composeTestRule.onNodeWithTag("emptySettingsPrompt").assertIsDisplayed()
   }
 
   @Test
-  fun displaysCorrectTripName() {
-    composeTestRule.setContent { SettingsScreen(sampleTrip, navigationActions) }
-    composeTestRule
-        .onNodeWithTag("emptySettingsPrompt")
-        .assertTextContains(
-            "You're viewing the Settings screen for Sample Trip, but it's not implemented yet.")
+  fun displaysCorrectTripNameInEditMode() {
+    composeTestRule.setContent {
+      SettingsScreen(
+          trip = sampleTrip, navigationActions = navigationActions, tripsViewModel = tripsViewModel)
+    }
+
+    // Check if the screen displays the trip name correctly in edit mode
+    composeTestRule.onNodeWithTag("inputTripTitle").assertTextContains("Sample Trip")
   }
 
   @Test
   fun displaysBottomNavigationCorrectly() {
-    //    tripsViewModel.selectTrip(Trip(name = "Sample Trip"))
-    composeTestRule.setContent { SettingsScreen(sampleTrip, navigationActions) }
+    composeTestRule.setContent {
+      SettingsScreen(
+          trip = sampleTrip, navigationActions = navigationActions, tripsViewModel = tripsViewModel)
+    }
 
     // Check that the bottom navigation menu is displayed
     composeTestRule.onNodeWithTag("bottomNavigationMenu").assertIsDisplayed()

--- a/app/src/main/java/com/android/voyageur/model/trip/TripsViewModel.kt
+++ b/app/src/main/java/com/android/voyageur/model/trip/TripsViewModel.kt
@@ -8,6 +8,7 @@ import com.google.firebase.Firebase
 import com.google.firebase.auth.auth
 import com.google.firebase.firestore.firestore
 import com.google.firebase.storage.FirebaseStorage
+import java.util.UUID
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -79,7 +80,7 @@ open class TripsViewModel(
 
   fun uploadImageToFirebase(uri: Uri, onSuccess: (String) -> Unit, onFailure: (Exception) -> Unit) {
     val storageRef = FirebaseStorage.getInstance().reference
-    val fileRef = storageRef.child("images/${uri.lastPathSegment}" + Math.random().toString())
+    val fileRef = storageRef.child("images/${uri.lastPathSegment}" + UUID.randomUUID())
     fileRef
         .putFile(uri)
         .addOnSuccessListener {

--- a/app/src/main/java/com/android/voyageur/model/trip/TripsViewModel.kt
+++ b/app/src/main/java/com/android/voyageur/model/trip/TripsViewModel.kt
@@ -56,6 +56,11 @@ open class TripsViewModel(
     tripsRepository.getTrips(
         creator = Firebase.auth.uid.orEmpty(),
         onSuccess = { trips ->
+          /*
+              This is a trick to force a recompose, because the reference wouldn't
+              change and update the UI as the list references wouldn't change, nor the object ref.
+              so the UI won't get updated without this.
+          */
           _trips.value = ArrayList()
           _trips.value = trips
           onSuccess()

--- a/app/src/main/java/com/android/voyageur/ui/overview/AddTrip.kt
+++ b/app/src/main/java/com/android/voyageur/ui/overview/AddTrip.kt
@@ -149,8 +149,10 @@ fun AddTripScreen(
             activities = listOf(),
             type = tripType,
             imageUri = imageUrl)
-    if (!isEditMode) tripsViewModel.createTrip(trip, onSuccess = { navigationActions.goBack() })
-    else {
+    if (!isEditMode) {
+      tripsViewModel.createTrip(trip)
+      navigationActions.goBack()
+    } else {
       tripsViewModel.updateTrip(
           trip,
           onSuccess = {

--- a/app/src/main/java/com/android/voyageur/ui/overview/AddTrip.kt
+++ b/app/src/main/java/com/android/voyageur/ui/overview/AddTrip.kt
@@ -156,7 +156,12 @@ fun AddTripScreen(
       tripsViewModel.updateTrip(
           trip,
           onSuccess = {
+            /*
+                This is a trick to force a recompose, because the reference wouldn't
+                change and update the UI.
+            */
             tripsViewModel.selectTrip(Trip())
+
             tripsViewModel.selectTrip(trip)
             onUpdate()
           })

--- a/app/src/main/java/com/android/voyageur/ui/overview/AddTrip.kt
+++ b/app/src/main/java/com/android/voyageur/ui/overview/AddTrip.kt
@@ -46,7 +46,8 @@ import java.util.Locale
 fun AddTripScreen(
     tripsViewModel: TripsViewModel = viewModel(factory = TripsViewModel.Factory),
     navigationActions: NavigationActions,
-    isEditMode: Boolean = false
+    isEditMode: Boolean = false,
+    onUpdate: () -> Unit = {}
 ) {
   var name by remember { mutableStateOf("") }
   var description by remember { mutableStateOf("") }
@@ -150,7 +151,13 @@ fun AddTripScreen(
             imageUri = imageUrl)
     if (!isEditMode) tripsViewModel.createTrip(trip, onSuccess = { navigationActions.goBack() })
     else {
-      tripsViewModel.updateTrip(trip, onSuccess = { navigationActions.goBack() })
+      tripsViewModel.updateTrip(
+          trip,
+          onSuccess = {
+            tripsViewModel.selectTrip(Trip())
+            tripsViewModel.selectTrip(trip)
+            onUpdate()
+          })
     }
   }
 

--- a/app/src/main/java/com/android/voyageur/ui/trip/Tabs.kt
+++ b/app/src/main/java/com/android/voyageur/ui/trip/Tabs.kt
@@ -56,7 +56,7 @@ fun TopTabs(tripsViewModel: TripsViewModel, navigationActions: NavigationActions
     when (selectedTabIndex) {
       0 -> ByDayScreen(trip, navigationActions)
       1 -> ActivitiesScreen(trip, navigationActions)
-      2 -> SettingsScreen(trip, navigationActions)
+      2 -> SettingsScreen(trip, navigationActions, tripsViewModel = tripsViewModel)
     }
   }
 }

--- a/app/src/main/java/com/android/voyageur/ui/trip/Tabs.kt
+++ b/app/src/main/java/com/android/voyageur/ui/trip/Tabs.kt
@@ -7,7 +7,6 @@ import androidx.compose.material3.Tab
 import androidx.compose.material3.TabRow
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.remember
@@ -32,7 +31,7 @@ fun TopTabs(tripsViewModel: TripsViewModel, navigationActions: NavigationActions
   var selectedTabIndex by remember { mutableIntStateOf(0) }
 
   val trip =
-      tripsViewModel.selectedTrip.collectAsState().value
+      tripsViewModel.selectedTrip.value
           ?: return Text(text = "No trip selected. Should not happen", color = Color.Red)
 
   // Column for top tabs and content
@@ -56,7 +55,15 @@ fun TopTabs(tripsViewModel: TripsViewModel, navigationActions: NavigationActions
     when (selectedTabIndex) {
       0 -> ByDayScreen(trip, navigationActions)
       1 -> ActivitiesScreen(trip, navigationActions)
-      2 -> SettingsScreen(trip, navigationActions, tripsViewModel = tripsViewModel)
+      2 ->
+          SettingsScreen(
+              trip,
+              navigationActions,
+              tripsViewModel = tripsViewModel,
+              onUpdate = {
+                selectedTabIndex = 0
+                selectedTabIndex = 2
+              })
     }
   }
 }

--- a/app/src/main/java/com/android/voyageur/ui/trip/settings/Settings.kt
+++ b/app/src/main/java/com/android/voyageur/ui/trip/settings/Settings.kt
@@ -1,23 +1,26 @@
 package com.android.voyageur.ui.trip.settings
 
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Scaffold
-import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.testTag
 import com.android.voyageur.model.trip.Trip
+import com.android.voyageur.model.trip.TripsViewModel
 import com.android.voyageur.ui.navigation.BottomNavigationMenu
 import com.android.voyageur.ui.navigation.LIST_TOP_LEVEL_DESTINATION
 import com.android.voyageur.ui.navigation.NavigationActions
+import com.android.voyageur.ui.overview.AddTripScreen
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun SettingsScreen(
     trip: Trip,
     navigationActions: NavigationActions,
+    tripsViewModel: TripsViewModel
 ) {
 
   Scaffold(
@@ -30,9 +33,8 @@ fun SettingsScreen(
             selectedItem = navigationActions.currentRoute())
       },
       content = { pd ->
-        Text(
-            modifier = Modifier.padding(pd).testTag("emptySettingsPrompt"),
-            text =
-                "You're viewing the Settings screen for ${trip.name}, but it's not implemented yet.")
+        Box(modifier = Modifier.padding(pd)) {
+          AddTripScreen(tripsViewModel, navigationActions, isEditMode = true)
+        }
       })
 }

--- a/app/src/main/java/com/android/voyageur/ui/trip/settings/Settings.kt
+++ b/app/src/main/java/com/android/voyageur/ui/trip/settings/Settings.kt
@@ -20,7 +20,8 @@ import com.android.voyageur.ui.overview.AddTripScreen
 fun SettingsScreen(
     trip: Trip,
     navigationActions: NavigationActions,
-    tripsViewModel: TripsViewModel
+    tripsViewModel: TripsViewModel,
+    onUpdate: () -> Unit = {}
 ) {
 
   Scaffold(
@@ -34,7 +35,7 @@ fun SettingsScreen(
       },
       content = { pd ->
         Box(modifier = Modifier.padding(pd)) {
-          AddTripScreen(tripsViewModel, navigationActions, isEditMode = true)
+          AddTripScreen(tripsViewModel, navigationActions, isEditMode = true, onUpdate = onUpdate)
         }
       })
 }


### PR DESCRIPTION
## Summary

Add the settings screen UI which edits the selected trip

Solves #85 

## Changes

- **Screens/UI:** In the `settings` tab of the trip view 
- **Repositories:** Added success callback to viewModel functions as well
- **Bug Fixes/Improvements:** List any GitHub issues this PR addresses or any improvements to the existing codebase.

## Checklist

Ensure all / most of these are checked before the pull request is submitted.
- [x] This PR resolves #85 
- [x] Tests have been added for new functionality.
- [x] Screenshots or UI changes have been attached (if applicable).

##  Testing
- **Manual Testing:**
    - [x] Tested on emulator / physical device.
- **Unit Tests**
    - [x] Added units tests for this

## Screenshots (if applicable)

<img width="231" alt="image" src="https://github.com/user-attachments/assets/89781b64-ddd9-4581-93d2-93bb78539b80">
