### PR TITLE
Feat/activities screen

### DIFF
--- a/app/src/androidTest/java/com/android/voyageur/ui/trip/activities/ActivitiesScreenTest.kt
+++ b/app/src/androidTest/java/com/android/voyageur/ui/trip/activities/ActivitiesScreenTest.kt
@@ -1,14 +1,13 @@
 package com.android.voyageur.ui.trip.activities
 
 import androidx.compose.ui.test.assertIsDisplayed
-import androidx.compose.ui.test.assertTextContains
+import androidx.compose.ui.test.assertIsNotDisplayed
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
 import com.android.voyageur.model.activity.Activity
 import com.android.voyageur.model.activity.ActivityType
-import com.android.voyageur.model.location.Location
 import com.android.voyageur.model.trip.Trip
 import com.android.voyageur.ui.navigation.LIST_TOP_LEVEL_DESTINATION
 import com.android.voyageur.ui.navigation.NavigationActions
@@ -19,23 +18,23 @@ import org.junit.Test
 import org.mockito.Mockito.mock
 
 class ActivitiesScreenTest {
-  private val sampleTrip = Trip(name = "Sample Trip", activities = listOf(
-    // Draft activity
-    Activity(
-      title = "Draft Activity",
-      description = "This is a draft activity",
-      estimatedPrice = 0.0,
-      activityType = ActivityType.WALK
-    ),
-    // Finalized activity
-    Activity(
-      title = "Final Activity",
-      description = "This is a final activity",
-      startTime = Timestamp.now(),
-      endDate = Timestamp.now(),
-      estimatedPrice = 20.0,
-      activityType = ActivityType.RESTAURANT
-    )))
+  private val sampleTrip =
+      Trip(
+          name = "Sample Trip",
+          activities =
+              listOf(
+                  Activity(
+                      title = "Draft Activity",
+                      description = "This is a draft activity",
+                      estimatedPrice = 0.0,
+                      activityType = ActivityType.WALK),
+                  Activity(
+                      title = "Final Activity",
+                      description = "This is a final activity",
+                      startTime = Timestamp.now(),
+                      endDate = Timestamp.now(),
+                      estimatedPrice = 20.0,
+                      activityType = ActivityType.RESTAURANT)))
 
   private lateinit var navigationActions: NavigationActions
 
@@ -44,7 +43,6 @@ class ActivitiesScreenTest {
   @Before
   fun setUp() {
     navigationActions = mock(NavigationActions::class.java)
-
   }
 
   @Test
@@ -54,35 +52,25 @@ class ActivitiesScreenTest {
     composeTestRule.onNodeWithTag("bottomNavigationMenu").assertIsDisplayed()
   }
 
-
   @Test
   fun displaysBottomNavigationCorrectly() {
-    //    tripsViewModel.selectTrip(Trip(name = "Sample Trip"))
     composeTestRule.setContent { ActivitiesScreen(sampleTrip, navigationActions) }
 
-    // Check that the bottom navigation menu is displayed
     composeTestRule.onNodeWithTag("bottomNavigationMenu").assertIsDisplayed()
 
-    // Verify that the bottom navigation has items with correct actions
     LIST_TOP_LEVEL_DESTINATION.forEach { destination ->
       composeTestRule.onNodeWithText(destination.textId).assertExists()
     }
   }
+
   @Test
   fun activitiesScreen_displaysDraftAndFinalSections() {
-    // Arrange: Create a sample Trip with activities
-    val sampleTrip = Trip(
-      name = "Sample Trip",
-      activities = finalActivities
-    )
-//    val navigationActions = NavigationActions {}
+    val sampleTrip = Trip(name = "Sample Trip", activities = SAMPLE_ACTIVITIES)
 
-    // Act: Launch the ActivitiesScreen
     composeTestRule.setContent {
       ActivitiesScreen(trip = sampleTrip, navigationActions = navigationActions)
     }
 
-    // Assert: Check if "Drafts" and "Final" headers are displayed
     composeTestRule.onNodeWithTag("lazyColumn").assertIsDisplayed()
     composeTestRule.onNodeWithText("Drafts").assertIsDisplayed()
     composeTestRule.onNodeWithText("Final").assertIsDisplayed()
@@ -90,18 +78,16 @@ class ActivitiesScreenTest {
 
   @Test
   fun activityItem_expandAndCollapse() {
-    // Arrange: Create a sample activity
-    val sampleActivity = finalActivities.first()
+    val sampleActivity = SAMPLE_ACTIVITIES.first()
 
-    // Act: Launch the ActivityItem
-    composeTestRule.setContent {
-      ActivityItem(activity = sampleActivity)
-    }
+    composeTestRule.setContent { ActivityItem(activity = sampleActivity) }
 
-    // Assert: Check if the expand icon is present and clickable
-    composeTestRule.onNodeWithTag("expandIcon_${sampleActivity.title}")
-      .assertIsDisplayed()
-      .performClick()
+    composeTestRule.onNodeWithText("Price").assertIsNotDisplayed()
+
+    composeTestRule
+        .onNodeWithTag("expandIcon_${sampleActivity.title}")
+        .assertIsDisplayed()
+        .performClick()
 
     // Check if the expanded content is displayed
     composeTestRule.onNodeWithText("Price").assertIsDisplayed()
@@ -109,16 +95,11 @@ class ActivitiesScreenTest {
   }
 
   @Test
-  fun activityCard_displaysCorrectTitleAndTime() {
-    // Arrange: Use the first activity in finalActivities
-    val sampleActivity = finalActivities.first()
+  fun activityCard_displaysCorrectTitle() {
+    val sampleActivity = SAMPLE_ACTIVITIES.first()
 
-    // Act: Launch the ActivityItem
-    composeTestRule.setContent {
-      ActivityItem(activity = sampleActivity)
-    }
+    composeTestRule.setContent { ActivityItem(activity = sampleActivity) }
 
-    // Assert: Check if the activity title and time are displayed
     composeTestRule.onNodeWithTag("cardItem_${sampleActivity.title}").assertIsDisplayed()
     composeTestRule.onNodeWithText(sampleActivity.title).assertIsDisplayed()
   }

--- a/app/src/androidTest/java/com/android/voyageur/ui/trip/activities/ActivitiesScreenTest.kt
+++ b/app/src/androidTest/java/com/android/voyageur/ui/trip/activities/ActivitiesScreenTest.kt
@@ -5,16 +5,37 @@ import androidx.compose.ui.test.assertTextContains
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import com.android.voyageur.model.activity.Activity
+import com.android.voyageur.model.activity.ActivityType
+import com.android.voyageur.model.location.Location
 import com.android.voyageur.model.trip.Trip
 import com.android.voyageur.ui.navigation.LIST_TOP_LEVEL_DESTINATION
 import com.android.voyageur.ui.navigation.NavigationActions
+import com.google.firebase.Timestamp
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.mockito.Mockito.mock
 
 class ActivitiesScreenTest {
-  private val sampleTrip = Trip(name = "Sample Trip")
+  private val sampleTrip = Trip(name = "Sample Trip", activities = listOf(
+    // Draft activity
+    Activity(
+      title = "Draft Activity",
+      description = "This is a draft activity",
+      estimatedPrice = 0.0,
+      activityType = ActivityType.WALK
+    ),
+    // Finalized activity
+    Activity(
+      title = "Final Activity",
+      description = "This is a final activity",
+      startTime = Timestamp.now(),
+      endDate = Timestamp.now(),
+      estimatedPrice = 20.0,
+      activityType = ActivityType.RESTAURANT
+    )))
 
   private lateinit var navigationActions: NavigationActions
 
@@ -23,6 +44,7 @@ class ActivitiesScreenTest {
   @Before
   fun setUp() {
     navigationActions = mock(NavigationActions::class.java)
+
   }
 
   @Test
@@ -30,17 +52,8 @@ class ActivitiesScreenTest {
     composeTestRule.setContent { ActivitiesScreen(sampleTrip, navigationActions) }
     composeTestRule.onNodeWithTag("activitiesScreen").assertIsDisplayed()
     composeTestRule.onNodeWithTag("bottomNavigationMenu").assertIsDisplayed()
-    composeTestRule.onNodeWithTag("emptyActivitiesPrompt").assertIsDisplayed()
   }
 
-  @Test
-  fun displaysCorrectTripName() {
-    composeTestRule.setContent { ActivitiesScreen(sampleTrip, navigationActions) }
-    composeTestRule
-        .onNodeWithTag("emptyActivitiesPrompt")
-        .assertTextContains(
-            "You're viewing the Activities screen for Sample Trip, but it's not implemented yet.")
-  }
 
   @Test
   fun displaysBottomNavigationCorrectly() {
@@ -54,5 +67,59 @@ class ActivitiesScreenTest {
     LIST_TOP_LEVEL_DESTINATION.forEach { destination ->
       composeTestRule.onNodeWithText(destination.textId).assertExists()
     }
+  }
+  @Test
+  fun activitiesScreen_displaysDraftAndFinalSections() {
+    // Arrange: Create a sample Trip with activities
+    val sampleTrip = Trip(
+      name = "Sample Trip",
+      activities = finalActivities
+    )
+//    val navigationActions = NavigationActions {}
+
+    // Act: Launch the ActivitiesScreen
+    composeTestRule.setContent {
+      ActivitiesScreen(trip = sampleTrip, navigationActions = navigationActions)
+    }
+
+    // Assert: Check if "Drafts" and "Final" headers are displayed
+    composeTestRule.onNodeWithTag("lazyColumn").assertIsDisplayed()
+    composeTestRule.onNodeWithText("Drafts").assertIsDisplayed()
+    composeTestRule.onNodeWithText("Final").assertIsDisplayed()
+  }
+
+  @Test
+  fun activityItem_expandAndCollapse() {
+    // Arrange: Create a sample activity
+    val sampleActivity = finalActivities.first()
+
+    // Act: Launch the ActivityItem
+    composeTestRule.setContent {
+      ActivityItem(activity = sampleActivity)
+    }
+
+    // Assert: Check if the expand icon is present and clickable
+    composeTestRule.onNodeWithTag("expandIcon_${sampleActivity.title}")
+      .assertIsDisplayed()
+      .performClick()
+
+    // Check if the expanded content is displayed
+    composeTestRule.onNodeWithText("Price").assertIsDisplayed()
+    composeTestRule.onNodeWithText("${sampleActivity.estimatedPrice} CHF").assertIsDisplayed()
+  }
+
+  @Test
+  fun activityCard_displaysCorrectTitleAndTime() {
+    // Arrange: Use the first activity in finalActivities
+    val sampleActivity = finalActivities.first()
+
+    // Act: Launch the ActivityItem
+    composeTestRule.setContent {
+      ActivityItem(activity = sampleActivity)
+    }
+
+    // Assert: Check if the activity title and time are displayed
+    composeTestRule.onNodeWithTag("cardItem_${sampleActivity.title}").assertIsDisplayed()
+    composeTestRule.onNodeWithText(sampleActivity.title).assertIsDisplayed()
   }
 }

--- a/app/src/main/java/com/android/voyageur/model/activity/Activity.kt
+++ b/app/src/main/java/com/android/voyageur/model/activity/Activity.kt
@@ -5,12 +5,12 @@ import com.google.firebase.Timestamp
 
 data class Activity(
     val title: String,
-    val description: String,
-    val location: Location,
-    val startTime: Timestamp,
-    val endDate: Timestamp,
-    val estimatedPrice: Number,
-    val activityType: ActivityType,
+    val description: String = "",
+    val location: Location = Location(),
+    val startTime: Timestamp = Timestamp(0, 0),
+    val endDate: Timestamp = Timestamp(0, 0),
+    val estimatedPrice: Number = 0.0,
+    val activityType: ActivityType = ActivityType.OTHER,
 )
 
 enum class ActivityType {
@@ -22,3 +22,9 @@ enum class ActivityType {
   TRANSPORT,
   OTHER,
 }
+
+fun Activity.hasDescription() = description != ""
+
+fun Activity.hasStartTime() = startTime != Timestamp(0, 0)
+
+fun Activity.hasEndDate() = endDate != Timestamp(0, 0)

--- a/app/src/main/java/com/android/voyageur/model/trip/Trip.kt
+++ b/app/src/main/java/com/android/voyageur/model/trip/Trip.kt
@@ -14,7 +14,7 @@ data class Trip(
     val locations: List<Location> = emptyList(),
     val startDate: Timestamp = Timestamp.now(),
     val endDate: Timestamp = Timestamp.now(),
-    val activities: List<Activity> = emptyList(),
+    var activities: List<Activity> = emptyList(),
     val type: TripType = TripType.TOURISM,
     val imageUri: String = "" // default image for trip
 ) {

--- a/app/src/main/java/com/android/voyageur/ui/trip/Tabs.kt
+++ b/app/src/main/java/com/android/voyageur/ui/trip/Tabs.kt
@@ -17,6 +17,7 @@ import androidx.compose.ui.platform.testTag
 import com.android.voyageur.model.trip.TripsViewModel
 import com.android.voyageur.ui.navigation.NavigationActions
 import com.android.voyageur.ui.trip.activities.ActivitiesScreen
+import com.android.voyageur.ui.trip.activities.finalActivities
 import com.android.voyageur.ui.trip.schedule.ByDayScreen
 import com.android.voyageur.ui.trip.schedule.TopBarWithImage
 import com.android.voyageur.ui.trip.settings.SettingsScreen
@@ -54,7 +55,8 @@ fun TopTabs(tripsViewModel: TripsViewModel, navigationActions: NavigationActions
     // Display content based on selected tab
     when (selectedTabIndex) {
       0 -> ByDayScreen(trip, navigationActions)
-      1 -> ActivitiesScreen(trip, navigationActions)
+      1 -> { trip.activities = finalActivities
+          ActivitiesScreen(trip, navigationActions) }
       2 ->
           SettingsScreen(
               trip,

--- a/app/src/main/java/com/android/voyageur/ui/trip/Tabs.kt
+++ b/app/src/main/java/com/android/voyageur/ui/trip/Tabs.kt
@@ -17,7 +17,7 @@ import androidx.compose.ui.platform.testTag
 import com.android.voyageur.model.trip.TripsViewModel
 import com.android.voyageur.ui.navigation.NavigationActions
 import com.android.voyageur.ui.trip.activities.ActivitiesScreen
-import com.android.voyageur.ui.trip.activities.finalActivities
+import com.android.voyageur.ui.trip.activities.SAMPLE_ACTIVITIES
 import com.android.voyageur.ui.trip.schedule.ByDayScreen
 import com.android.voyageur.ui.trip.schedule.TopBarWithImage
 import com.android.voyageur.ui.trip.settings.SettingsScreen
@@ -55,8 +55,10 @@ fun TopTabs(tripsViewModel: TripsViewModel, navigationActions: NavigationActions
     // Display content based on selected tab
     when (selectedTabIndex) {
       0 -> ByDayScreen(trip, navigationActions)
-      1 -> { trip.activities = finalActivities
-          ActivitiesScreen(trip, navigationActions) }
+      1 -> {
+        trip.activities = SAMPLE_ACTIVITIES
+        ActivitiesScreen(trip, navigationActions)
+      }
       2 ->
           SettingsScreen(
               trip,

--- a/app/src/main/java/com/android/voyageur/ui/trip/activities/Activities.kt
+++ b/app/src/main/java/com/android/voyageur/ui/trip/activities/Activities.kt
@@ -45,7 +45,8 @@ import com.android.voyageur.ui.navigation.BottomNavigationMenu
 import com.android.voyageur.ui.navigation.LIST_TOP_LEVEL_DESTINATION
 import com.android.voyageur.ui.navigation.NavigationActions
 import com.google.firebase.Timestamp
-import java.text.SimpleDateFormat
+import java.time.ZoneId
+import java.time.format.DateTimeFormatter
 import java.util.Locale
 
 @SuppressLint("UnusedMaterial3ScaffoldPaddingParameter")
@@ -116,12 +117,19 @@ fun ActivityItem(
 ) {
   var isExpanded by remember { mutableStateOf(false) }
 
-  val dateFormat = SimpleDateFormat("dd/MM/yyyy", Locale.getDefault())
-  val timeFormat = SimpleDateFormat("hh:mm a", Locale.getDefault())
+  val dateFormat = DateTimeFormatter.ofPattern("dd/MM/yyyy", Locale.getDefault())
+  val timeFormat = DateTimeFormatter.ofPattern("hh:mm a", Locale.getDefault())
 
-  val dateFormatted = dateFormat.format(activity.startTime.toDate())
-  val startTimeFormatted = timeFormat.format(activity.startTime.toDate())
-  val endTimeFormatted = timeFormat.format(activity.endDate.toDate())
+  // Convert Timestamp to LocalDateTime for formatting
+  val startLocalDateTime =
+      activity.startTime.toDate().toInstant().atZone(ZoneId.systemDefault()).toLocalDateTime()
+  val endLocalDateTime =
+      activity.endDate.toDate().toInstant().atZone(ZoneId.systemDefault()).toLocalDateTime()
+
+  // Format the date and time
+  val dateFormatted = dateFormat.format(startLocalDateTime)
+  val startTimeFormatted = timeFormat.format(startLocalDateTime)
+  val endTimeFormatted = timeFormat.format(endLocalDateTime)
 
   Card(
       shape = MaterialTheme.shapes.medium,
@@ -206,14 +214,20 @@ fun ActivityItem(
       })
 }
 
+fun createTimestamp(year: Int, month: Int, day: Int, hour: Int, minute: Int): Timestamp {
+  val calendar = java.util.Calendar.getInstance()
+  calendar.set(year, month - 1, day, hour, minute) // Month is 0-based
+  return Timestamp(calendar.time)
+}
+
 val SAMPLE_ACTIVITIES =
     listOf(
         Activity(
             title = "Breakfast",
             description = "",
             activityType = ActivityType.RESTAURANT,
-            startTime = Timestamp.now(),
-            endDate = Timestamp.now(),
+            startTime = createTimestamp(2024, 11, 3, 10, 0),
+            endDate = createTimestamp(2024, 11, 3, 12, 30),
             estimatedPrice = 20.25,
             location = Location()),
         Activity(
@@ -239,8 +253,8 @@ val SAMPLE_ACTIVITIES =
             title = "Dinner3",
             description = "",
             activityType = ActivityType.RESTAURANT,
-            startTime = Timestamp.now(),
-            endDate = Timestamp.now(),
+            startTime = createTimestamp(2024, 11, 3, 19, 30),
+            endDate = createTimestamp(2024, 11, 3, 21, 0),
             estimatedPrice = 23.25,
             location = Location()),
         Activity(

--- a/app/src/main/java/com/android/voyageur/ui/trip/activities/Activities.kt
+++ b/app/src/main/java/com/android/voyageur/ui/trip/activities/Activities.kt
@@ -23,7 +23,6 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
-import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
@@ -36,11 +35,13 @@ import androidx.compose.ui.draw.rotate
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.text.font.FontWeight
-import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.android.voyageur.model.activity.Activity
 import com.android.voyageur.model.activity.ActivityType
+import com.android.voyageur.model.activity.hasDescription
+import com.android.voyageur.model.activity.hasEndDate
+import com.android.voyageur.model.activity.hasStartTime
 import com.android.voyageur.model.location.Location
 import com.android.voyageur.model.trip.Trip
 import com.android.voyageur.ui.navigation.BottomNavigationMenu
@@ -62,74 +63,16 @@ fun ActivitiesScreen(
   //        activity.startTime != Timestamp(0, 0) && activity.endDate != Timestamp(0, 0)
   //    }
 
-  val finalActivities =
-      listOf(
-          Activity(
-              title = "Breakfast",
-              description = "",
-              activityType = ActivityType.RESTAURANT,
-              startTime = Timestamp.now(),
-              endDate = Timestamp.now(),
-              estimatedPrice = 20.25,
-              location = Location()),
-          Activity(
-              title = "Dinner",
-              description = "",
-              activityType = ActivityType.RESTAURANT,
-              startTime = Timestamp.now(),
-              endDate = Timestamp.now(),
-              estimatedPrice = 23.25,
-              location = Location()),
-          Activity(
-              title = "Dinner2",
-              description = "",
-              activityType = ActivityType.RESTAURANT,
-              startTime = Timestamp.now(),
-              endDate = Timestamp.now(),
-              estimatedPrice = 23.25,
-              location = Location()),
-          Activity(
-              title = "Dinner3",
-              description = "",
-              activityType = ActivityType.RESTAURANT,
-              startTime = Timestamp.now(),
-              endDate = Timestamp.now(),
-              estimatedPrice = 23.25,
-              location = Location()),
-          Activity(
-              title = "Dinner4",
-              description = "",
-              activityType = ActivityType.RESTAURANT,
-              startTime = Timestamp.now(),
-              endDate = Timestamp.now(),
-              estimatedPrice = 23.25,
-              location = Location()),
-          Activity(
-              title = "Dinner5",
-              description = "",
-              activityType = ActivityType.RESTAURANT,
-              startTime = Timestamp.now(),
-              endDate = Timestamp.now(),
-              estimatedPrice = 23.25,
-              location = Location()),
-          Activity(
-              title = "Too long name to be displayed on the Activity Box",
-              description = "",
-              activityType = ActivityType.OTHER,
-              startTime = Timestamp.now(),
-              endDate = Timestamp.now(),
-              estimatedPrice = 00.00,
-              location = Location()),
-          Activity(
-              title = "Visit city",
-              description = "",
-              activityType = ActivityType.OTHER,
-              //                startTime = oneDayAfterNow,
-              //                endDate = oneDayAfterNow,
-              startTime = Timestamp.now(),
-              endDate = Timestamp.now(),
-              estimatedPrice = 00.00,
-              location = Location()))
+//    trip.activities = finalActivities
+
+  val drafts =
+      finalActivities.filter { activity ->
+        activity.startTime == Timestamp(0, 0) || activity.endDate == Timestamp(0, 0)
+      }
+  val final =
+      finalActivities.filter { activity ->
+        activity.startTime != Timestamp(0, 0) && activity.endDate != Timestamp(0, 0)
+      }
 
   Scaffold(
       // TODO: Final implementation of ActivitiesScreen
@@ -149,11 +92,29 @@ fun ActivitiesScreen(
                     .testTag("lazyColumn"),
             verticalArrangement = Arrangement.spacedBy(10.dp, Alignment.Top),
         ) {
-          item { Text(text = "Drafts",               fontSize = 24.sp,
-              fontWeight = FontWeight.Bold, modifier = Modifier.padding(start = 10.dp)) }
-          finalActivities.forEach { activity ->
+          item {
+            Text(
+                text = "Drafts",
+                fontSize = 24.sp,
+                fontWeight = FontWeight.Bold,
+                modifier = Modifier.padding(start = 10.dp))
+          }
+          drafts.forEach { activity ->
             item {
-              ActivityItem(activity, onDelete = { /* Handle delete action */})
+              ActivityItem(activity)
+              Spacer(modifier = Modifier.height(10.dp))
+            }
+          }
+          item {
+            Text(
+                text = "Final",
+                fontSize = 24.sp,
+                fontWeight = FontWeight.Bold,
+                modifier = Modifier.padding(start = 10.dp))
+          }
+          final.forEach { activity ->
+            item {
+              ActivityItem(activity)
               Spacer(modifier = Modifier.height(10.dp))
             }
           }
@@ -164,39 +125,50 @@ fun ActivitiesScreen(
 @Composable
 fun ActivityItem(
     activity: Activity,
-    onDelete: (Activity) -> Unit // Callback function for delete action
 ) {
   // State to track expanded or collapsed status
   var isExpanded by remember { mutableStateOf(false) }
 
-  // Format the start and end times
-  val timeFormat = SimpleDateFormat("h:mm a", Locale.getDefault())
+  //  // Format the start and end times
+  //  val timeFormat = SimpleDateFormat("h:mm a", Locale.getDefault())
+  //  val startTimeFormatted = timeFormat.format(activity.startTime.toDate())
+  //  val endTimeFormatted = timeFormat.format(activity.endDate.toDate())
+  // Date and Time Formatter
+  val dateFormat = SimpleDateFormat("dd/MM/yyyy", Locale.getDefault())
+  val timeFormat = SimpleDateFormat("hh:mm a", Locale.getDefault())
+
+  // Formatting the Date and Time
+  val dateFormatted = dateFormat.format(activity.startTime.toDate())
   val startTimeFormatted = timeFormat.format(activity.startTime.toDate())
   val endTimeFormatted = timeFormat.format(activity.endDate.toDate())
-    Card(
-       shape = MaterialTheme.shapes.medium,
-      modifier = Modifier.padding(start = 10.dp, end = 10.dp)
-          .testTag("cardItem"),
-        content = {
+
+  Card(
+      shape = MaterialTheme.shapes.medium,
+      modifier = Modifier.padding(start = 10.dp, end = 10.dp).testTag("cardItem"),
+      content = {
         Column(modifier = Modifier.padding(16.dp).fillMaxWidth()) {
           Row(
               horizontalArrangement = Arrangement.SpaceBetween,
               verticalAlignment = Alignment.CenterVertically,
               modifier = Modifier.fillMaxWidth()) {
-                Column (modifier = Modifier.weight(1f)) {
-                  Text(text = activity.title, fontWeight = FontWeight.Medium,
+                Column(modifier = Modifier.weight(1f)) {
+                  Text(
+                      text = activity.title,
+                      fontWeight = FontWeight.Medium,
                       modifier = Modifier.padding(end = 8.dp),
                       fontSize = 16.sp)
-                  Text(
-                      text = "$startTimeFormatted - $endTimeFormatted",
-                      fontSize = 12.sp,
-                      color = Color.Gray)
+                  if (activity.hasStartTime() && activity.hasEndDate()) {
+                    Text(
+                        text = "$dateFormatted $startTimeFormatted - $endTimeFormatted",
+                        fontSize = 12.sp,
+                        color = Color.Gray)
+                  }
                 }
 
                 Row(verticalAlignment = Alignment.CenterVertically) {
                   // Delete icon, visible only when expanded
                   AnimatedVisibility(visible = isExpanded) {
-                    IconButton(onClick = { onDelete(activity) }) {
+                    IconButton(onClick = { /*TODO: delete activity*/}) {
                       Icon(
                           imageVector =
                               Icons.TwoTone.Delete, // Use Icons.Default.Delete for trashcan
@@ -218,16 +190,18 @@ fun ActivityItem(
           // Expandable content with animation
           AnimatedVisibility(visible = isExpanded, enter = fadeIn(), exit = fadeOut()) {
             Column(modifier = Modifier.fillMaxWidth().padding(top = 8.dp)) {
-              Text(
-                  text = "Description",
-                  fontWeight = FontWeight.SemiBold,
-                  fontSize = 14.sp,
-                  modifier = Modifier.padding(vertical = 2.dp))
-              Text(
-                  text = activity.description,
-                  fontSize = 14.sp,
-                  modifier = Modifier.padding(bottom = 8.dp))
-
+              if (activity.hasDescription()) {
+                Text(
+                    text = "Description",
+                    fontWeight = FontWeight.SemiBold,
+                    fontSize = 14.sp,
+                    modifier = Modifier.padding(vertical = 2.dp))
+                Text(
+                    text = activity.description,
+                    fontSize = 14.sp,
+                    modifier = Modifier.padding(bottom = 8.dp))
+              }
+              // TODO: Add location once we have the final location model
               Text(
                   text = "Price",
                   fontWeight = FontWeight.SemiBold,
@@ -249,3 +223,74 @@ fun ActivityItem(
         }
       })
 }
+val finalActivities =
+    listOf(
+        Activity(
+            title = "Breakfast",
+            description = "",
+            activityType = ActivityType.RESTAURANT,
+            startTime = Timestamp.now(),
+            endDate = Timestamp.now(),
+            estimatedPrice = 20.25,
+            location = Location()),
+        Activity(
+            title = "Lunch",
+        ),
+        Activity(
+            title = "Dinner",
+            description = "Dinner description",
+            activityType = ActivityType.RESTAURANT,
+            startTime = Timestamp.now(),
+            endDate = Timestamp.now(),
+            estimatedPrice = 23.25,
+            location = Location()),
+        Activity(
+            title = "Dinner2",
+            description = "",
+            activityType = ActivityType.RESTAURANT,
+            startTime = Timestamp.now(),
+            endDate = Timestamp.now(),
+            estimatedPrice = 23.25,
+            location = Location()),
+        Activity(
+            title = "Dinner3",
+            description = "",
+            activityType = ActivityType.RESTAURANT,
+            startTime = Timestamp.now(),
+            endDate = Timestamp.now(),
+            estimatedPrice = 23.25,
+            location = Location()),
+        Activity(
+            title = "Dinner4",
+            description = "Too long description to be displayed on the Activity Box",
+            activityType = ActivityType.RESTAURANT,
+            startTime = Timestamp.now(),
+            endDate = Timestamp.now(),
+            estimatedPrice = 23.25,
+            location = Location()),
+        Activity(
+            title = "Dinner5",
+            description = "",
+            activityType = ActivityType.RESTAURANT,
+            startTime = Timestamp.now(),
+            endDate = Timestamp.now(),
+            estimatedPrice = 23.25,
+            location = Location()),
+        Activity(
+            title = "Too long name to be displayed on the Activity Box",
+            description = "",
+            activityType = ActivityType.OTHER,
+            startTime = Timestamp.now(),
+            endDate = Timestamp.now(),
+            estimatedPrice = 00.00,
+            location = Location()),
+        Activity(
+            title = "Visit city",
+            description = "",
+            activityType = ActivityType.OTHER,
+            //                startTime = oneDayAfterNow,
+            //                endDate = oneDayAfterNow,
+            startTime = Timestamp.now(),
+            endDate = Timestamp.now(),
+            estimatedPrice = 00.00,
+            location = Location()))

--- a/app/src/main/java/com/android/voyageur/ui/trip/activities/Activities.kt
+++ b/app/src/main/java/com/android/voyageur/ui/trip/activities/Activities.kt
@@ -14,11 +14,8 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.ArrowDropDown
-import androidx.compose.material.icons.filled.Delete
-import androidx.compose.material.icons.outlined.Delete
 import androidx.compose.material.icons.twotone.Delete
 import androidx.compose.material3.Card
-import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
@@ -52,7 +49,6 @@ import java.text.SimpleDateFormat
 import java.util.Locale
 
 @SuppressLint("UnusedMaterial3ScaffoldPaddingParameter")
-@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun ActivitiesScreen(
     trip: Trip,
@@ -80,10 +76,7 @@ fun ActivitiesScreen(
       content = { pd ->
         LazyColumn(
             modifier =
-                Modifier.padding(pd) // Use Scaffold’s padding
-                    .padding(top = 16.dp) // Additional padding at the top
-                    .fillMaxWidth() // Fill the available width
-                    .testTag("lazyColumn"),
+                Modifier.padding(pd).padding(top = 16.dp).fillMaxWidth().testTag("lazyColumn"),
             verticalArrangement = Arrangement.spacedBy(10.dp, Alignment.Top),
         ) {
           item {
@@ -116,9 +109,7 @@ fun ActivitiesScreen(
       })
 }
 
-/**
- * Composable that displays an activity item in a card view.
- */
+/** Composable that displays an activity item in a card view. */
 @Composable
 fun ActivityItem(
     activity: Activity,
@@ -160,21 +151,21 @@ fun ActivityItem(
                   AnimatedVisibility(visible = isExpanded) {
                     IconButton(onClick = { /*TODO: delete activity*/}) {
                       Icon(
-                          imageVector =
-                              Icons.TwoTone.Delete,
+                          imageVector = Icons.TwoTone.Delete,
                           contentDescription = "Delete Activity",
                           tint = Color.Red)
                     }
                   }
 
                   // Expand/collapse icon
-                  IconButton(onClick = { isExpanded = !isExpanded },
+                  IconButton(
+                      onClick = { isExpanded = !isExpanded },
                       modifier = Modifier.testTag("expandIcon_${activity.title}")) {
-                    Icon(
-                        imageVector = Icons.Default.ArrowDropDown,
-                        contentDescription = if (isExpanded) "Collapse" else "Expand",
-                        modifier = Modifier.rotate(if (isExpanded) 180f else 0f))
-                  }
+                        Icon(
+                            imageVector = Icons.Default.ArrowDropDown,
+                            contentDescription = if (isExpanded) "Collapse" else "Expand",
+                            modifier = Modifier.rotate(if (isExpanded) 180f else 0f))
+                      }
                 }
               }
 
@@ -214,7 +205,8 @@ fun ActivityItem(
         }
       })
 }
-val finalActivities =
+
+val SAMPLE_ACTIVITIES =
     listOf(
         Activity(
             title = "Breakfast",

--- a/app/src/main/java/com/android/voyageur/ui/trip/activities/Activities.kt
+++ b/app/src/main/java/com/android/voyageur/ui/trip/activities/Activities.kt
@@ -1,26 +1,135 @@
 package com.android.voyageur.ui.trip.activities
 
+import android.annotation.SuppressLint
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.ArrowDropDown
+import androidx.compose.material.icons.filled.Delete
+import androidx.compose.material.icons.outlined.Delete
+import androidx.compose.material.icons.twotone.Delete
+import androidx.compose.material3.Card
 import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.rotate
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.android.voyageur.model.activity.Activity
+import com.android.voyageur.model.activity.ActivityType
+import com.android.voyageur.model.location.Location
 import com.android.voyageur.model.trip.Trip
 import com.android.voyageur.ui.navigation.BottomNavigationMenu
 import com.android.voyageur.ui.navigation.LIST_TOP_LEVEL_DESTINATION
 import com.android.voyageur.ui.navigation.NavigationActions
+import com.google.firebase.Timestamp
+import java.text.SimpleDateFormat
+import java.util.Locale
 
+@SuppressLint("UnusedMaterial3ScaffoldPaddingParameter")
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun ActivitiesScreen(
     trip: Trip,
     navigationActions: NavigationActions,
 ) {
-  //  val trip =
-  //      tripsViewModel.selectedTrip.collectAsState().value
-  //          ?: return Text(text = "No ToDo selected. Should not happen", color = Color.Red)
+
+  //    val finalActivities = trip.activities.filter { activity ->
+  //        activity.startTime != Timestamp(0, 0) && activity.endDate != Timestamp(0, 0)
+  //    }
+
+  val finalActivities =
+      listOf(
+          Activity(
+              title = "Breakfast",
+              description = "",
+              activityType = ActivityType.RESTAURANT,
+              startTime = Timestamp.now(),
+              endDate = Timestamp.now(),
+              estimatedPrice = 20.25,
+              location = Location()),
+          Activity(
+              title = "Dinner",
+              description = "",
+              activityType = ActivityType.RESTAURANT,
+              startTime = Timestamp.now(),
+              endDate = Timestamp.now(),
+              estimatedPrice = 23.25,
+              location = Location()),
+          Activity(
+              title = "Dinner2",
+              description = "",
+              activityType = ActivityType.RESTAURANT,
+              startTime = Timestamp.now(),
+              endDate = Timestamp.now(),
+              estimatedPrice = 23.25,
+              location = Location()),
+          Activity(
+              title = "Dinner3",
+              description = "",
+              activityType = ActivityType.RESTAURANT,
+              startTime = Timestamp.now(),
+              endDate = Timestamp.now(),
+              estimatedPrice = 23.25,
+              location = Location()),
+          Activity(
+              title = "Dinner4",
+              description = "",
+              activityType = ActivityType.RESTAURANT,
+              startTime = Timestamp.now(),
+              endDate = Timestamp.now(),
+              estimatedPrice = 23.25,
+              location = Location()),
+          Activity(
+              title = "Dinner5",
+              description = "",
+              activityType = ActivityType.RESTAURANT,
+              startTime = Timestamp.now(),
+              endDate = Timestamp.now(),
+              estimatedPrice = 23.25,
+              location = Location()),
+          Activity(
+              title = "Too long name to be displayed on the Activity Box",
+              description = "",
+              activityType = ActivityType.OTHER,
+              startTime = Timestamp.now(),
+              endDate = Timestamp.now(),
+              estimatedPrice = 00.00,
+              location = Location()),
+          Activity(
+              title = "Visit city",
+              description = "",
+              activityType = ActivityType.OTHER,
+              //                startTime = oneDayAfterNow,
+              //                endDate = oneDayAfterNow,
+              startTime = Timestamp.now(),
+              endDate = Timestamp.now(),
+              estimatedPrice = 00.00,
+              location = Location()))
 
   Scaffold(
       // TODO: Final implementation of ActivitiesScreen
@@ -32,9 +141,111 @@ fun ActivitiesScreen(
             selectedItem = navigationActions.currentRoute())
       },
       content = { pd ->
-        Text(
-            modifier = Modifier.padding(pd).testTag("emptyActivitiesPrompt"),
-            text =
-                "You're viewing the Activities screen for ${trip.name}, but it's not implemented yet.")
+        LazyColumn(
+            modifier =
+                Modifier.padding(pd) // Use Scaffold’s padding
+                    .padding(top = 16.dp) // Additional padding at the top
+                    .fillMaxWidth() // Fill the available width
+                    .testTag("lazyColumn"),
+            verticalArrangement = Arrangement.spacedBy(10.dp, Alignment.Top),
+        ) {
+          item { Text(text = "Drafts",               fontSize = 24.sp,
+              fontWeight = FontWeight.Bold, modifier = Modifier.padding(start = 10.dp)) }
+          finalActivities.forEach { activity ->
+            item {
+              ActivityItem(activity, onDelete = { /* Handle delete action */})
+              Spacer(modifier = Modifier.height(10.dp))
+            }
+          }
+        }
+      })
+}
+
+@Composable
+fun ActivityItem(
+    activity: Activity,
+    onDelete: (Activity) -> Unit // Callback function for delete action
+) {
+  // State to track expanded or collapsed status
+  var isExpanded by remember { mutableStateOf(false) }
+
+  // Format the start and end times
+  val timeFormat = SimpleDateFormat("h:mm a", Locale.getDefault())
+  val startTimeFormatted = timeFormat.format(activity.startTime.toDate())
+  val endTimeFormatted = timeFormat.format(activity.endDate.toDate())
+    Card(
+       shape = MaterialTheme.shapes.medium,
+      modifier = Modifier.padding(start = 10.dp, end = 10.dp)
+          .testTag("cardItem"),
+        content = {
+        Column(modifier = Modifier.padding(16.dp).fillMaxWidth()) {
+          Row(
+              horizontalArrangement = Arrangement.SpaceBetween,
+              verticalAlignment = Alignment.CenterVertically,
+              modifier = Modifier.fillMaxWidth()) {
+                Column (modifier = Modifier.weight(1f)) {
+                  Text(text = activity.title, fontWeight = FontWeight.Medium,
+                      modifier = Modifier.padding(end = 8.dp),
+                      fontSize = 16.sp)
+                  Text(
+                      text = "$startTimeFormatted - $endTimeFormatted",
+                      fontSize = 12.sp,
+                      color = Color.Gray)
+                }
+
+                Row(verticalAlignment = Alignment.CenterVertically) {
+                  // Delete icon, visible only when expanded
+                  AnimatedVisibility(visible = isExpanded) {
+                    IconButton(onClick = { onDelete(activity) }) {
+                      Icon(
+                          imageVector =
+                              Icons.TwoTone.Delete, // Use Icons.Default.Delete for trashcan
+                          contentDescription = "Delete Activity",
+                          tint = Color.Red)
+                    }
+                  }
+
+                  // Expand/collapse icon with rotation
+                  IconButton(onClick = { isExpanded = !isExpanded }) {
+                    Icon(
+                        imageVector = Icons.Default.ArrowDropDown,
+                        contentDescription = if (isExpanded) "Collapse" else "Expand",
+                        modifier = Modifier.rotate(if (isExpanded) 180f else 0f))
+                  }
+                }
+              }
+
+          // Expandable content with animation
+          AnimatedVisibility(visible = isExpanded, enter = fadeIn(), exit = fadeOut()) {
+            Column(modifier = Modifier.fillMaxWidth().padding(top = 8.dp)) {
+              Text(
+                  text = "Description",
+                  fontWeight = FontWeight.SemiBold,
+                  fontSize = 14.sp,
+                  modifier = Modifier.padding(vertical = 2.dp))
+              Text(
+                  text = activity.description,
+                  fontSize = 14.sp,
+                  modifier = Modifier.padding(bottom = 8.dp))
+
+              Text(
+                  text = "Price",
+                  fontWeight = FontWeight.SemiBold,
+                  fontSize = 14.sp,
+                  modifier = Modifier.padding(vertical = 2.dp))
+              Text(
+                  text = "${activity.estimatedPrice} CHF",
+                  fontSize = 14.sp,
+                  modifier = Modifier.padding(bottom = 8.dp))
+
+              Text(
+                  text = "Type",
+                  fontWeight = FontWeight.SemiBold,
+                  fontSize = 14.sp,
+                  modifier = Modifier.padding(vertical = 2.dp))
+              Text(text = activity.activityType.toString(), fontSize = 14.sp)
+            }
+          }
+        }
       })
 }

--- a/app/src/main/java/com/android/voyageur/ui/trip/activities/Activities.kt
+++ b/app/src/main/java/com/android/voyageur/ui/trip/activities/Activities.kt
@@ -59,23 +59,17 @@ fun ActivitiesScreen(
     navigationActions: NavigationActions,
 ) {
 
-  //    val finalActivities = trip.activities.filter { activity ->
-  //        activity.startTime != Timestamp(0, 0) && activity.endDate != Timestamp(0, 0)
-  //    }
-
-//    trip.activities = finalActivities
-
   val drafts =
-      finalActivities.filter { activity ->
+      trip.activities.filter { activity ->
         activity.startTime == Timestamp(0, 0) || activity.endDate == Timestamp(0, 0)
       }
   val final =
-      finalActivities.filter { activity ->
+      trip.activities.filter { activity ->
         activity.startTime != Timestamp(0, 0) && activity.endDate != Timestamp(0, 0)
       }
 
   Scaffold(
-      // TODO: Final implementation of ActivitiesScreen
+      // TODO: Search Bar
       modifier = Modifier.testTag("activitiesScreen"),
       bottomBar = {
         BottomNavigationMenu(
@@ -122,29 +116,25 @@ fun ActivitiesScreen(
       })
 }
 
+/**
+ * Composable that displays an activity item in a card view.
+ */
 @Composable
 fun ActivityItem(
     activity: Activity,
 ) {
-  // State to track expanded or collapsed status
   var isExpanded by remember { mutableStateOf(false) }
 
-  //  // Format the start and end times
-  //  val timeFormat = SimpleDateFormat("h:mm a", Locale.getDefault())
-  //  val startTimeFormatted = timeFormat.format(activity.startTime.toDate())
-  //  val endTimeFormatted = timeFormat.format(activity.endDate.toDate())
-  // Date and Time Formatter
   val dateFormat = SimpleDateFormat("dd/MM/yyyy", Locale.getDefault())
   val timeFormat = SimpleDateFormat("hh:mm a", Locale.getDefault())
 
-  // Formatting the Date and Time
   val dateFormatted = dateFormat.format(activity.startTime.toDate())
   val startTimeFormatted = timeFormat.format(activity.startTime.toDate())
   val endTimeFormatted = timeFormat.format(activity.endDate.toDate())
 
   Card(
       shape = MaterialTheme.shapes.medium,
-      modifier = Modifier.padding(start = 10.dp, end = 10.dp).testTag("cardItem"),
+      modifier = Modifier.padding(start = 10.dp, end = 10.dp).testTag("cardItem_${activity.title}"),
       content = {
         Column(modifier = Modifier.padding(16.dp).fillMaxWidth()) {
           Row(
@@ -171,14 +161,15 @@ fun ActivityItem(
                     IconButton(onClick = { /*TODO: delete activity*/}) {
                       Icon(
                           imageVector =
-                              Icons.TwoTone.Delete, // Use Icons.Default.Delete for trashcan
+                              Icons.TwoTone.Delete,
                           contentDescription = "Delete Activity",
                           tint = Color.Red)
                     }
                   }
 
-                  // Expand/collapse icon with rotation
-                  IconButton(onClick = { isExpanded = !isExpanded }) {
+                  // Expand/collapse icon
+                  IconButton(onClick = { isExpanded = !isExpanded },
+                      modifier = Modifier.testTag("expandIcon_${activity.title}")) {
                     Icon(
                         imageVector = Icons.Default.ArrowDropDown,
                         contentDescription = if (isExpanded) "Collapse" else "Expand",
@@ -288,8 +279,6 @@ val finalActivities =
             title = "Visit city",
             description = "",
             activityType = ActivityType.OTHER,
-            //                startTime = oneDayAfterNow,
-            //                endDate = oneDayAfterNow,
             startTime = Timestamp.now(),
             endDate = Timestamp.now(),
             estimatedPrice = 00.00,


### PR DESCRIPTION
## Summary

This feature introduces the Activities Screen for a trip. 
Here you can see all the activities for a trip, divided into 2 sections: 
1. Drafts: activities without a date set
2. Finalized: activities with a date set 
By default the activity title, date and time are visible, but you can expand the activity card to show other details such as description (if non empty), price, type.

## Changes

- **Models:** the activities field of a trip can now be changed, also added default values for activities
- **Screens/UI:** addedActivities Sreen

## Checklist

- [x] This PR resolves #99 
- [x] Tests have been added for new functionality.
- [x] Screenshots or UI changes have been attached (if applicable).
- [x] Documentation has been updated (if applicable).

##  Testing


- **Manual Testing:**

    - [x] Tested on emulator / physical device.
- **Unit Tests**
    - [x] Added units tests for this


## Screenshots (if applicable)


https://github.com/user-attachments/assets/8aabcd78-5223-40cc-9b75-dd73c62e7da0


