### PR TITLE
feat: add support for interests in the profile screen + tests

### DIFF
--- a/app/src/androidTest/java/com/android/voyageur/ui/profile/EditProfileScreenTest.kt
+++ b/app/src/androidTest/java/com/android/voyageur/ui/profile/EditProfileScreenTest.kt
@@ -2,13 +2,16 @@ package com.android.voyageur.ui.profile
 
 import androidx.activity.compose.setContent
 import androidx.compose.ui.test.assert
+import androidx.compose.ui.test.assertCountEquals
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.assertIsNotEnabled
+import androidx.compose.ui.test.assertTextEquals
 import androidx.compose.ui.test.hasText
 import androidx.compose.ui.test.junit4.createAndroidComposeRule
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performImeAction
 import androidx.compose.ui.test.performTextInput
 import com.android.voyageur.MainActivity
 import com.android.voyageur.model.user.User
@@ -259,5 +262,110 @@ class EditProfileScreenTest {
 
     // Assert: The interest chip is still displayed
     composeTestRule.onNodeWithText(interestToRemove).assertIsDisplayed()
+  }
+  // New test: Do not add whitespace-only interest
+  @Test
+  fun doNotAddWhitespaceOnlyInterest() {
+    // Arrange
+    userViewModel._user.value =
+      User("123", "Jane Doe", "jane@example.com", interests = mutableListOf())
+    userViewModel._isLoading.value = false
+
+    // Wait for the UI to settle
+    composeTestRule.waitForIdle()
+
+    // Act: Enter an interest that is only whitespaces and click the Add button
+    val whitespaceInterest = "   "
+    composeTestRule.onNodeWithTag("newInterestField").performTextInput(whitespaceInterest)
+    composeTestRule.onNodeWithTag("addInterestButton").performClick()
+
+    // Assert: Check that "No interests added yet" text is still displayed
+    composeTestRule.onNodeWithTag("noInterests").assertIsDisplayed()
+    // Also check that the interest is not added
+    composeTestRule.onAllNodes(hasText(whitespaceInterest.trim())).assertCountEquals(0)
+  }
+  // Test: Interests are displayed
+  @Test
+  fun interestsAreDisplayed() {
+    // Arrange
+    val interests = listOf("Travel", "Photography")
+    userViewModel._user.value =
+      User("123", "Jane Doe", "jane@example.com", interests = interests.toMutableList())
+    userViewModel._isLoading.value = false
+
+    // Wait for the UI to settle
+    composeTestRule.waitForIdle()
+
+    // Assert: Check that the interest chips are displayed
+    for (interest in interests) {
+      composeTestRule.onNodeWithText(interest).assertIsDisplayed()
+    }
+  }
+  // Test: No interests text not displayed when interests exist
+  @Test
+  fun noInterestsTextNotDisplayedWhenInterestsExist() {
+    // Arrange
+    userViewModel._user.value =
+      User("123", "Jane Doe", "jane@example.com", interests = mutableListOf("Travel"))
+    userViewModel._isLoading.value = false
+
+    // Wait for the UI to settle
+    composeTestRule.waitForIdle()
+
+    // Assert: Check that "No interests added yet" text is not displayed
+    composeTestRule.onNodeWithTag("noInterests").assertDoesNotExist()
+  }
+  // Test: Do not add empty interest
+  @Test
+  fun doNotAddEmptyInterest() {
+    // Arrange
+    userViewModel._user.value =
+      User("123", "Jane Doe", "jane@example.com", interests = mutableListOf())
+    userViewModel._isLoading.value = false
+
+    // Wait for the UI to settle
+    composeTestRule.waitForIdle()
+
+    // Act: Click the Add button without entering any text
+    composeTestRule.onNodeWithTag("addInterestButton").performClick()
+
+    // Assert: Check that "No interests added yet" text is still displayed
+    composeTestRule.onNodeWithTag("noInterests").assertIsDisplayed()
+  }
+  // Test: Add interest using IME action
+  @Test
+  fun addInterestWithImeAction() {
+    // Arrange
+    userViewModel._user.value =
+      User("123", "Jane Doe", "jane@example.com", interests = mutableListOf())
+    userViewModel._isLoading.value = false
+
+    // Wait for the UI to settle
+    composeTestRule.waitForIdle()
+
+    // Act: Enter a new interest and press the "Done" IME action
+    val newInterest = "Cooking"
+    composeTestRule.onNodeWithTag("newInterestField").performTextInput(newInterest)
+    composeTestRule.onNodeWithTag("newInterestField").performImeAction()
+
+    // Assert: Check that the new interest chip is displayed
+    composeTestRule.onNodeWithText(newInterest).assertIsDisplayed()
+  }
+  // Test: Do not add empty interest with IME action
+  @Test
+  fun doNotAddEmptyInterestWithImeAction() {
+    // Arrange
+    userViewModel._user.value =
+      User("123", "Jane Doe", "jane@example.com", interests = mutableListOf())
+    userViewModel._isLoading.value = false
+
+    // Wait for the UI to settle
+    composeTestRule.waitForIdle()
+
+    // Act: Press the "Done" IME action without entering any text
+    composeTestRule.onNodeWithTag("newInterestField").performImeAction()
+
+    // Assert: Check that "No interests added yet" text is still displayed
+    composeTestRule.onNodeWithTag("noInterests").assertIsDisplayed()
   }
 }

--- a/app/src/androidTest/java/com/android/voyageur/ui/profile/EditProfileScreenTest.kt
+++ b/app/src/androidTest/java/com/android/voyageur/ui/profile/EditProfileScreenTest.kt
@@ -367,5 +367,4 @@ class EditProfileScreenTest {
     // Assert: Check that "No interests added yet" text is still displayed
     composeTestRule.onNodeWithTag("noInterests").assertIsDisplayed()
   }
-
 }

--- a/app/src/androidTest/java/com/android/voyageur/ui/profile/EditProfileScreenTest.kt
+++ b/app/src/androidTest/java/com/android/voyageur/ui/profile/EditProfileScreenTest.kt
@@ -5,7 +5,6 @@ import androidx.compose.ui.test.assert
 import androidx.compose.ui.test.assertCountEquals
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.assertIsNotEnabled
-import androidx.compose.ui.test.assertTextEquals
 import androidx.compose.ui.test.hasText
 import androidx.compose.ui.test.junit4.createAndroidComposeRule
 import androidx.compose.ui.test.onNodeWithTag
@@ -268,7 +267,7 @@ class EditProfileScreenTest {
   fun doNotAddWhitespaceOnlyInterest() {
     // Arrange
     userViewModel._user.value =
-      User("123", "Jane Doe", "jane@example.com", interests = mutableListOf())
+        User("123", "Jane Doe", "jane@example.com", interests = mutableListOf())
     userViewModel._isLoading.value = false
 
     // Wait for the UI to settle
@@ -290,7 +289,7 @@ class EditProfileScreenTest {
     // Arrange
     val interests = listOf("Travel", "Photography")
     userViewModel._user.value =
-      User("123", "Jane Doe", "jane@example.com", interests = interests.toMutableList())
+        User("123", "Jane Doe", "jane@example.com", interests = interests.toMutableList())
     userViewModel._isLoading.value = false
 
     // Wait for the UI to settle
@@ -306,7 +305,7 @@ class EditProfileScreenTest {
   fun noInterestsTextNotDisplayedWhenInterestsExist() {
     // Arrange
     userViewModel._user.value =
-      User("123", "Jane Doe", "jane@example.com", interests = mutableListOf("Travel"))
+        User("123", "Jane Doe", "jane@example.com", interests = mutableListOf("Travel"))
     userViewModel._isLoading.value = false
 
     // Wait for the UI to settle
@@ -320,7 +319,7 @@ class EditProfileScreenTest {
   fun doNotAddEmptyInterest() {
     // Arrange
     userViewModel._user.value =
-      User("123", "Jane Doe", "jane@example.com", interests = mutableListOf())
+        User("123", "Jane Doe", "jane@example.com", interests = mutableListOf())
     userViewModel._isLoading.value = false
 
     // Wait for the UI to settle
@@ -337,7 +336,7 @@ class EditProfileScreenTest {
   fun addInterestWithImeAction() {
     // Arrange
     userViewModel._user.value =
-      User("123", "Jane Doe", "jane@example.com", interests = mutableListOf())
+        User("123", "Jane Doe", "jane@example.com", interests = mutableListOf())
     userViewModel._isLoading.value = false
 
     // Wait for the UI to settle
@@ -356,7 +355,7 @@ class EditProfileScreenTest {
   fun doNotAddEmptyInterestWithImeAction() {
     // Arrange
     userViewModel._user.value =
-      User("123", "Jane Doe", "jane@example.com", interests = mutableListOf())
+        User("123", "Jane Doe", "jane@example.com", interests = mutableListOf())
     userViewModel._isLoading.value = false
 
     // Wait for the UI to settle

--- a/app/src/androidTest/java/com/android/voyageur/ui/profile/EditProfileScreenTest.kt
+++ b/app/src/androidTest/java/com/android/voyageur/ui/profile/EditProfileScreenTest.kt
@@ -29,8 +29,7 @@ import org.mockito.kotlin.anyOrNull
 
 class EditProfileScreenTest {
 
-  @get:Rule
-  val composeTestRule = createAndroidComposeRule<MainActivity>()
+  @get:Rule val composeTestRule = createAndroidComposeRule<MainActivity>()
 
   private lateinit var navigationActions: NavigationActions
   private lateinit var userRepository: UserRepository
@@ -57,17 +56,19 @@ class EditProfileScreenTest {
 
     // Mock userRepository.getUserById to call onSuccess with a User
     doAnswer { invocation ->
-      val userId = invocation.getArgument<String>(0)
-      val onSuccess = invocation.getArgument<(User) -> Unit>(1)
-      val user = User(
-        id = userId,
-        name = "Test User",
-        email = "test@example.com",
-        interests = listOf("Travel", "Photography")
-      )
-      onSuccess(user)
-      null
-    }.`when`(userRepository).getUserById(anyString(), anyOrNull(), anyOrNull())
+          val userId = invocation.getArgument<String>(0)
+          val onSuccess = invocation.getArgument<(User) -> Unit>(1)
+          val user =
+              User(
+                  id = userId,
+                  name = "Test User",
+                  email = "test@example.com",
+                  interests = listOf("Travel", "Photography"))
+          onSuccess(user)
+          null
+        }
+        .`when`(userRepository)
+        .getUserById(anyString(), anyOrNull(), anyOrNull())
 
     // Create the UserViewModel with the mocked userRepository and firebaseAuth
     userViewModel = UserViewModel(userRepository, firebaseAuth)
@@ -183,7 +184,8 @@ class EditProfileScreenTest {
   @Test
   fun addInterestSuccessfully() {
     // Arrange
-    userViewModel._user.value = User("123", "Jane Doe", "jane@example.com", interests = mutableListOf())
+    userViewModel._user.value =
+        User("123", "Jane Doe", "jane@example.com", interests = mutableListOf())
     userViewModel._isLoading.value = false
 
     // Wait for the UI to settle
@@ -203,12 +205,12 @@ class EditProfileScreenTest {
   fun removeInterestWithConfirmation() {
     // Arrange
     val interestToRemove = "Photography"
-    userViewModel._user.value = User(
-      "123",
-      "Jane Doe",
-      "jane@example.com",
-      interests = mutableListOf("Travel", interestToRemove)
-    )
+    userViewModel._user.value =
+        User(
+            "123",
+            "Jane Doe",
+            "jane@example.com",
+            interests = mutableListOf("Travel", interestToRemove))
     userViewModel._isLoading.value = false
 
     // Wait for the UI to settle
@@ -219,7 +221,10 @@ class EditProfileScreenTest {
 
     // Assert: Confirmation dialog is displayed
     composeTestRule.onNodeWithText("Remove Interest").assertIsDisplayed()
-    composeTestRule.onNodeWithText("Are you sure you want to remove \"$interestToRemove\" from your interests?").assertIsDisplayed()
+    composeTestRule
+        .onNodeWithText(
+            "Are you sure you want to remove \"$interestToRemove\" from your interests?")
+        .assertIsDisplayed()
 
     // Act: Confirm the deletion
     composeTestRule.onNodeWithText("Remove").performClick()
@@ -232,12 +237,12 @@ class EditProfileScreenTest {
   fun cancelRemoveInterest() {
     // Arrange
     val interestToRemove = "Travel"
-    userViewModel._user.value = User(
-      "123",
-      "Jane Doe",
-      "jane@example.com",
-      interests = mutableListOf(interestToRemove, "Photography")
-    )
+    userViewModel._user.value =
+        User(
+            "123",
+            "Jane Doe",
+            "jane@example.com",
+            interests = mutableListOf(interestToRemove, "Photography"))
     userViewModel._isLoading.value = false
 
     // Wait for the UI to settle

--- a/app/src/androidTest/java/com/android/voyageur/ui/profile/EditProfileScreenTest.kt
+++ b/app/src/androidTest/java/com/android/voyageur/ui/profile/EditProfileScreenTest.kt
@@ -367,4 +367,5 @@ class EditProfileScreenTest {
     // Assert: Check that "No interests added yet" text is still displayed
     composeTestRule.onNodeWithTag("noInterests").assertIsDisplayed()
   }
+
 }

--- a/app/src/androidTest/java/com/android/voyageur/ui/profile/ProfileScreenTest.kt
+++ b/app/src/androidTest/java/com/android/voyageur/ui/profile/ProfileScreenTest.kt
@@ -51,14 +51,14 @@ class ProfileScreenTest {
 
     // Mock userRepository.getUserById to call onSuccess with a User
     doAnswer { invocation ->
-      val userId = invocation.getArgument<String>(0)
-      val onSuccess = invocation.getArgument<(User) -> Unit>(1)
-      val user = User(userId, "Test User", "test@example.com", interests = emptyList())
-      onSuccess(user)
-      null
-    }
-      .`when`(userRepository)
-      .getUserById(anyString(), anyOrNull(), anyOrNull())
+          val userId = invocation.getArgument<String>(0)
+          val onSuccess = invocation.getArgument<(User) -> Unit>(1)
+          val user = User(userId, "Test User", "test@example.com", interests = emptyList())
+          onSuccess(user)
+          null
+        }
+        .`when`(userRepository)
+        .getUserById(anyString(), anyOrNull(), anyOrNull())
 
     // Create the UserViewModel with the mocked userRepository and firebaseAuth
     userViewModel = UserViewModel(userRepository, firebaseAuth)
@@ -111,7 +111,8 @@ class ProfileScreenTest {
   @Test
   fun displayDefaultProfilePictureWhenNoProfilePicture() {
     // Arrange: Mock a user without a profile picture
-    val user = User("123", "Jane Doe", "jane@example.com", profilePicture = "", interests = emptyList())
+    val user =
+        User("123", "Jane Doe", "jane@example.com", profilePicture = "", interests = emptyList())
     userViewModel._user.value = user
     userViewModel._isLoading.value = false
 
@@ -122,7 +123,13 @@ class ProfileScreenTest {
   @Test
   fun displayProfilePictureWhenUserHasProfilePicture() {
     // Arrange: Mock a user with a profile picture
-    val user = User("123", "Jane Doe", "jane@example.com", profilePicture = "http://example.com/profile.jpg", interests = emptyList())
+    val user =
+        User(
+            "123",
+            "Jane Doe",
+            "jane@example.com",
+            profilePicture = "http://example.com/profile.jpg",
+            interests = emptyList())
     userViewModel._user.value = user
     userViewModel._isLoading.value = false
 
@@ -174,12 +181,11 @@ class ProfileScreenTest {
 
     // Assert: Check that the interests are displayed
     composeTestRule.onNodeWithTag("interestsFlowRow").assertIsDisplayed()
-    interests.forEach { interest ->
-      composeTestRule.onNodeWithText(interest).assertIsDisplayed()
-    }
+    interests.forEach { interest -> composeTestRule.onNodeWithText(interest).assertIsDisplayed() }
   }
 
-  // New test to verify the "No interests added yet" message is displayed when the user has no interests
+  // New test to verify the "No interests added yet" message is displayed when the user has no
+  // interests
   @Test
   fun displayNoInterestsMessageWhenUserHasNoInterests() {
     // Arrange: Mock a user with no interests

--- a/app/src/androidTest/java/com/android/voyageur/ui/profile/interests/InterestChipEditableTest.kt
+++ b/app/src/androidTest/java/com/android/voyageur/ui/profile/interests/InterestChipEditableTest.kt
@@ -11,100 +11,89 @@ import org.mockito.Mockito.*
 
 class InterestChipEditableTest {
 
-    @get:Rule
-    val composeTestRule = createComposeRule()
+  @get:Rule val composeTestRule = createComposeRule()
 
-    @Test
-    fun interestChipEditable_displaysInterestText() {
-        // Arrange
-        val interest = "Photography"
+  @Test
+  fun interestChipEditable_displaysInterestText() {
+    // Arrange
+    val interest = "Photography"
 
-        // Act
-        composeTestRule.setContent {
-            InterestChipEditable(interest = interest, onRemove = {})
-        }
+    // Act
+    composeTestRule.setContent { InterestChipEditable(interest = interest, onRemove = {}) }
 
-        // Assert
-        composeTestRule.onNodeWithText(interest).assertIsDisplayed()
+    // Assert
+    composeTestRule.onNodeWithText(interest).assertIsDisplayed()
+  }
+
+  @Test
+  fun interestChipEditable_displaysRemoveIcon() {
+    // Arrange
+    val interest = "Travel"
+
+    // Act
+    composeTestRule.setContent { InterestChipEditable(interest = interest, onRemove = {}) }
+
+    // Assert
+    composeTestRule.onNodeWithTag("removeInterestButton_$interest").assertIsDisplayed()
+  }
+
+  @Test
+  fun interestChipEditable_showsConfirmationDialog_whenRemoveIconClicked() {
+    // Arrange
+    val interest = "Cooking"
+
+    // Act
+    composeTestRule.setContent { InterestChipEditable(interest = interest, onRemove = {}) }
+
+    // Click on the remove icon
+    composeTestRule.onNodeWithTag("removeInterestButton_$interest").performClick()
+
+    // Assert
+    composeTestRule.onNodeWithText("Remove Interest").assertIsDisplayed()
+    composeTestRule
+        .onNodeWithText("Are you sure you want to remove \"$interest\" from your interests?")
+        .assertIsDisplayed()
+  }
+
+  @Test
+  fun interestChipEditable_callsOnRemove_whenConfirmed() {
+    // Arrange
+    val interest = "Hiking"
+    val onRemoveMock = mock(Runnable::class.java) // Using Runnable as a simple interface to mock
+
+    // Act
+    composeTestRule.setContent {
+      InterestChipEditable(interest = interest, onRemove = { onRemoveMock.run() })
     }
 
-    @Test
-    fun interestChipEditable_displaysRemoveIcon() {
-        // Arrange
-        val interest = "Travel"
+    // Click on the remove icon
+    composeTestRule.onNodeWithTag("removeInterestButton_$interest").performClick()
 
-        // Act
-        composeTestRule.setContent {
-            InterestChipEditable(interest = interest, onRemove = {})
-        }
+    // Confirm deletion
+    composeTestRule.onNodeWithText("Remove").performClick()
 
-        // Assert
-        composeTestRule.onNodeWithTag("removeInterestButton_$interest").assertIsDisplayed()
+    // Assert
+    verify(onRemoveMock).run()
+  }
+
+  @Test
+  fun interestChipEditable_doesNotCallOnRemove_whenCancelled() {
+    // Arrange
+    val interest = "Reading"
+    val onRemoveMock = mock(Runnable::class.java)
+
+    // Act
+    composeTestRule.setContent {
+      InterestChipEditable(interest = interest, onRemove = { onRemoveMock.run() })
     }
 
-    @Test
-    fun interestChipEditable_showsConfirmationDialog_whenRemoveIconClicked() {
-        // Arrange
-        val interest = "Cooking"
+    // Click on the remove icon
+    composeTestRule.onNodeWithTag("removeInterestButton_$interest").performClick()
 
-        // Act
-        composeTestRule.setContent {
-            InterestChipEditable(interest = interest, onRemove = {})
-        }
+    // Cancel deletion
+    composeTestRule.onNodeWithText("Cancel").performClick()
 
-        // Click on the remove icon
-        composeTestRule.onNodeWithTag("removeInterestButton_$interest").performClick()
-
-        // Assert
-        composeTestRule.onNodeWithText("Remove Interest").assertIsDisplayed()
-        composeTestRule.onNodeWithText("Are you sure you want to remove \"$interest\" from your interests?").assertIsDisplayed()
-    }
-
-    @Test
-    fun interestChipEditable_callsOnRemove_whenConfirmed() {
-        // Arrange
-        val interest = "Hiking"
-        val onRemoveMock = mock(Runnable::class.java) // Using Runnable as a simple interface to mock
-
-        // Act
-        composeTestRule.setContent {
-            InterestChipEditable(
-                interest = interest,
-                onRemove = { onRemoveMock.run() }
-            )
-        }
-
-        // Click on the remove icon
-        composeTestRule.onNodeWithTag("removeInterestButton_$interest").performClick()
-
-        // Confirm deletion
-        composeTestRule.onNodeWithText("Remove").performClick()
-
-        // Assert
-        verify(onRemoveMock).run()
-    }
-
-    @Test
-    fun interestChipEditable_doesNotCallOnRemove_whenCancelled() {
-        // Arrange
-        val interest = "Reading"
-        val onRemoveMock = mock(Runnable::class.java)
-
-        // Act
-        composeTestRule.setContent {
-            InterestChipEditable(
-                interest = interest,
-                onRemove = { onRemoveMock.run() }
-            )
-        }
-
-        // Click on the remove icon
-        composeTestRule.onNodeWithTag("removeInterestButton_$interest").performClick()
-
-        // Cancel deletion
-        composeTestRule.onNodeWithText("Cancel").performClick()
-
-        // Assert
-        verify(onRemoveMock, never()).run()
-    }
+    // Assert
+    verify(onRemoveMock, never()).run()
+  }
 }

--- a/app/src/androidTest/java/com/android/voyageur/ui/profile/interests/InterestChipEditableTest.kt
+++ b/app/src/androidTest/java/com/android/voyageur/ui/profile/interests/InterestChipEditableTest.kt
@@ -1,0 +1,110 @@
+package com.android.voyageur.ui.profile.interests
+
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import org.junit.Rule
+import org.junit.Test
+import org.mockito.Mockito.*
+
+class InterestChipEditableTest {
+
+    @get:Rule
+    val composeTestRule = createComposeRule()
+
+    @Test
+    fun interestChipEditable_displaysInterestText() {
+        // Arrange
+        val interest = "Photography"
+
+        // Act
+        composeTestRule.setContent {
+            InterestChipEditable(interest = interest, onRemove = {})
+        }
+
+        // Assert
+        composeTestRule.onNodeWithText(interest).assertIsDisplayed()
+    }
+
+    @Test
+    fun interestChipEditable_displaysRemoveIcon() {
+        // Arrange
+        val interest = "Travel"
+
+        // Act
+        composeTestRule.setContent {
+            InterestChipEditable(interest = interest, onRemove = {})
+        }
+
+        // Assert
+        composeTestRule.onNodeWithTag("removeInterestButton_$interest").assertIsDisplayed()
+    }
+
+    @Test
+    fun interestChipEditable_showsConfirmationDialog_whenRemoveIconClicked() {
+        // Arrange
+        val interest = "Cooking"
+
+        // Act
+        composeTestRule.setContent {
+            InterestChipEditable(interest = interest, onRemove = {})
+        }
+
+        // Click on the remove icon
+        composeTestRule.onNodeWithTag("removeInterestButton_$interest").performClick()
+
+        // Assert
+        composeTestRule.onNodeWithText("Remove Interest").assertIsDisplayed()
+        composeTestRule.onNodeWithText("Are you sure you want to remove \"$interest\" from your interests?").assertIsDisplayed()
+    }
+
+    @Test
+    fun interestChipEditable_callsOnRemove_whenConfirmed() {
+        // Arrange
+        val interest = "Hiking"
+        val onRemoveMock = mock(Runnable::class.java) // Using Runnable as a simple interface to mock
+
+        // Act
+        composeTestRule.setContent {
+            InterestChipEditable(
+                interest = interest,
+                onRemove = { onRemoveMock.run() }
+            )
+        }
+
+        // Click on the remove icon
+        composeTestRule.onNodeWithTag("removeInterestButton_$interest").performClick()
+
+        // Confirm deletion
+        composeTestRule.onNodeWithText("Remove").performClick()
+
+        // Assert
+        verify(onRemoveMock).run()
+    }
+
+    @Test
+    fun interestChipEditable_doesNotCallOnRemove_whenCancelled() {
+        // Arrange
+        val interest = "Reading"
+        val onRemoveMock = mock(Runnable::class.java)
+
+        // Act
+        composeTestRule.setContent {
+            InterestChipEditable(
+                interest = interest,
+                onRemove = { onRemoveMock.run() }
+            )
+        }
+
+        // Click on the remove icon
+        composeTestRule.onNodeWithTag("removeInterestButton_$interest").performClick()
+
+        // Cancel deletion
+        composeTestRule.onNodeWithText("Cancel").performClick()
+
+        // Assert
+        verify(onRemoveMock, never()).run()
+    }
+}

--- a/app/src/androidTest/java/com/android/voyageur/ui/profile/interests/InterestChipTest.kt
+++ b/app/src/androidTest/java/com/android/voyageur/ui/profile/interests/InterestChipTest.kt
@@ -11,52 +11,44 @@ import org.junit.Test
 
 class InterestChipTest {
 
-    @get:Rule
-    val composeTestRule = createComposeRule()
+  @get:Rule val composeTestRule = createComposeRule()
 
-    @Test
-    fun interestChip_displaysInterestText() {
-        // Arrange
-        val interest = "Photography"
+  @Test
+  fun interestChip_displaysInterestText() {
+    // Arrange
+    val interest = "Photography"
 
-        // Act
-        composeTestRule.setContent {
-            InterestChip(interest = interest)
-        }
+    // Act
+    composeTestRule.setContent { InterestChip(interest = interest) }
 
-        // Assert
-        composeTestRule.onNodeWithText(interest).assertIsDisplayed()
+    // Assert
+    composeTestRule.onNodeWithText(interest).assertIsDisplayed()
+  }
+
+  @Test
+  fun interestChip_hasCorrectTestTag() {
+    // Arrange
+    val interest = "Travel"
+
+    // Act
+    composeTestRule.setContent { InterestChip(interest = interest) }
+
+    // Assert
+    composeTestRule.onNodeWithTag("interest_$interest").assertIsDisplayed()
+  }
+
+  @Test
+  fun interestChip_appliesModifiers() {
+    // Arrange
+    val interest = "Cooking"
+    val customTag = "customTestTag"
+
+    // Act
+    composeTestRule.setContent {
+      InterestChip(interest = interest, modifier = Modifier.testTag(customTag))
     }
 
-    @Test
-    fun interestChip_hasCorrectTestTag() {
-        // Arrange
-        val interest = "Travel"
-
-        // Act
-        composeTestRule.setContent {
-            InterestChip(interest = interest)
-        }
-
-        // Assert
-        composeTestRule.onNodeWithTag("interest_$interest").assertIsDisplayed()
-    }
-
-    @Test
-    fun interestChip_appliesModifiers() {
-        // Arrange
-        val interest = "Cooking"
-        val customTag = "customTestTag"
-
-        // Act
-        composeTestRule.setContent {
-            InterestChip(
-                interest = interest,
-                modifier = Modifier.testTag(customTag)
-            )
-        }
-
-        // Assert
-        composeTestRule.onNodeWithTag(customTag).assertIsDisplayed()
-    }
+    // Assert
+    composeTestRule.onNodeWithTag(customTag).assertIsDisplayed()
+  }
 }

--- a/app/src/androidTest/java/com/android/voyageur/ui/profile/interests/InterestChipTest.kt
+++ b/app/src/androidTest/java/com/android/voyageur/ui/profile/interests/InterestChipTest.kt
@@ -1,0 +1,62 @@
+package com.android.voyageur.ui.profile.interests
+
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.onNodeWithText
+import org.junit.Rule
+import org.junit.Test
+
+class InterestChipTest {
+
+    @get:Rule
+    val composeTestRule = createComposeRule()
+
+    @Test
+    fun interestChip_displaysInterestText() {
+        // Arrange
+        val interest = "Photography"
+
+        // Act
+        composeTestRule.setContent {
+            InterestChip(interest = interest)
+        }
+
+        // Assert
+        composeTestRule.onNodeWithText(interest).assertIsDisplayed()
+    }
+
+    @Test
+    fun interestChip_hasCorrectTestTag() {
+        // Arrange
+        val interest = "Travel"
+
+        // Act
+        composeTestRule.setContent {
+            InterestChip(interest = interest)
+        }
+
+        // Assert
+        composeTestRule.onNodeWithTag("interest_$interest").assertIsDisplayed()
+    }
+
+    @Test
+    fun interestChip_appliesModifiers() {
+        // Arrange
+        val interest = "Cooking"
+        val customTag = "customTestTag"
+
+        // Act
+        composeTestRule.setContent {
+            InterestChip(
+                interest = interest,
+                modifier = Modifier.testTag(customTag)
+            )
+        }
+
+        // Assert
+        composeTestRule.onNodeWithTag(customTag).assertIsDisplayed()
+    }
+}

--- a/app/src/main/java/com/android/voyageur/model/user/User.kt
+++ b/app/src/main/java/com/android/voyageur/model/user/User.kt
@@ -10,33 +10,34 @@ data class User(
     var interests: List<String> = mutableListOf(),
     var username: String = ""
 ) {
-    override fun equals(other: Any?): Boolean {
-        if (this === other) return true
-        if (javaClass != other?.javaClass) return false
+  override fun equals(other: Any?): Boolean {
+    if (this === other) return true
+    if (javaClass != other?.javaClass) return false
 
-        other as User
+    other as User
 
-        if (id != other.id) return false
-        if (name != other.name) return false
-        if (email != other.email) return false
-        if (profilePicture != other.profilePicture) return false
-        if (bio != other.bio) return false
-        if (!contacts.containsAll(other.contacts) || !other.contacts.containsAll(contacts)) return false
-        if (!interests.containsAll(other.interests) || !other.interests.containsAll(interests)) return false
-        if (username != other.username) return false
+    if (id != other.id) return false
+    if (name != other.name) return false
+    if (email != other.email) return false
+    if (profilePicture != other.profilePicture) return false
+    if (bio != other.bio) return false
+    if (!contacts.containsAll(other.contacts) || !other.contacts.containsAll(contacts)) return false
+    if (!interests.containsAll(other.interests) || !other.interests.containsAll(interests))
+        return false
+    if (username != other.username) return false
 
-        return true
-    }
+    return true
+  }
 
-    override fun hashCode(): Int {
-        var result = id.hashCode()
-        result = 31 * result + name.hashCode()
-        result = 31 * result + email.hashCode()
-        result = 31 * result + profilePicture.hashCode()
-        result = 31 * result + bio.hashCode()
-        result = 31 * result + contacts.toSet().hashCode()
-        result = 31 * result + interests.toSet().hashCode()
-        result = 31 * result + username.hashCode()
-        return result
-    }
+  override fun hashCode(): Int {
+    var result = id.hashCode()
+    result = 31 * result + name.hashCode()
+    result = 31 * result + email.hashCode()
+    result = 31 * result + profilePicture.hashCode()
+    result = 31 * result + bio.hashCode()
+    result = 31 * result + contacts.toSet().hashCode()
+    result = 31 * result + interests.toSet().hashCode()
+    result = 31 * result + username.hashCode()
+    return result
+  }
 }

--- a/app/src/main/java/com/android/voyageur/model/user/User.kt
+++ b/app/src/main/java/com/android/voyageur/model/user/User.kt
@@ -7,33 +7,36 @@ data class User(
     var profilePicture: String = "",
     var bio: String = "",
     var contacts: List<String> = mutableListOf(),
+    var interests: List<String> = mutableListOf(),
     var username: String = ""
 ) {
-  override fun equals(other: Any?): Boolean {
-    if (this === other) return true
-    if (javaClass != other?.javaClass) return false
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (javaClass != other?.javaClass) return false
 
-    other as User
+        other as User
 
-    if (id != other.id) return false
-    if (name != other.name) return false
-    if (email != other.email) return false
-    if (profilePicture != other.profilePicture) return false
-    if (bio != other.bio) return false
-    if (!contacts.containsAll(other.contacts) || !other.contacts.containsAll(contacts)) return false
-    if (username != other.username) return false
+        if (id != other.id) return false
+        if (name != other.name) return false
+        if (email != other.email) return false
+        if (profilePicture != other.profilePicture) return false
+        if (bio != other.bio) return false
+        if (!contacts.containsAll(other.contacts) || !other.contacts.containsAll(contacts)) return false
+        if (!interests.containsAll(other.interests) || !other.interests.containsAll(interests)) return false
+        if (username != other.username) return false
 
-    return true
-  }
+        return true
+    }
 
-  override fun hashCode(): Int {
-    var result = id.hashCode()
-    result = 31 * result + name.hashCode()
-    result = 31 * result + email.hashCode()
-    result = 31 * result + profilePicture.hashCode()
-    result = 31 * result + bio.hashCode()
-    result = 31 * result + contacts.hashCode()
-    result = 31 * result + username.hashCode()
-    return result
-  }
+    override fun hashCode(): Int {
+        var result = id.hashCode()
+        result = 31 * result + name.hashCode()
+        result = 31 * result + email.hashCode()
+        result = 31 * result + profilePicture.hashCode()
+        result = 31 * result + bio.hashCode()
+        result = 31 * result + contacts.toSet().hashCode()
+        result = 31 * result + interests.toSet().hashCode()
+        result = 31 * result + username.hashCode()
+        return result
+    }
 }

--- a/app/src/main/java/com/android/voyageur/ui/profile/EditProfileScreen.kt
+++ b/app/src/main/java/com/android/voyageur/ui/profile/EditProfileScreen.kt
@@ -324,7 +324,7 @@ fun Context.findActivity(): ComponentActivity {
     if (context is ComponentActivity) {
       return context
     }
-    context = (context as ContextWrapper).baseContext
+    context = context.baseContext
   }
   throw IllegalStateException("No Activity found")
 }

--- a/app/src/main/java/com/android/voyageur/ui/profile/EditProfileScreen.kt
+++ b/app/src/main/java/com/android/voyageur/ui/profile/EditProfileScreen.kt
@@ -1,27 +1,44 @@
 package com.android.voyageur.ui.profile
 
+import android.Manifest
+import android.content.Context
+import android.content.pm.PackageManager
 import android.net.Uri
+import android.os.Build
+import android.widget.Toast
+import androidx.activity.ComponentActivity
+import android.content.ContextWrapper
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ExperimentalLayoutApi
+import androidx.compose.foundation.layout.FlowRow
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.text.KeyboardActions
+import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.AccountCircle
+import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Button
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
@@ -32,131 +49,308 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.unit.dp
+import androidx.core.app.ActivityCompat
+import androidx.core.content.ContextCompat
 import coil.compose.rememberAsyncImagePainter
 import com.android.voyageur.model.user.UserViewModel
 import com.android.voyageur.ui.navigation.BottomNavigationMenu
 import com.android.voyageur.ui.navigation.LIST_TOP_LEVEL_DESTINATION
 import com.android.voyageur.ui.navigation.NavigationActions
 import com.android.voyageur.ui.navigation.Route
+import com.android.voyageur.ui.profile.interests.InterestChip
+import com.android.voyageur.ui.profile.interests.InterestChipEditable
 
-@OptIn(ExperimentalMaterial3Api::class)
+@OptIn(ExperimentalMaterial3Api::class, ExperimentalLayoutApi::class)
 @Composable
 fun EditProfileScreen(userViewModel: UserViewModel, navigationActions: NavigationActions) {
-  val user by userViewModel.user.collectAsState()
-  val isLoading by userViewModel.isLoading.collectAsState()
+    val user by userViewModel.user.collectAsState()
+    val isLoading by userViewModel.isLoading.collectAsState()
 
-  var name by remember { mutableStateOf(user?.name ?: "") }
-  var email by remember { mutableStateOf(user?.email ?: "") }
-  var profilePictureUri by remember { mutableStateOf<Uri?>(null) }
-  var profilePictureUrl by remember { mutableStateOf(user?.profilePicture ?: "") }
-  var isSaving by remember { mutableStateOf(false) }
+    var name by remember { mutableStateOf(user?.name ?: "") }
+    var email by remember { mutableStateOf(user?.email ?: "") }
+    var profilePictureUri by remember { mutableStateOf<Uri?>(null) }
+    var profilePictureUrl by remember { mutableStateOf(user?.profilePicture ?: "") }
+    var isSaving by remember { mutableStateOf(false) }
 
-  val pickPhotoLauncher =
-      rememberLauncherForActivityResult(ActivityResultContracts.GetContent()) { uri: Uri? ->
-        uri?.let { profilePictureUri = it }
-      }
+    // State variables for interests
+    var interests by remember { mutableStateOf(user?.interests?.toMutableList() ?: mutableListOf()) }
+    var newInterest by remember { mutableStateOf("") }
 
-  if (isSaving) {
-    LaunchedEffect(isSaving) {
-      if (profilePictureUri != null) {
-        userViewModel.updateUserProfilePicture(profilePictureUri!!) { downloadUrl ->
-          val updatedUser = user!!.copy(name = name, profilePicture = downloadUrl)
-          userViewModel.updateUser(updatedUser)
-          isSaving = false
-          navigationActions.navigateTo(Route.PROFILE)
+    // Context and permission state variables
+    val context = LocalContext.current
+    var showPermissionRationale by remember { mutableStateOf(false) }
+    var permissionToRequest by remember { mutableStateOf("") }
+    // Photo picker launcher
+    val pickPhotoLauncher =
+        rememberLauncherForActivityResult(ActivityResultContracts.GetContent()) { uri: Uri? ->
+            uri?.let { profilePictureUri = it }
         }
-      } else {
-        val updatedUser = user!!.copy(name = name)
-        userViewModel.updateUser(updatedUser)
-        isSaving = false
-        navigationActions.navigateTo(Route.PROFILE)
-      }
-    }
-  }
 
-  Scaffold(
-      bottomBar = {
-        BottomNavigationMenu(
-            onTabSelect = { route -> navigationActions.navigateTo(route) },
-            tabList = LIST_TOP_LEVEL_DESTINATION,
-            selectedItem = navigationActions.currentRoute(),
-        )
-      },
-      content = { paddingValues ->
-        Box(
-            modifier = Modifier.fillMaxSize().padding(paddingValues),
-            contentAlignment = Alignment.Center) {
-              if (isLoading) {
-                CircularProgressIndicator(modifier = Modifier.testTag("loadingIndicator"))
-              } else {
-                user?.let { userData ->
-                  Column(
-                      modifier = Modifier.fillMaxSize().padding(16.dp),
-                      verticalArrangement = Arrangement.Center,
-                      horizontalAlignment = Alignment.CenterHorizontally) {
-                        // Display the selected image or the existing profile picture
-                        if (profilePictureUri != null) {
-                          Image(
-                              painter = rememberAsyncImagePainter(model = profilePictureUri),
-                              contentDescription = "Profile Picture",
-                              modifier =
-                                  Modifier.size(128.dp).clip(CircleShape).testTag("profilePicture"))
-                        } else if (profilePictureUrl.isNotEmpty()) {
-                          Image(
-                              painter = rememberAsyncImagePainter(model = profilePictureUrl),
-                              contentDescription = "Profile Picture",
-                              modifier =
-                                  Modifier.size(128.dp).clip(CircleShape).testTag("profilePicture"))
-                        } else {
-                          Icon(
-                              imageVector = Icons.Default.AccountCircle,
-                              contentDescription = "Default Profile Picture",
-                              modifier = Modifier.size(128.dp).testTag("defaultProfilePicture"))
+    // Permission launcher
+    val permissionLauncher = rememberLauncherForActivityResult(
+        ActivityResultContracts.RequestPermission()
+    ) { isGranted ->
+        if (isGranted) {
+            pickPhotoLauncher.launch("image/*")
+        } else {
+            Toast.makeText(context, "Permission denied. Unable to select photo.", Toast.LENGTH_SHORT).show()
+        }
+    }
+
+    if (isSaving) {
+        LaunchedEffect(isSaving) {
+            if (profilePictureUri != null) {
+                userViewModel.updateUserProfilePicture(profilePictureUri!!) { downloadUrl ->
+                    val updatedUser = user!!.copy(
+                        name = name,
+                        profilePicture = downloadUrl,
+                        interests = interests
+                    )
+                    userViewModel.updateUser(updatedUser)
+                    isSaving = false
+                    navigationActions.navigateTo(Route.PROFILE)
+                }
+            } else {
+                val updatedUser = user!!.copy(
+                    name = name,
+                    interests = interests
+                )
+                userViewModel.updateUser(updatedUser)
+                isSaving = false
+                navigationActions.navigateTo(Route.PROFILE)
+            }
+        }
+    }
+
+    Scaffold(
+        bottomBar = {
+            BottomNavigationMenu(
+                onTabSelect = { route -> navigationActions.navigateTo(route) },
+                tabList = LIST_TOP_LEVEL_DESTINATION,
+                selectedItem = navigationActions.currentRoute(),
+            )
+        },
+        content = { paddingValues ->
+            Box(
+                modifier = Modifier.fillMaxSize().padding(paddingValues),
+                contentAlignment = Alignment.Center) {
+                if (isLoading) {
+                    CircularProgressIndicator(modifier = Modifier.testTag("loadingIndicator"))
+                } else {
+                    user?.let { userData ->
+                        Column(
+                            modifier = Modifier.fillMaxSize().padding(16.dp),
+                            verticalArrangement = Arrangement.Center,
+                            horizontalAlignment = Alignment.CenterHorizontally) {
+                            // Display the selected image or the existing profile picture
+                            if (profilePictureUri != null) {
+                                Image(
+                                    painter = rememberAsyncImagePainter(model = profilePictureUri),
+                                    contentDescription = "Profile Picture",
+                                    modifier =
+                                    Modifier.size(128.dp).clip(CircleShape).testTag("profilePicture"))
+                            } else if (profilePictureUrl.isNotEmpty()) {
+                                Image(
+                                    painter = rememberAsyncImagePainter(model = profilePictureUrl),
+                                    contentDescription = "Profile Picture",
+                                    modifier =
+                                    Modifier.size(128.dp).clip(CircleShape).testTag("profilePicture"))
+                            } else {
+                                Icon(
+                                    imageVector = Icons.Default.AccountCircle,
+                                    contentDescription = "Default Profile Picture",
+                                    modifier = Modifier.size(128.dp).testTag("defaultProfilePicture"))
+                            }
+
+                            Button(
+                                onClick = {
+                                    val permission = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+                                        Manifest.permission.READ_MEDIA_IMAGES
+                                    } else {
+                                        Manifest.permission.READ_EXTERNAL_STORAGE
+                                    }
+
+                                    permissionToRequest = permission
+
+                                    when {
+                                        ContextCompat.checkSelfPermission(context, permission) == PackageManager.PERMISSION_GRANTED -> {
+                                            // Permission is granted
+                                            pickPhotoLauncher.launch("image/*")
+                                        }
+                                        ActivityCompat.shouldShowRequestPermissionRationale(
+                                            context.findActivity(), permission
+                                        ) -> {
+                                            // Show rationale
+                                            showPermissionRationale = true
+                                        }
+                                        else -> {
+                                            // Request permission
+                                            permissionLauncher.launch(permission)
+                                        }
+                                    }
+                                },
+                                modifier = Modifier.testTag("editImageButton")
+                            ) {
+                                Text("Edit Profile Picture")
+                            }
+
+
+                            Spacer(modifier = Modifier.height(16.dp))
+
+                            OutlinedTextField(
+                                value = name,
+                                onValueChange = { name = it },
+                                label = { Text("Name") },
+                                modifier = Modifier.testTag("nameField"),
+                            )
+
+                            Spacer(modifier = Modifier.height(16.dp))
+
+                            OutlinedTextField(
+                                value = email,
+                                onValueChange = {},
+                                label = { Text("Email") },
+                                readOnly = true,
+                                enabled = false,
+                                modifier = Modifier.testTag("emailField"))
+
+                            Spacer(modifier = Modifier.height(16.dp))
+
+                            // Display interests
+                            Text(
+                                text = "Interests:",
+                                style = MaterialTheme.typography.titleMedium,
+                                modifier = Modifier.padding(vertical = 8.dp)
+                            )
+
+                            if (interests.isNotEmpty()) {
+                                // Display interests using FlowRow for better layout
+                                FlowRow(
+                                    modifier = Modifier
+                                        .fillMaxWidth()
+                                        .padding(horizontal = 16.dp)
+                                ) {
+                                    interests.forEach { interest ->
+                                        InterestChipEditable(
+                                            interest = interest,
+                                            onRemove = {
+                                                interests = interests.filter { it != interest }.toMutableList()
+                                            }
+                                        )
+                                    }
+                                }
+                            } else {
+                                // Display message when no interests are added
+                                Text(
+                                    text = "No interests added yet",
+                                    style = MaterialTheme.typography.bodyMedium,
+                                    modifier = Modifier.testTag("noInterests")
+                                )
+                            }
+
+                            Spacer(modifier = Modifier.height(16.dp))
+
+                            // Input field to add new interest
+                            Row(
+                                verticalAlignment = Alignment.CenterVertically
+                            ) {
+                                OutlinedTextField(
+                                    value = newInterest,
+                                    onValueChange = { newInterest = it },
+                                    label = { Text("Add Interest") },
+                                    modifier = Modifier
+                                        .weight(1f)
+                                        .testTag("newInterestField"),
+                                    keyboardOptions = KeyboardOptions(imeAction = ImeAction.Done),
+                                    keyboardActions = KeyboardActions(
+                                        onDone = {
+                                            if (newInterest.isNotBlank()) {
+                                                if (!interests.contains(newInterest.trim())) {
+                                                    interests.add(newInterest.trim())
+                                                }
+                                                newInterest = ""
+                                            }
+                                        }
+                                    )
+                                )
+                                Spacer(modifier = Modifier.width(8.dp))
+
+                                Button(
+                                    onClick = {
+                                        if (newInterest.isNotBlank()) {
+                                            if (!interests.contains(newInterest.trim())) {
+                                                interests.add(newInterest.trim())
+                                            }
+                                            newInterest = ""
+                                        }
+                                    },
+                                    modifier = Modifier.testTag("addInterestButton")
+                                ) {
+                                    Text("Add")
+                                }
+                            }
+
+                            Spacer(modifier = Modifier.height(16.dp))
+
+                            Button(
+                                onClick = { isSaving = true },
+                                modifier = Modifier.testTag("saveButton")) {
+                                Text("Save")
+                            }
+                            // Show rationale dialog if needed
+                            if (showPermissionRationale) {
+                                AlertDialog(
+                                    onDismissRequest = { showPermissionRationale = false },
+                                    title = { Text("Permission Required") },
+                                    text = {
+                                        Text("This app needs access to your photos to allow you to select a profile picture.")
+                                    },
+                                    confirmButton = {
+                                        TextButton(
+                                            onClick = {
+                                                showPermissionRationale = false
+                                                permissionLauncher.launch(permissionToRequest)
+                                            }
+                                        ) {
+                                            Text("Allow")
+                                        }
+                                    },
+                                    dismissButton = {
+                                        TextButton(
+                                            onClick = { showPermissionRationale = false }
+                                        ) {
+                                            Text("Cancel")
+                                        }
+                                    }
+                                )
+                            }
+
                         }
 
-                        Button(
-                            onClick = { pickPhotoLauncher.launch("image/*") },
-                            modifier = Modifier.testTag("editImageButton")) {
-                              Text("Edit Profile Picture")
-                            }
-
-                        Spacer(modifier = Modifier.height(16.dp))
-
-                        OutlinedTextField(
-                            value = name,
-                            onValueChange = { name = it },
-                            label = { Text("Name") },
-                            modifier = Modifier.testTag("nameField"))
-
-                        Spacer(modifier = Modifier.height(16.dp))
-
-                        OutlinedTextField(
-                            value = email,
-                            onValueChange = {},
-                            label = { Text("Email") },
-                            readOnly = true,
-                            enabled = false,
-                            modifier = Modifier.testTag("emailField"))
-
-                        Spacer(modifier = Modifier.height(16.dp))
-
-                        Button(
-                            onClick = { isSaving = true },
-                            modifier = Modifier.testTag("saveButton")) {
-                              Text("Save")
-                            }
-                      }
-                }
-                    ?: run {
-                      Column(horizontalAlignment = Alignment.CenterHorizontally) {
-                        Text(
-                            "No user data available",
-                            modifier = Modifier.testTag("noUserData").padding(16.dp))
-                      }
                     }
-              }
+                        ?: run {
+                            Column(horizontalAlignment = Alignment.CenterHorizontally) {
+                                Text(
+                                    "No user data available",
+                                    modifier = Modifier.testTag("noUserData").padding(16.dp))
+                            }
+                        }
+                }
             }
-      })
+        })
+}
+
+fun Context.findActivity(): ComponentActivity {
+    var context = this
+    while (context is ContextWrapper) {
+        if (context is ComponentActivity) {
+            return context
+        }
+        context = (context as ContextWrapper).baseContext
+    }
+    throw IllegalStateException("No Activity found")
 }

--- a/app/src/main/java/com/android/voyageur/ui/profile/ProfileScreen.kt
+++ b/app/src/main/java/com/android/voyageur/ui/profile/ProfileScreen.kt
@@ -1,7 +1,6 @@
 package com.android.voyageur.ui.profile
 
 import androidx.compose.foundation.Image
-import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -34,7 +33,6 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.unit.dp
 import coil.compose.rememberAsyncImagePainter
@@ -44,96 +42,84 @@ import com.android.voyageur.ui.navigation.BottomNavigationMenu
 import com.android.voyageur.ui.navigation.LIST_TOP_LEVEL_DESTINATION
 import com.android.voyageur.ui.navigation.NavigationActions
 import com.android.voyageur.ui.navigation.Route
-import androidx.compose.ui.graphics.Color.Companion
 import com.android.voyageur.ui.profile.interests.InterestChip
 
 @Composable
 fun ProfileScreen(userViewModel: UserViewModel, navigationActions: NavigationActions) {
-    // Observe user and loading state from UserViewModel
-    val user by userViewModel.user.collectAsState()
-    val isLoading by userViewModel.isLoading.collectAsState()
+  // Observe user and loading state from UserViewModel
+  val user by userViewModel.user.collectAsState()
+  val isLoading by userViewModel.isLoading.collectAsState()
 
-    var isSigningOut by remember { mutableStateOf(false) }
+  var isSigningOut by remember { mutableStateOf(false) }
 
-    // Navigate to AUTH if user is null and not loading
-    if (user == null && !isLoading) {
-        LaunchedEffect(Unit) { navigationActions.navigateTo(Route.AUTH) }
-        return // Exit composable to prevent further execution
+  // Navigate to AUTH if user is null and not loading
+  if (user == null && !isLoading) {
+    LaunchedEffect(Unit) { navigationActions.navigateTo(Route.AUTH) }
+    return // Exit composable to prevent further execution
+  }
+
+  // Handle sign-out
+  if (isSigningOut) {
+    LaunchedEffect(Unit) {
+      userViewModel.signOutUser()
+      navigationActions.navigateTo(Route.AUTH)
     }
+  }
 
-    // Handle sign-out
-    if (isSigningOut) {
-        LaunchedEffect(Unit) {
-            userViewModel.signOutUser()
-            navigationActions.navigateTo(Route.AUTH)
-        }
-    }
-
-    // Main Scaffold layout for ProfileScreen with Bottom Navigation
-    Scaffold(
-        modifier = Modifier.testTag("profileScreen"),
-        bottomBar = {
-            BottomNavigationMenu(
-                onTabSelect = { route -> navigationActions.navigateTo(route) },
-                tabList = LIST_TOP_LEVEL_DESTINATION,
-                selectedItem = navigationActions.currentRoute(),
-            )
-        },
-        content = { paddingValues ->
-            Box(
-                modifier =
+  // Main Scaffold layout for ProfileScreen with Bottom Navigation
+  Scaffold(
+      modifier = Modifier.testTag("profileScreen"),
+      bottomBar = {
+        BottomNavigationMenu(
+            onTabSelect = { route -> navigationActions.navigateTo(route) },
+            tabList = LIST_TOP_LEVEL_DESTINATION,
+            selectedItem = navigationActions.currentRoute(),
+        )
+      },
+      content = { paddingValues ->
+        Box(
+            modifier =
                 Modifier.fillMaxSize().padding(paddingValues).testTag("profileScreenContent"),
-                contentAlignment = Alignment.Center) {
-                when {
-                    isSigningOut -> {
-                        CircularProgressIndicator(modifier = Modifier.testTag("signingOutIndicator"))
-                    }
-                    isLoading -> {
-                        CircularProgressIndicator(modifier = Modifier.testTag("loadingIndicator"))
-                    }
-                    user != null -> {
-                        ProfileContent(
-                            userData = user!!,
-                            onSignOut = { isSigningOut = true },
-                            onEdit = { navigationActions.navigateTo(Route.EDIT_PROFILE) })
-                    }
-                    else -> {
-                        Text("No user data available", modifier = Modifier.testTag("noUserData"))
-                    }
+            contentAlignment = Alignment.Center) {
+              when {
+                isSigningOut -> {
+                  CircularProgressIndicator(modifier = Modifier.testTag("signingOutIndicator"))
                 }
+                isLoading -> {
+                  CircularProgressIndicator(modifier = Modifier.testTag("loadingIndicator"))
+                }
+                user != null -> {
+                  ProfileContent(
+                      userData = user!!,
+                      onSignOut = { isSigningOut = true },
+                      onEdit = { navigationActions.navigateTo(Route.EDIT_PROFILE) })
+                }
+                else -> {
+                  Text("No user data available", modifier = Modifier.testTag("noUserData"))
+                }
+              }
             }
-        })
+      })
 }
 
 @OptIn(ExperimentalLayoutApi::class)
 @Composable
 fun ProfileContent(userData: User, onSignOut: () -> Unit, onEdit: () -> Unit) {
-    Column(
-        modifier = Modifier
-            .fillMaxSize()
-            .padding(16.dp)
-            .testTag("profileContent"),
-        verticalArrangement = Arrangement.Center,
-        horizontalAlignment = Alignment.CenterHorizontally
-    ) {
+  Column(
+      modifier = Modifier.fillMaxSize().padding(16.dp).testTag("profileContent"),
+      verticalArrangement = Arrangement.Center,
+      horizontalAlignment = Alignment.CenterHorizontally) {
         // Display the profile picture if available
         if (userData.profilePicture.isNotEmpty()) {
-            Image(
-                painter = rememberAsyncImagePainter(model = userData.profilePicture),
-                contentDescription = "Profile Picture",
-                modifier = Modifier
-                    .size(128.dp)
-                    .clip(CircleShape)
-                    .testTag("profilePicture")
-            )
+          Image(
+              painter = rememberAsyncImagePainter(model = userData.profilePicture),
+              contentDescription = "Profile Picture",
+              modifier = Modifier.size(128.dp).clip(CircleShape).testTag("profilePicture"))
         } else {
-            Icon(
-                imageVector = Icons.Default.AccountCircle,
-                contentDescription = "Default Profile Picture",
-                modifier = Modifier
-                    .size(128.dp)
-                    .testTag("defaultProfilePicture")
-            )
+          Icon(
+              imageVector = Icons.Default.AccountCircle,
+              contentDescription = "Default Profile Picture",
+              modifier = Modifier.size(128.dp).testTag("defaultProfilePicture"))
         }
 
         Spacer(modifier = Modifier.height(16.dp))
@@ -142,13 +128,11 @@ fun ProfileContent(userData: User, onSignOut: () -> Unit, onEdit: () -> Unit) {
         Text(
             text = userData.name.takeIf { it.isNotEmpty() } ?: "No name available",
             style = MaterialTheme.typography.titleLarge,
-            modifier = Modifier.testTag("userName")
-        )
+            modifier = Modifier.testTag("userName"))
         Text(
             text = userData.email.takeIf { it.isNotEmpty() } ?: "No email available",
             style = MaterialTheme.typography.bodyMedium,
-            modifier = Modifier.testTag("userEmail")
-        )
+            modifier = Modifier.testTag("userEmail"))
 
         Spacer(modifier = Modifier.height(16.dp))
 
@@ -156,45 +140,37 @@ fun ProfileContent(userData: User, onSignOut: () -> Unit, onEdit: () -> Unit) {
         Text(
             text = "Interests:",
             style = MaterialTheme.typography.titleMedium,
-            modifier = Modifier.padding(vertical = 8.dp)
-        )
+            modifier = Modifier.padding(vertical = 8.dp))
 
         if (userData.interests.isNotEmpty()) {
-            // Display interests using FlowRow for better layout
-            FlowRow(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .padding(horizontal = 16.dp)
-                    .testTag("interestsFlowRow") ,
-                horizontalArrangement = Arrangement.Center
-            ) {
+          // Display interests using FlowRow for better layout
+          FlowRow(
+              modifier =
+                  Modifier.fillMaxWidth().padding(horizontal = 16.dp).testTag("interestsFlowRow"),
+              horizontalArrangement = Arrangement.Center) {
                 userData.interests.forEach { interest ->
-                    InterestChip(
-                        interest = interest,
-                        modifier = Modifier.padding(4.dp)
-                    )
+                  InterestChip(interest = interest, modifier = Modifier.padding(4.dp))
                 }
-            }
+              }
         } else {
-            // Display message when no interests are added
-            Text(
-                text = "No interests added yet",
-                style = MaterialTheme.typography.bodyMedium,
-                modifier = Modifier.testTag("noInterests")
-            )
+          // Display message when no interests are added
+          Text(
+              text = "No interests added yet",
+              style = MaterialTheme.typography.bodyMedium,
+              modifier = Modifier.testTag("noInterests"))
         }
 
         Spacer(modifier = Modifier.height(16.dp))
 
         // Edit and Sign out buttons
         Row {
-            Button(onClick = onEdit, modifier = Modifier.testTag("editButton")) {
-                Text(text = "Edit")
-            }
-            Spacer(modifier = Modifier.width(16.dp))
-            Button(onClick = onSignOut, modifier = Modifier.testTag("signOutButton")) {
-                Text(text = "Sign Out")
-            }
+          Button(onClick = onEdit, modifier = Modifier.testTag("editButton")) {
+            Text(text = "Edit")
+          }
+          Spacer(modifier = Modifier.width(16.dp))
+          Button(onClick = onSignOut, modifier = Modifier.testTag("signOutButton")) {
+            Text(text = "Sign Out")
+          }
         }
-    }
+      }
 }

--- a/app/src/main/java/com/android/voyageur/ui/profile/ProfileScreen.kt
+++ b/app/src/main/java/com/android/voyageur/ui/profile/ProfileScreen.kt
@@ -1,12 +1,16 @@
 package com.android.voyageur.ui.profile
 
 import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ExperimentalLayoutApi
+import androidx.compose.foundation.layout.FlowRow
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
@@ -30,6 +34,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.unit.dp
 import coil.compose.rememberAsyncImagePainter
@@ -39,107 +44,157 @@ import com.android.voyageur.ui.navigation.BottomNavigationMenu
 import com.android.voyageur.ui.navigation.LIST_TOP_LEVEL_DESTINATION
 import com.android.voyageur.ui.navigation.NavigationActions
 import com.android.voyageur.ui.navigation.Route
+import androidx.compose.ui.graphics.Color.Companion
+import com.android.voyageur.ui.profile.interests.InterestChip
 
 @Composable
 fun ProfileScreen(userViewModel: UserViewModel, navigationActions: NavigationActions) {
-  // Observe user and loading state from UserViewModel
-  val user by userViewModel.user.collectAsState()
-  val isLoading by userViewModel.isLoading.collectAsState()
+    // Observe user and loading state from UserViewModel
+    val user by userViewModel.user.collectAsState()
+    val isLoading by userViewModel.isLoading.collectAsState()
 
-  var isSigningOut by remember { mutableStateOf(false) }
+    var isSigningOut by remember { mutableStateOf(false) }
 
-  // Navigate to AUTH if user is null and not loading
-  if (user == null && !isLoading) {
-    LaunchedEffect(Unit) { navigationActions.navigateTo(Route.AUTH) }
-    return // Exit composable to prevent further execution
-  }
-
-  // Handle sign-out
-  if (isSigningOut) {
-    LaunchedEffect(Unit) {
-      userViewModel.signOutUser()
-      navigationActions.navigateTo(Route.AUTH)
+    // Navigate to AUTH if user is null and not loading
+    if (user == null && !isLoading) {
+        LaunchedEffect(Unit) { navigationActions.navigateTo(Route.AUTH) }
+        return // Exit composable to prevent further execution
     }
-  }
 
-  // Main Scaffold layout for ProfileScreen with Bottom Navigation
-  Scaffold(
-      modifier = Modifier.testTag("profileScreen"),
-      bottomBar = {
-        BottomNavigationMenu(
-            onTabSelect = { route -> navigationActions.navigateTo(route) },
-            tabList = LIST_TOP_LEVEL_DESTINATION,
-            selectedItem = navigationActions.currentRoute(),
-        )
-      },
-      content = { paddingValues ->
-        Box(
-            modifier =
+    // Handle sign-out
+    if (isSigningOut) {
+        LaunchedEffect(Unit) {
+            userViewModel.signOutUser()
+            navigationActions.navigateTo(Route.AUTH)
+        }
+    }
+
+    // Main Scaffold layout for ProfileScreen with Bottom Navigation
+    Scaffold(
+        modifier = Modifier.testTag("profileScreen"),
+        bottomBar = {
+            BottomNavigationMenu(
+                onTabSelect = { route -> navigationActions.navigateTo(route) },
+                tabList = LIST_TOP_LEVEL_DESTINATION,
+                selectedItem = navigationActions.currentRoute(),
+            )
+        },
+        content = { paddingValues ->
+            Box(
+                modifier =
                 Modifier.fillMaxSize().padding(paddingValues).testTag("profileScreenContent"),
-            contentAlignment = Alignment.Center) {
-              when {
-                isSigningOut -> {
-                  CircularProgressIndicator(modifier = Modifier.testTag("signingOutIndicator"))
+                contentAlignment = Alignment.Center) {
+                when {
+                    isSigningOut -> {
+                        CircularProgressIndicator(modifier = Modifier.testTag("signingOutIndicator"))
+                    }
+                    isLoading -> {
+                        CircularProgressIndicator(modifier = Modifier.testTag("loadingIndicator"))
+                    }
+                    user != null -> {
+                        ProfileContent(
+                            userData = user!!,
+                            onSignOut = { isSigningOut = true },
+                            onEdit = { navigationActions.navigateTo(Route.EDIT_PROFILE) })
+                    }
+                    else -> {
+                        Text("No user data available", modifier = Modifier.testTag("noUserData"))
+                    }
                 }
-                isLoading -> {
-                  CircularProgressIndicator(modifier = Modifier.testTag("loadingIndicator"))
-                }
-                user != null -> {
-                  ProfileContent(
-                      userData = user!!,
-                      onSignOut = { isSigningOut = true },
-                      onEdit = { navigationActions.navigateTo(Route.EDIT_PROFILE) })
-                }
-                else -> {
-                  Text("No user data available", modifier = Modifier.testTag("noUserData"))
-                }
-              }
             }
-      })
+        })
 }
 
+@OptIn(ExperimentalLayoutApi::class)
 @Composable
 fun ProfileContent(userData: User, onSignOut: () -> Unit, onEdit: () -> Unit) {
-  Column(
-      modifier = Modifier.fillMaxSize().padding(16.dp).testTag("profileContent"),
-      verticalArrangement = Arrangement.Center,
-      horizontalAlignment = Alignment.CenterHorizontally) {
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(16.dp)
+            .testTag("profileContent"),
+        verticalArrangement = Arrangement.Center,
+        horizontalAlignment = Alignment.CenterHorizontally
+    ) {
         // Display the profile picture if available
         if (userData.profilePicture.isNotEmpty()) {
-          Image(
-              painter = rememberAsyncImagePainter(model = userData.profilePicture),
-              contentDescription = "Profile Picture",
-              modifier = Modifier.size(128.dp).clip(CircleShape).testTag("profilePicture"))
+            Image(
+                painter = rememberAsyncImagePainter(model = userData.profilePicture),
+                contentDescription = "Profile Picture",
+                modifier = Modifier
+                    .size(128.dp)
+                    .clip(CircleShape)
+                    .testTag("profilePicture")
+            )
         } else {
-          Icon(
-              imageVector = Icons.Default.AccountCircle,
-              contentDescription = "Default Profile Picture",
-              modifier = Modifier.size(128.dp).testTag("defaultProfilePicture"))
+            Icon(
+                imageVector = Icons.Default.AccountCircle,
+                contentDescription = "Default Profile Picture",
+                modifier = Modifier
+                    .size(128.dp)
+                    .testTag("defaultProfilePicture")
+            )
         }
 
         Spacer(modifier = Modifier.height(16.dp))
 
         // Display user name and email
         Text(
-            text = "Name: ${userData.name.takeIf { it.isNotEmpty() } ?: "No name available"}",
+            text = userData.name.takeIf { it.isNotEmpty() } ?: "No name available",
             style = MaterialTheme.typography.titleLarge,
-            modifier = Modifier.testTag("userName"))
+            modifier = Modifier.testTag("userName")
+        )
         Text(
-            text = "Email: ${userData.email.takeIf { it.isNotEmpty() } ?: "No email available"}",
+            text = userData.email.takeIf { it.isNotEmpty() } ?: "No email available",
             style = MaterialTheme.typography.bodyMedium,
-            modifier = Modifier.testTag("userEmail"))
+            modifier = Modifier.testTag("userEmail")
+        )
+
+        Spacer(modifier = Modifier.height(16.dp))
+
+        // Display interests
+        Text(
+            text = "Interests:",
+            style = MaterialTheme.typography.titleMedium,
+            modifier = Modifier.padding(vertical = 8.dp)
+        )
+
+        if (userData.interests.isNotEmpty()) {
+            // Display interests using FlowRow for better layout
+            FlowRow(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 16.dp)
+                    .testTag("interestsFlowRow") ,
+                horizontalArrangement = Arrangement.Center
+            ) {
+                userData.interests.forEach { interest ->
+                    InterestChip(
+                        interest = interest,
+                        modifier = Modifier.padding(4.dp)
+                    )
+                }
+            }
+        } else {
+            // Display message when no interests are added
+            Text(
+                text = "No interests added yet",
+                style = MaterialTheme.typography.bodyMedium,
+                modifier = Modifier.testTag("noInterests")
+            )
+        }
 
         Spacer(modifier = Modifier.height(16.dp))
 
         // Edit and Sign out buttons
         Row {
-          Button(onClick = onEdit, modifier = Modifier.testTag("editButton")) {
-            Text(text = "Edit")
-          }
-          Spacer(modifier = Modifier.width(16.dp))
-          Button(onClick = onSignOut, modifier = Modifier.testTag("signOutButton")) {
-            Text(text = "Sign Out")
-          }
+            Button(onClick = onEdit, modifier = Modifier.testTag("editButton")) {
+                Text(text = "Edit")
+            }
+            Spacer(modifier = Modifier.width(16.dp))
+            Button(onClick = onSignOut, modifier = Modifier.testTag("signOutButton")) {
+                Text(text = "Sign Out")
+            }
         }
-      }
+    }
 }

--- a/app/src/main/java/com/android/voyageur/ui/profile/interests/InterestChip.kt
+++ b/app/src/main/java/com/android/voyageur/ui/profile/interests/InterestChip.kt
@@ -12,15 +12,15 @@ import androidx.compose.ui.unit.dp
 
 @Composable
 fun InterestChip(interest: String, modifier: Modifier = Modifier) {
-    Text(
-        text = interest,
-        style = MaterialTheme.typography.bodySmall.copy(
-            color = MaterialTheme.colorScheme.onPrimaryContainer
-        ),
-        modifier = modifier
-            .clip(MaterialTheme.shapes.small)
-            .background(MaterialTheme.colorScheme.primaryContainer)
-            .padding(horizontal = 12.dp, vertical = 6.dp)
-            .testTag("interest_$interest")
-    )
+  Text(
+      text = interest,
+      style =
+          MaterialTheme.typography.bodySmall.copy(
+              color = MaterialTheme.colorScheme.onPrimaryContainer),
+      modifier =
+          modifier
+              .clip(MaterialTheme.shapes.small)
+              .background(MaterialTheme.colorScheme.primaryContainer)
+              .padding(horizontal = 12.dp, vertical = 6.dp)
+              .testTag("interest_$interest"))
 }

--- a/app/src/main/java/com/android/voyageur/ui/profile/interests/InterestChip.kt
+++ b/app/src/main/java/com/android/voyageur/ui/profile/interests/InterestChip.kt
@@ -1,0 +1,26 @@
+package com.android.voyageur.ui.profile.interests
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.unit.dp
+
+@Composable
+fun InterestChip(interest: String, modifier: Modifier = Modifier) {
+    Text(
+        text = interest,
+        style = MaterialTheme.typography.bodySmall.copy(
+            color = MaterialTheme.colorScheme.onPrimaryContainer
+        ),
+        modifier = modifier
+            .clip(MaterialTheme.shapes.small)
+            .background(MaterialTheme.colorScheme.primaryContainer)
+            .padding(horizontal = 12.dp, vertical = 6.dp)
+            .testTag("interest_$interest")
+    )
+}

--- a/app/src/main/java/com/android/voyageur/ui/profile/interests/InterestChipEditable.kt
+++ b/app/src/main/java/com/android/voyageur/ui/profile/interests/InterestChipEditable.kt
@@ -5,8 +5,8 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Clear
 import androidx.compose.material3.AlertDialog
@@ -28,64 +28,49 @@ import androidx.compose.ui.unit.dp
 
 @Composable
 fun InterestChipEditable(interest: String, onRemove: () -> Unit) {
-    var showDialog by remember { mutableStateOf(false) }
+  var showDialog by remember { mutableStateOf(false) }
 
-    // Chip UI
-    Box(
-        modifier = Modifier
-            .padding(4.dp)
-            .clip(MaterialTheme.shapes.small)
-            .background(MaterialTheme.colorScheme.primaryContainer)
-    ) {
+  // Chip UI
+  Box(
+      modifier =
+          Modifier.padding(4.dp)
+              .clip(MaterialTheme.shapes.small)
+              .background(MaterialTheme.colorScheme.primaryContainer)) {
         Row(
             verticalAlignment = Alignment.CenterVertically,
-            modifier = Modifier.padding(horizontal = 12.dp, vertical = 6.dp)
-        ) {
-            Text(
-                text = interest,
-                style = MaterialTheme.typography.bodySmall.copy(
-                    color = MaterialTheme.colorScheme.onPrimaryContainer
-                )
-            )
-            Spacer(modifier = Modifier.width(8.dp))
-            IconButton(
-                onClick = {
-                    showDialog = true
-                },
-                modifier = Modifier
-                    .size(16.dp)
-                    .testTag("removeInterestButton_$interest")
-            ) {
-                Icon(
-                    imageVector = Icons.Default.Clear,
-                    contentDescription = "Remove Interest",
-                    tint = MaterialTheme.colorScheme.error
-                )
+            modifier = Modifier.padding(horizontal = 12.dp, vertical = 6.dp)) {
+              Text(
+                  text = interest,
+                  style =
+                      MaterialTheme.typography.bodySmall.copy(
+                          color = MaterialTheme.colorScheme.onPrimaryContainer))
+              Spacer(modifier = Modifier.width(8.dp))
+              IconButton(
+                  onClick = { showDialog = true },
+                  modifier = Modifier.size(16.dp).testTag("removeInterestButton_$interest")) {
+                    Icon(
+                        imageVector = Icons.Default.Clear,
+                        contentDescription = "Remove Interest",
+                        tint = MaterialTheme.colorScheme.error)
+                  }
             }
-        }
-    }
+      }
 
-    // Confirmation Dialog
-    if (showDialog) {
-        AlertDialog(
-            onDismissRequest = { showDialog = false },
-            title = { Text(text = "Remove Interest") },
-            text = { Text("Are you sure you want to remove \"$interest\" from your interests?") },
-            confirmButton = {
-                TextButton(
-                    onClick = {
-                        onRemove()
-                        showDialog = false
-                    }
-                ) {
-                    Text("Remove")
-                }
-            },
-            dismissButton = {
-                TextButton(onClick = { showDialog = false }) {
-                    Text("Cancel")
-                }
-            }
-        )
-    }
+  // Confirmation Dialog
+  if (showDialog) {
+    AlertDialog(
+        onDismissRequest = { showDialog = false },
+        title = { Text(text = "Remove Interest") },
+        text = { Text("Are you sure you want to remove \"$interest\" from your interests?") },
+        confirmButton = {
+          TextButton(
+              onClick = {
+                onRemove()
+                showDialog = false
+              }) {
+                Text("Remove")
+              }
+        },
+        dismissButton = { TextButton(onClick = { showDialog = false }) { Text("Cancel") } })
+  }
 }

--- a/app/src/main/java/com/android/voyageur/ui/profile/interests/InterestChipEditable.kt
+++ b/app/src/main/java/com/android/voyageur/ui/profile/interests/InterestChipEditable.kt
@@ -1,0 +1,91 @@
+package com.android.voyageur.ui.profile.interests
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.size
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Clear
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.unit.dp
+
+@Composable
+fun InterestChipEditable(interest: String, onRemove: () -> Unit) {
+    var showDialog by remember { mutableStateOf(false) }
+
+    // Chip UI
+    Box(
+        modifier = Modifier
+            .padding(4.dp)
+            .clip(MaterialTheme.shapes.small)
+            .background(MaterialTheme.colorScheme.primaryContainer)
+    ) {
+        Row(
+            verticalAlignment = Alignment.CenterVertically,
+            modifier = Modifier.padding(horizontal = 12.dp, vertical = 6.dp)
+        ) {
+            Text(
+                text = interest,
+                style = MaterialTheme.typography.bodySmall.copy(
+                    color = MaterialTheme.colorScheme.onPrimaryContainer
+                )
+            )
+            Spacer(modifier = Modifier.width(8.dp))
+            IconButton(
+                onClick = {
+                    showDialog = true
+                },
+                modifier = Modifier
+                    .size(16.dp)
+                    .testTag("removeInterestButton_$interest")
+            ) {
+                Icon(
+                    imageVector = Icons.Default.Clear,
+                    contentDescription = "Remove Interest",
+                    tint = MaterialTheme.colorScheme.error
+                )
+            }
+        }
+    }
+
+    // Confirmation Dialog
+    if (showDialog) {
+        AlertDialog(
+            onDismissRequest = { showDialog = false },
+            title = { Text(text = "Remove Interest") },
+            text = { Text("Are you sure you want to remove \"$interest\" from your interests?") },
+            confirmButton = {
+                TextButton(
+                    onClick = {
+                        onRemove()
+                        showDialog = false
+                    }
+                ) {
+                    Text("Remove")
+                }
+            },
+            dismissButton = {
+                TextButton(onClick = { showDialog = false }) {
+                    Text("Cancel")
+                }
+            }
+        )
+    }
+}

--- a/app/src/test/java/com/android/voyageur/model/user/UserTest.kt
+++ b/app/src/test/java/com/android/voyageur/model/user/UserTest.kt
@@ -6,92 +6,124 @@ import org.junit.Test
 
 class UserTest {
 
-  private lateinit var user: User
-  private lateinit var friend: User
-  private lateinit var trip: Trip
+    private lateinit var user: User
+    private lateinit var trip: Trip
 
-  @Before
-  fun setUp() {
-    user = User(id = "user1", name = "John Doe", email = "john.doe@example.com")
-    friend = User(id = "friend1", name = "Jane Doe", email = "jane.doe@example.com")
-    trip = Trip(id = "trip1", name = "Paris Trip", description = "A trip to Paris")
-  }
+    @Before
+    fun setUp() {
+        user = User(id = "user1", name = "John Doe", email = "john.doe@example.com")
+        trip = Trip(id = "trip1", name = "Paris Trip", description = "A trip to Paris")
+    }
 
-  @Test
-  fun testEquals_sameProperties_shouldReturnTrue() {
-    val user1 =
-        User(
+    @Test
+    fun testEquals_sameProperties_shouldReturnTrue() {
+        val user1 = User(
             id = "1",
             name = "Test User",
             email = "test@example.com",
             profilePicture = "picture.jpg",
             bio = "Bio",
             contacts = listOf("2", "3"),
-            username = "testuser")
+            interests = listOf("Hiking", "Reading"),
+            username = "testuser"
+        )
 
-    val user2 =
-        User(
+        val user2 = User(
             id = "1",
             name = "Test User",
             email = "test@example.com",
             profilePicture = "picture.jpg",
             bio = "Bio",
             contacts = listOf("2", "3"),
-            username = "testuser")
+            interests = listOf("Hiking", "Reading"),
+            username = "testuser"
+        )
 
-    assertEquals(user1, user2)
-    assertEquals(user1.hashCode(), user2.hashCode())
-  }
+        assertEquals(user1, user2)
+        assertEquals(user1.hashCode(), user2.hashCode())
+    }
 
-  @Test
-  fun testEquals_differentProperties_shouldReturnFalse() {
-    val user1 =
-        User(
+    @Test
+    fun testEquals_differentProperties_shouldReturnFalse() {
+        val user1 = User(
             id = "1",
             name = "Test User",
             email = "test@example.com",
             profilePicture = "picture.jpg",
             bio = "Bio",
             contacts = listOf("2", "3"),
-            username = "testuser")
+            interests = listOf("Hiking", "Reading"),
+            username = "testuser"
+        )
 
-    val user2 =
-        User(
+        val user2 = User(
             id = "2",
             name = "Another User",
             email = "another@example.com",
             profilePicture = "another.jpg",
             bio = "Another Bio",
             contacts = listOf("3", "4"),
-            username = "anotheruser")
+            interests = listOf("Swimming", "Cooking"),
+            username = "anotheruser"
+        )
 
-    assertNotEquals(user1, user2)
-    assertNotEquals(user1.hashCode(), user2.hashCode())
-  }
+        assertNotEquals(user1, user2)
+        assertNotEquals(user1.hashCode(), user2.hashCode())
+    }
 
-  @Test
-  fun testEquals_differentContactsOrder_shouldReturnTrue() {
-    val user1 =
-        User(
+    @Test
+    fun testEquals_sameInterestsDifferentOrder_shouldReturnTrue() {
+        val user1 =
+            User(
+                id = "1",
+                name = "Test User",
+                email = "test@example.com",
+                profilePicture = "picture.jpg",
+                bio = "Bio",
+                contacts = listOf("2", "3"),
+                interests = listOf("Hiking", "Reading"),
+                username = "testuser")
+
+        val user2 =
+            User(
+                id = "1",
+                name = "Test User",
+                email = "test@example.com",
+                profilePicture = "picture.jpg",
+                bio = "Bio",
+                contacts = listOf("3", "2"), // Different order of contacts
+                interests = listOf("Reading", "Hiking"),
+                username = "testuser")
+
+        assertEquals(user1, user2)
+        assertEquals(user1.hashCode(), user2.hashCode())
+    }
+
+    @Test
+    fun testEquals_differentInterests_shouldReturnFalse() {
+        val user1 = User(
             id = "1",
             name = "Test User",
             email = "test@example.com",
             profilePicture = "picture.jpg",
             bio = "Bio",
             contacts = listOf("2", "3"),
-            username = "testuser")
+            interests = listOf("Hiking", "Reading"),
+            username = "testuser"
+        )
 
-    val user2 =
-        User(
+        val user2 = User(
             id = "1",
             name = "Test User",
             email = "test@example.com",
             profilePicture = "picture.jpg",
             bio = "Bio",
-            contacts = listOf("3", "2"), // Different order of contacts
-            username = "testuser")
+            contacts = listOf("2", "3"),
+            interests = listOf("Swimming", "Reading"), // Different interests
+            username = "testuser"
+        )
 
-    assertEquals(user1, user2)
-    assertNotEquals(user1.hashCode(), user2.hashCode())
-  }
+        assertNotEquals(user1, user2)
+        assertNotEquals(user1.hashCode(), user2.hashCode())
+    }
 }

--- a/app/src/test/java/com/android/voyageur/model/user/UserTest.kt
+++ b/app/src/test/java/com/android/voyageur/model/user/UserTest.kt
@@ -6,18 +6,19 @@ import org.junit.Test
 
 class UserTest {
 
-    private lateinit var user: User
-    private lateinit var trip: Trip
+  private lateinit var user: User
+  private lateinit var trip: Trip
 
-    @Before
-    fun setUp() {
-        user = User(id = "user1", name = "John Doe", email = "john.doe@example.com")
-        trip = Trip(id = "trip1", name = "Paris Trip", description = "A trip to Paris")
-    }
+  @Before
+  fun setUp() {
+    user = User(id = "user1", name = "John Doe", email = "john.doe@example.com")
+    trip = Trip(id = "trip1", name = "Paris Trip", description = "A trip to Paris")
+  }
 
-    @Test
-    fun testEquals_sameProperties_shouldReturnTrue() {
-        val user1 = User(
+  @Test
+  fun testEquals_sameProperties_shouldReturnTrue() {
+    val user1 =
+        User(
             id = "1",
             name = "Test User",
             email = "test@example.com",
@@ -25,10 +26,10 @@ class UserTest {
             bio = "Bio",
             contacts = listOf("2", "3"),
             interests = listOf("Hiking", "Reading"),
-            username = "testuser"
-        )
+            username = "testuser")
 
-        val user2 = User(
+    val user2 =
+        User(
             id = "1",
             name = "Test User",
             email = "test@example.com",
@@ -36,16 +37,16 @@ class UserTest {
             bio = "Bio",
             contacts = listOf("2", "3"),
             interests = listOf("Hiking", "Reading"),
-            username = "testuser"
-        )
+            username = "testuser")
 
-        assertEquals(user1, user2)
-        assertEquals(user1.hashCode(), user2.hashCode())
-    }
+    assertEquals(user1, user2)
+    assertEquals(user1.hashCode(), user2.hashCode())
+  }
 
-    @Test
-    fun testEquals_differentProperties_shouldReturnFalse() {
-        val user1 = User(
+  @Test
+  fun testEquals_differentProperties_shouldReturnFalse() {
+    val user1 =
+        User(
             id = "1",
             name = "Test User",
             email = "test@example.com",
@@ -53,10 +54,10 @@ class UserTest {
             bio = "Bio",
             contacts = listOf("2", "3"),
             interests = listOf("Hiking", "Reading"),
-            username = "testuser"
-        )
+            username = "testuser")
 
-        val user2 = User(
+    val user2 =
+        User(
             id = "2",
             name = "Another User",
             email = "another@example.com",
@@ -64,44 +65,16 @@ class UserTest {
             bio = "Another Bio",
             contacts = listOf("3", "4"),
             interests = listOf("Swimming", "Cooking"),
-            username = "anotheruser"
-        )
+            username = "anotheruser")
 
-        assertNotEquals(user1, user2)
-        assertNotEquals(user1.hashCode(), user2.hashCode())
-    }
+    assertNotEquals(user1, user2)
+    assertNotEquals(user1.hashCode(), user2.hashCode())
+  }
 
-    @Test
-    fun testEquals_sameInterestsDifferentOrder_shouldReturnTrue() {
-        val user1 =
-            User(
-                id = "1",
-                name = "Test User",
-                email = "test@example.com",
-                profilePicture = "picture.jpg",
-                bio = "Bio",
-                contacts = listOf("2", "3"),
-                interests = listOf("Hiking", "Reading"),
-                username = "testuser")
-
-        val user2 =
-            User(
-                id = "1",
-                name = "Test User",
-                email = "test@example.com",
-                profilePicture = "picture.jpg",
-                bio = "Bio",
-                contacts = listOf("3", "2"), // Different order of contacts
-                interests = listOf("Reading", "Hiking"),
-                username = "testuser")
-
-        assertEquals(user1, user2)
-        assertEquals(user1.hashCode(), user2.hashCode())
-    }
-
-    @Test
-    fun testEquals_differentInterests_shouldReturnFalse() {
-        val user1 = User(
+  @Test
+  fun testEquals_sameInterestsDifferentOrder_shouldReturnTrue() {
+    val user1 =
+        User(
             id = "1",
             name = "Test User",
             email = "test@example.com",
@@ -109,10 +82,38 @@ class UserTest {
             bio = "Bio",
             contacts = listOf("2", "3"),
             interests = listOf("Hiking", "Reading"),
-            username = "testuser"
-        )
+            username = "testuser")
 
-        val user2 = User(
+    val user2 =
+        User(
+            id = "1",
+            name = "Test User",
+            email = "test@example.com",
+            profilePicture = "picture.jpg",
+            bio = "Bio",
+            contacts = listOf("3", "2"), // Different order of contacts
+            interests = listOf("Reading", "Hiking"),
+            username = "testuser")
+
+    assertEquals(user1, user2)
+    assertEquals(user1.hashCode(), user2.hashCode())
+  }
+
+  @Test
+  fun testEquals_differentInterests_shouldReturnFalse() {
+    val user1 =
+        User(
+            id = "1",
+            name = "Test User",
+            email = "test@example.com",
+            profilePicture = "picture.jpg",
+            bio = "Bio",
+            contacts = listOf("2", "3"),
+            interests = listOf("Hiking", "Reading"),
+            username = "testuser")
+
+    val user2 =
+        User(
             id = "1",
             name = "Test User",
             email = "test@example.com",
@@ -120,10 +121,9 @@ class UserTest {
             bio = "Bio",
             contacts = listOf("2", "3"),
             interests = listOf("Swimming", "Reading"), // Different interests
-            username = "testuser"
-        )
+            username = "testuser")
 
-        assertNotEquals(user1, user2)
-        assertNotEquals(user1.hashCode(), user2.hashCode())
-    }
+    assertNotEquals(user1, user2)
+    assertNotEquals(user1.hashCode(), user2.hashCode())
+  }
 }

--- a/app/src/test/java/com/android/voyageur/model/user/UserViewModelTest.kt
+++ b/app/src/test/java/com/android/voyageur/model/user/UserViewModelTest.kt
@@ -31,7 +31,7 @@ class UserViewModelTest {
   private lateinit var userViewModel: UserViewModel
   private val testDispatcher = UnconfinedTestDispatcher()
 
-  private val user = User("1", "name", "email", "", "bio", listOf(), "username")
+    private val user = User("1", "name", "email", "", "bio", listOf(), emptyList(), "username")
 
   @Before
   fun setUp() {

--- a/app/src/test/java/com/android/voyageur/model/user/UserViewModelTest.kt
+++ b/app/src/test/java/com/android/voyageur/model/user/UserViewModelTest.kt
@@ -31,7 +31,7 @@ class UserViewModelTest {
   private lateinit var userViewModel: UserViewModel
   private val testDispatcher = UnconfinedTestDispatcher()
 
-    private val user = User("1", "name", "email", "", "bio", listOf(), emptyList(), "username")
+  private val user = User("1", "name", "email", "", "bio", listOf(), emptyList(), "username")
 
   @Before
   fun setUp() {

--- a/app/src/test/java/com/android/voyageur/ui/profile/FindActivityTest.kt
+++ b/app/src/test/java/com/android/voyageur/ui/profile/FindActivityTest.kt
@@ -3,57 +3,55 @@ package com.android.voyageur.ui.profile
 import android.content.ContextWrapper
 import androidx.activity.ComponentActivity
 import org.junit.Assert.assertEquals
-import org.junit.Assert.assertThrows
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.Robolectric
 import org.robolectric.RobolectricTestRunner
-import org.robolectric.annotation.Config
 
 @RunWith(RobolectricTestRunner::class)
 class FindActivityTest {
 
-    @Test
-    fun contextIsComponentActivity_returnsActivity() {
-        // Arrange: Create a ComponentActivity using Robolectric
-        val activity = Robolectric.buildActivity(ComponentActivity::class.java).setup().get()
+  @Test
+  fun contextIsComponentActivity_returnsActivity() {
+    // Arrange: Create a ComponentActivity using Robolectric
+    val activity = Robolectric.buildActivity(ComponentActivity::class.java).setup().get()
 
-        // Act: Call findActivity on the activity itself
-        val result = activity.findActivity()
+    // Act: Call findActivity on the activity itself
+    val result = activity.findActivity()
 
-        // Assert: The result should be the same activity
-        assertEquals(activity, result)
-    }
+    // Assert: The result should be the same activity
+    assertEquals(activity, result)
+  }
 
-    @Test
-    fun contextIsWrappedComponentActivity_returnsActivity() {
-        // Arrange: Create a ComponentActivity using Robolectric
-        val activity = Robolectric.buildActivity(ComponentActivity::class.java).setup().get()
+  @Test
+  fun contextIsWrappedComponentActivity_returnsActivity() {
+    // Arrange: Create a ComponentActivity using Robolectric
+    val activity = Robolectric.buildActivity(ComponentActivity::class.java).setup().get()
 
-        // Wrap the activity in a ContextWrapper
-        val contextWrapper = ContextWrapper(activity)
+    // Wrap the activity in a ContextWrapper
+    val contextWrapper = ContextWrapper(activity)
 
-        // Act: Call findActivity on the wrapped context
-        val result = contextWrapper.findActivity()
+    // Act: Call findActivity on the wrapped context
+    val result = contextWrapper.findActivity()
 
-        // Assert: The result should be the original activity
-        assertEquals(activity, result)
-    }
+    // Assert: The result should be the original activity
+    assertEquals(activity, result)
+  }
 
-    @Test
-    fun contextIsDeeplyWrappedComponentActivity_returnsActivity() {
-        // Arrange: Create a ComponentActivity using Robolectric
-        val activity = Robolectric.buildActivity(ComponentActivity::class.java).setup().get()
+  @Test
+  fun contextIsDeeplyWrappedComponentActivity_returnsActivity() {
+    // Arrange: Create a ComponentActivity using Robolectric
+    val activity = Robolectric.buildActivity(ComponentActivity::class.java).setup().get()
 
-        // Wrap the activity multiple times
-        val contextWrapperLevel1 = ContextWrapper(activity)
-        val contextWrapperLevel2 = ContextWrapper(contextWrapperLevel1)
-        val contextWrapperLevel3 = ContextWrapper(contextWrapperLevel2)
+    // Wrap the activity multiple times
+    val contextWrapperLevel1 = ContextWrapper(activity)
+    val contextWrapperLevel2 = ContextWrapper(contextWrapperLevel1)
+    val contextWrapperLevel3 = ContextWrapper(contextWrapperLevel2)
 
-        // Act: Call findActivity on the deeply wrapped context
-        val result = contextWrapperLevel3.findActivity()
+    // Act: Call findActivity on the deeply wrapped context
+    val result = contextWrapperLevel3.findActivity()
 
-        // Assert: The result should be the original activity
-        assertEquals(activity, result)
-    }
+    // Assert: The result should be the original activity
+    assertEquals(activity, result)
+  }
 }

--- a/app/src/test/java/com/android/voyageur/ui/profile/FindActivityTest.kt
+++ b/app/src/test/java/com/android/voyageur/ui/profile/FindActivityTest.kt
@@ -1,0 +1,59 @@
+package com.android.voyageur.ui.profile
+
+import android.content.ContextWrapper
+import androidx.activity.ComponentActivity
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertThrows
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.Robolectric
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+@RunWith(RobolectricTestRunner::class)
+class FindActivityTest {
+
+    @Test
+    fun contextIsComponentActivity_returnsActivity() {
+        // Arrange: Create a ComponentActivity using Robolectric
+        val activity = Robolectric.buildActivity(ComponentActivity::class.java).setup().get()
+
+        // Act: Call findActivity on the activity itself
+        val result = activity.findActivity()
+
+        // Assert: The result should be the same activity
+        assertEquals(activity, result)
+    }
+
+    @Test
+    fun contextIsWrappedComponentActivity_returnsActivity() {
+        // Arrange: Create a ComponentActivity using Robolectric
+        val activity = Robolectric.buildActivity(ComponentActivity::class.java).setup().get()
+
+        // Wrap the activity in a ContextWrapper
+        val contextWrapper = ContextWrapper(activity)
+
+        // Act: Call findActivity on the wrapped context
+        val result = contextWrapper.findActivity()
+
+        // Assert: The result should be the original activity
+        assertEquals(activity, result)
+    }
+
+    @Test
+    fun contextIsDeeplyWrappedComponentActivity_returnsActivity() {
+        // Arrange: Create a ComponentActivity using Robolectric
+        val activity = Robolectric.buildActivity(ComponentActivity::class.java).setup().get()
+
+        // Wrap the activity multiple times
+        val contextWrapperLevel1 = ContextWrapper(activity)
+        val contextWrapperLevel2 = ContextWrapper(contextWrapperLevel1)
+        val contextWrapperLevel3 = ContextWrapper(contextWrapperLevel2)
+
+        // Act: Call findActivity on the deeply wrapped context
+        val result = contextWrapperLevel3.findActivity()
+
+        // Assert: The result should be the original activity
+        assertEquals(activity, result)
+    }
+}


### PR DESCRIPTION
## Summary

This PR adds support for managing user interests within the app, allowing users to view, add, and remove their interests. Interests are now displayed both in the ProfileScreen and EditProfileScreen. The implementation includes UI components for displaying and editing interests, as well as unit and UI tests to ensure functionality and reliability. Significant enhancements have also been made to the UserViewModel and related classes to support these new features. The associated tests have been updated and expanded to cover the new functionalities.

## Changes

- **Screens/UI:** 
  - ProfileScreen:
    - Interest Display:
      - Updated to display the user's interests as chips, providing a personalized overview of the user's profile.
      - Used the InterestChip composable to render each interest.
  - EditProfileScreen:
    - Interest Management:
      - Implemented UI components for displaying the user's current interests as editable chips.
      - Added functionality to add new interests through an input field with validation to prevent duplicates.
      - Included the ability to remove interests via a delete icon on each interest chip, with a confirmation dialog to prevent accidental deletions.
    - Keyboard Interaction:
      - Enhanced keyboard interactions, including dismissing the keyboard when "Done" is pressed in "Add interest" text field.
    - Permission Handling:
      - Updated UI to handle permissions when choosing a profile picture, including requesting runtime permissions and showing rationale dialogs.
- InterestChip and InterestChipEditable:
  - Created new composables to represent interests:
    - InterestChip displays interests in the ProfileScreen.
    - InterestChipEditable is used in EditProfileScreen with additional functionality for editing.

- **Bug Fixes/Improvements:**
  - This PR solves #112 

## Checklist

Ensure all / most of these are checked before the pull request is submitted.
- [X] This PR resolves #112 
- [X] Tests have been added for new functionality.
- [X] Screenshots or UI changes have been attached.
- [X] Documentation has been updated.

##  Testing

- Manual Testing:
  - Tested on emulator and physical devices.
  - Verified that interests are displayed correctly in the ProfileScreen.
  - Verified adding and removing interests functions correctly in EditProfileScreen.
  - Tested permission requests and rationale dialogs when changing the profile picture.

- UI Tests:
  - Implemented UI tests in ProfileScreenTest to verify interests display.
  - Implemented UI tests in EditProfileScreenTest for adding and removing interests.
  - Tested the confirmation dialog for interest removal.
  - Verified the behavior of the keyboard interactions.

- Unit Tests:
  - Added unit tests for InterestChip and InterestChipEditable composables.
  - Ensured that the UI components display correctly and handle user interactions as expected.

##  Related Issues/Tickets

This PR closes #112 

## Screenshots (if applicable)

<img width="365" alt="Screenshot 2024-11-07 at 22 49 02" src="https://github.com/user-attachments/assets/e0006a83-d779-4442-ba44-0d4c28c17e3a">
 
<img width="365" alt="Screenshot 2024-11-07 at 22 49 08" src="https://github.com/user-attachments/assets/40daada0-9d17-489f-9c4a-ce8e0d4857ce">

<img width="365" alt="Screenshot 2024-11-07 at 22 49 15" src="https://github.com/user-attachments/assets/5da8e4e5-dc4d-4e91-b7ed-561245f93920">

<img width="365" alt="Screenshot 2024-11-07 at 22 49 32" src="https://github.com/user-attachments/assets/09055770-e0d5-4550-9069-ef4ef63eefc3">
