### PR TITLE
Feat/add activity screen

### DIFF
--- a/app/src/androidTest/java/com/android/voyageur/ui/trip/AddActivityTest.kt
+++ b/app/src/androidTest/java/com/android/voyageur/ui/trip/AddActivityTest.kt
@@ -1,0 +1,132 @@
+package com.android.voyageur.ui.trip
+
+import android.content.Context
+import android.widget.Toast
+import androidx.compose.ui.test.*
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.test.core.app.ApplicationProvider
+import com.android.voyageur.model.activity.ActivityType
+import com.android.voyageur.model.trip.TripRepository
+import com.android.voyageur.model.trip.TripsViewModel
+import com.android.voyageur.ui.navigation.NavigationActions
+import com.android.voyageur.ui.navigation.Screen
+import io.mockk.*
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.mockito.Mockito
+import org.mockito.Mockito.mock
+import org.mockito.Mockito.`when`
+import org.mockito.kotlin.any
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.whenever
+import java.util.*
+
+class AddActivityScreenTest {
+
+    private lateinit var tripRepository: TripRepository
+    private lateinit var navigationActions: NavigationActions
+    private lateinit var tripsViewModel: TripsViewModel
+    private lateinit var context: Context
+
+
+    @get:Rule val composeTestRule = createComposeRule()
+
+    @Before
+    fun setUp() {
+        tripRepository = mock(TripRepository::class.java)
+        navigationActions = mock(NavigationActions::class.java)
+        tripsViewModel = TripsViewModel(tripRepository)
+        context = ApplicationProvider.getApplicationContext()
+
+        `when`(navigationActions.currentRoute()).thenReturn(Screen.ADD_ACTIVITY)
+
+        mockkStatic(Toast::class)
+        every { Toast.makeText(any(), any<String>(), any()) } returns mockk()
+    }
+
+    @Test
+    fun addActivityScreen_initialState() {
+        composeTestRule.setContent {
+            AddActivityScreen(tripsViewModel, navigationActions)
+        }
+
+        composeTestRule.onNodeWithTag("addActivityTitle").assertTextEquals("Create a New Activity")
+        composeTestRule.onNodeWithTag("inputActivityTitle").assertIsDisplayed()
+        composeTestRule.onNodeWithTag("inputActivityDescription").assertIsDisplayed()
+        composeTestRule.onNodeWithTag("inputActivityLocation").assertIsDisplayed()
+        composeTestRule.onNodeWithTag("inputDate").assertIsDisplayed()
+        composeTestRule.onNodeWithTag("inputStartTime").assertIsDisplayed()
+        composeTestRule.onNodeWithTag("inputEndTime").assertIsDisplayed()
+        composeTestRule.onNodeWithTag("inputActivityPrice").assertIsDisplayed()
+        composeTestRule.onNodeWithTag("inputActivityType").assertIsDisplayed()
+        composeTestRule.onNodeWithTag("activitySave").assertIsDisplayed()
+    }
+
+    @Test
+    fun addActivityScreen_datePickerSelectsDate() {
+        composeTestRule.setContent {
+            AddActivityScreen(tripsViewModel, navigationActions)
+        }
+
+        composeTestRule.onNodeWithTag("inputDate").performClick()
+        composeTestRule.onNodeWithText("OK").performClick()
+        composeTestRule.onNodeWithTag("inputDate").assertIsDisplayed()
+    }
+
+    @Test
+    fun addActivityScreen_timePickerSelectsTime() {
+        composeTestRule.setContent {
+            AddActivityScreen(tripsViewModel, navigationActions)
+        }
+
+        composeTestRule.onNodeWithTag("inputStartTime").performClick()
+        composeTestRule.onNodeWithText("OK").performClick()
+        composeTestRule.onNodeWithTag("inputEndTime").performClick()
+        composeTestRule.onNodeWithText("OK").performClick()
+    }
+
+    @Test
+    fun addActivityScreen_selectActivityType() {
+        composeTestRule.setContent {
+            AddActivityScreen(tripsViewModel, navigationActions)
+        }
+
+        composeTestRule.onNodeWithTag("inputActivityType").assertHasClickAction()
+        composeTestRule.onNodeWithTag("inputActivityType").performClick()
+    }
+
+    @Test
+    fun addActivityScreen_saveButtonDisabledIfTitleEmpty() {
+        composeTestRule.setContent {
+            AddActivityScreen(tripsViewModel, navigationActions)
+        }
+
+        composeTestRule.onNodeWithTag("activitySave").assertIsNotEnabled()
+    }
+
+    @Test
+    fun addActivityScreen_saveButtonEnabledIfTitleNonEmpty() {
+        composeTestRule.setContent {
+            AddActivityScreen(tripsViewModel, navigationActions)
+        }
+
+        composeTestRule.onNodeWithTag("inputActivityTitle").performTextInput("Hiking")
+        composeTestRule.onNodeWithTag("activitySave").assertIsEnabled()
+    }
+
+//    @Test
+//    fun addActivityScreen_validActivityCreatedAndNavigateBack() {
+//        composeTestRule.setContent {
+//            AddActivityScreen(tripsViewModel, navigationActions)
+//        }
+//
+//        composeTestRule.onNodeWithTag("inputActivityTitle").performTextInput("Hiking")
+//        composeTestRule.onNodeWithTag("inputDate").performClick()
+//        composeTestRule.onNodeWithText("OK").performClick()
+//        composeTestRule.onNodeWithTag("activitySave").performClick()
+//
+//        Mockito.verify(tripRepository).updateTrip(any(), any(), any())
+//        Mockito.verify(navigationActions).goBack()
+//    }
+}

--- a/app/src/androidTest/java/com/android/voyageur/ui/trip/AddActivityTest.kt
+++ b/app/src/androidTest/java/com/android/voyageur/ui/trip/AddActivityTest.kt
@@ -5,128 +5,111 @@ import android.widget.Toast
 import androidx.compose.ui.test.*
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.test.core.app.ApplicationProvider
-import com.android.voyageur.model.activity.ActivityType
 import com.android.voyageur.model.trip.TripRepository
 import com.android.voyageur.model.trip.TripsViewModel
 import com.android.voyageur.ui.navigation.NavigationActions
 import com.android.voyageur.ui.navigation.Screen
 import io.mockk.*
+import java.util.*
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
-import org.mockito.Mockito
 import org.mockito.Mockito.mock
 import org.mockito.Mockito.`when`
 import org.mockito.kotlin.any
-import org.mockito.kotlin.eq
-import org.mockito.kotlin.whenever
-import java.util.*
 
 class AddActivityScreenTest {
 
-    private lateinit var tripRepository: TripRepository
-    private lateinit var navigationActions: NavigationActions
-    private lateinit var tripsViewModel: TripsViewModel
-    private lateinit var context: Context
+  private lateinit var tripRepository: TripRepository
+  private lateinit var navigationActions: NavigationActions
+  private lateinit var tripsViewModel: TripsViewModel
+  private lateinit var context: Context
 
+  @get:Rule val composeTestRule = createComposeRule()
 
-    @get:Rule val composeTestRule = createComposeRule()
+  @Before
+  fun setUp() {
+    tripRepository = mock(TripRepository::class.java)
+    navigationActions = mock(NavigationActions::class.java)
+    tripsViewModel = TripsViewModel(tripRepository)
+    context = ApplicationProvider.getApplicationContext()
 
-    @Before
-    fun setUp() {
-        tripRepository = mock(TripRepository::class.java)
-        navigationActions = mock(NavigationActions::class.java)
-        tripsViewModel = TripsViewModel(tripRepository)
-        context = ApplicationProvider.getApplicationContext()
+    `when`(navigationActions.currentRoute()).thenReturn(Screen.ADD_ACTIVITY)
 
-        `when`(navigationActions.currentRoute()).thenReturn(Screen.ADD_ACTIVITY)
+    mockkStatic(Toast::class)
+    every { Toast.makeText(any(), any<String>(), any()) } returns mockk()
+  }
 
-        mockkStatic(Toast::class)
-        every { Toast.makeText(any(), any<String>(), any()) } returns mockk()
-    }
+  @Test
+  fun addActivityScreen_initialState() {
+    composeTestRule.setContent { AddActivityScreen(tripsViewModel, navigationActions) }
 
-    @Test
-    fun addActivityScreen_initialState() {
-        composeTestRule.setContent {
-            AddActivityScreen(tripsViewModel, navigationActions)
-        }
+    composeTestRule.onNodeWithTag("addActivityTitle").assertTextEquals("Create a New Activity")
+    composeTestRule.onNodeWithTag("inputActivityTitle").assertIsDisplayed()
+    composeTestRule.onNodeWithTag("inputActivityDescription").assertIsDisplayed()
+    composeTestRule.onNodeWithTag("inputActivityLocation").assertIsDisplayed()
+    composeTestRule.onNodeWithTag("inputDate").assertIsDisplayed()
+    composeTestRule.onNodeWithTag("inputStartTime").assertIsDisplayed()
+    composeTestRule.onNodeWithTag("inputEndTime").assertIsDisplayed()
+    composeTestRule.onNodeWithTag("inputActivityPrice").assertIsDisplayed()
+    composeTestRule.onNodeWithTag("inputActivityType").assertIsDisplayed()
+    composeTestRule.onNodeWithTag("activitySave").assertIsDisplayed()
+  }
 
-        composeTestRule.onNodeWithTag("addActivityTitle").assertTextEquals("Create a New Activity")
-        composeTestRule.onNodeWithTag("inputActivityTitle").assertIsDisplayed()
-        composeTestRule.onNodeWithTag("inputActivityDescription").assertIsDisplayed()
-        composeTestRule.onNodeWithTag("inputActivityLocation").assertIsDisplayed()
-        composeTestRule.onNodeWithTag("inputDate").assertIsDisplayed()
-        composeTestRule.onNodeWithTag("inputStartTime").assertIsDisplayed()
-        composeTestRule.onNodeWithTag("inputEndTime").assertIsDisplayed()
-        composeTestRule.onNodeWithTag("inputActivityPrice").assertIsDisplayed()
-        composeTestRule.onNodeWithTag("inputActivityType").assertIsDisplayed()
-        composeTestRule.onNodeWithTag("activitySave").assertIsDisplayed()
-    }
+  @Test
+  fun addActivityScreen_datePickerSelectsDate() {
+    composeTestRule.setContent { AddActivityScreen(tripsViewModel, navigationActions) }
 
-    @Test
-    fun addActivityScreen_datePickerSelectsDate() {
-        composeTestRule.setContent {
-            AddActivityScreen(tripsViewModel, navigationActions)
-        }
+    composeTestRule.onNodeWithTag("inputDate").performClick()
+    composeTestRule.onNodeWithText("OK").performClick()
+    composeTestRule.onNodeWithTag("inputDate").assertIsDisplayed()
+  }
 
-        composeTestRule.onNodeWithTag("inputDate").performClick()
-        composeTestRule.onNodeWithText("OK").performClick()
-        composeTestRule.onNodeWithTag("inputDate").assertIsDisplayed()
-    }
+  @Test
+  fun addActivityScreen_timePickerSelectsTime() {
+    composeTestRule.setContent { AddActivityScreen(tripsViewModel, navigationActions) }
 
-    @Test
-    fun addActivityScreen_timePickerSelectsTime() {
-        composeTestRule.setContent {
-            AddActivityScreen(tripsViewModel, navigationActions)
-        }
+    composeTestRule.onNodeWithTag("inputStartTime").performClick()
+    composeTestRule.onNodeWithText("OK").performClick()
+    composeTestRule.onNodeWithTag("inputEndTime").performClick()
+    composeTestRule.onNodeWithText("OK").performClick()
+  }
 
-        composeTestRule.onNodeWithTag("inputStartTime").performClick()
-        composeTestRule.onNodeWithText("OK").performClick()
-        composeTestRule.onNodeWithTag("inputEndTime").performClick()
-        composeTestRule.onNodeWithText("OK").performClick()
-    }
+  @Test
+  fun addActivityScreen_selectActivityType() {
+    composeTestRule.setContent { AddActivityScreen(tripsViewModel, navigationActions) }
 
-    @Test
-    fun addActivityScreen_selectActivityType() {
-        composeTestRule.setContent {
-            AddActivityScreen(tripsViewModel, navigationActions)
-        }
+    composeTestRule.onNodeWithTag("inputActivityType").assertHasClickAction()
+    composeTestRule.onNodeWithTag("inputActivityType").performClick()
+  }
 
-        composeTestRule.onNodeWithTag("inputActivityType").assertHasClickAction()
-        composeTestRule.onNodeWithTag("inputActivityType").performClick()
-    }
+  @Test
+  fun addActivityScreen_saveButtonDisabledIfTitleEmpty() {
+    composeTestRule.setContent { AddActivityScreen(tripsViewModel, navigationActions) }
 
-    @Test
-    fun addActivityScreen_saveButtonDisabledIfTitleEmpty() {
-        composeTestRule.setContent {
-            AddActivityScreen(tripsViewModel, navigationActions)
-        }
+    composeTestRule.onNodeWithTag("activitySave").assertIsNotEnabled()
+  }
 
-        composeTestRule.onNodeWithTag("activitySave").assertIsNotEnabled()
-    }
+  @Test
+  fun addActivityScreen_saveButtonEnabledIfTitleNonEmpty() {
+    composeTestRule.setContent { AddActivityScreen(tripsViewModel, navigationActions) }
 
-    @Test
-    fun addActivityScreen_saveButtonEnabledIfTitleNonEmpty() {
-        composeTestRule.setContent {
-            AddActivityScreen(tripsViewModel, navigationActions)
-        }
+    composeTestRule.onNodeWithTag("inputActivityTitle").performTextInput("Hiking")
+    composeTestRule.onNodeWithTag("activitySave").assertIsEnabled()
+  }
 
-        composeTestRule.onNodeWithTag("inputActivityTitle").performTextInput("Hiking")
-        composeTestRule.onNodeWithTag("activitySave").assertIsEnabled()
-    }
-
-//    @Test
-//    fun addActivityScreen_validActivityCreatedAndNavigateBack() {
-//        composeTestRule.setContent {
-//            AddActivityScreen(tripsViewModel, navigationActions)
-//        }
-//
-//        composeTestRule.onNodeWithTag("inputActivityTitle").performTextInput("Hiking")
-//        composeTestRule.onNodeWithTag("inputDate").performClick()
-//        composeTestRule.onNodeWithText("OK").performClick()
-//        composeTestRule.onNodeWithTag("activitySave").performClick()
-//
-//        Mockito.verify(tripRepository).updateTrip(any(), any(), any())
-//        Mockito.verify(navigationActions).goBack()
-//    }
+  //    @Test
+  //    fun addActivityScreen_validActivityCreatedAndNavigateBack() {
+  //        composeTestRule.setContent {
+  //            AddActivityScreen(tripsViewModel, navigationActions)
+  //        }
+  //
+  //        composeTestRule.onNodeWithTag("inputActivityTitle").performTextInput("Hiking")
+  //        composeTestRule.onNodeWithTag("inputDate").performClick()
+  //        composeTestRule.onNodeWithText("OK").performClick()
+  //        composeTestRule.onNodeWithTag("activitySave").performClick()
+  //
+  //        Mockito.verify(tripRepository).updateTrip(any(), any(), any())
+  //        Mockito.verify(navigationActions).goBack()
+  //    }
 }

--- a/app/src/androidTest/java/com/android/voyageur/ui/trip/activities/ActivitiesScreenTest.kt
+++ b/app/src/androidTest/java/com/android/voyageur/ui/trip/activities/ActivitiesScreenTest.kt
@@ -32,7 +32,7 @@ class ActivitiesScreenTest {
                       title = "Final Activity",
                       description = "This is a final activity",
                       startTime = Timestamp.now(),
-                      endDate = Timestamp.now(),
+                      endTime = Timestamp.now(),
                       estimatedPrice = 20.0,
                       activityType = ActivityType.RESTAURANT)))
 

--- a/app/src/main/java/com/android/voyageur/App.kt
+++ b/app/src/main/java/com/android/voyageur/App.kt
@@ -18,6 +18,7 @@ import com.android.voyageur.ui.overview.OverviewScreen
 import com.android.voyageur.ui.profile.EditProfileScreen
 import com.android.voyageur.ui.profile.ProfileScreen
 import com.android.voyageur.ui.search.SearchScreen
+import com.android.voyageur.ui.trip.AddActivityScreen
 import com.android.voyageur.ui.trip.TopTabs
 import com.google.android.libraries.places.api.net.PlacesClient
 
@@ -60,6 +61,7 @@ fun VoyageurApp(placesClient: PlacesClient) {
 
     navigation(startDestination = Screen.TOP_TABS, route = Route.TOP_TABS) {
       composable(Screen.TOP_TABS) { TopTabs(tripsViewModel, navigationActions) }
+      composable(Screen.ADD_ACTIVITY) { AddActivityScreen(tripsViewModel, navigationActions) }
     }
   }
 }

--- a/app/src/main/java/com/android/voyageur/model/activity/Activity.kt
+++ b/app/src/main/java/com/android/voyageur/model/activity/Activity.kt
@@ -2,15 +2,16 @@ package com.android.voyageur.model.activity
 
 import com.android.voyageur.model.location.Location
 import com.google.firebase.Timestamp
+import java.util.Date
 
 data class Activity(
-    val title: String,
-    val description: String,
-    val location: Location,
-    val startTime: Timestamp,
-    val endTime: Timestamp,
-    val estimatedPrice: Number,
-    val activityType: ActivityType,
+    val title: String = "",
+    val description: String = "",
+    val location: Location = Location(""),
+    val startTime: Timestamp = Timestamp.now(),
+    val endTime: Timestamp = Timestamp.now(),
+    val estimatedPrice: Double = 0.0,
+    val activityType: ActivityType = ActivityType.WALK,
 )
 
 enum class ActivityType {

--- a/app/src/main/java/com/android/voyageur/model/activity/Activity.kt
+++ b/app/src/main/java/com/android/voyageur/model/activity/Activity.kt
@@ -7,8 +7,8 @@ data class Activity(
     val title: String = "",
     val description: String = "",
     val location: Location = Location(""),
-    val startTime: Timestamp = Timestamp.now(),
-    val endTime: Timestamp = Timestamp.now(),
+    val startTime: Timestamp = Timestamp(0, 0),
+    val endTime: Timestamp = Timestamp(0, 0),
     val estimatedPrice: Double = 0.0,
     val activityType: ActivityType = ActivityType.WALK,
 )

--- a/app/src/main/java/com/android/voyageur/model/activity/Activity.kt
+++ b/app/src/main/java/com/android/voyageur/model/activity/Activity.kt
@@ -27,4 +27,4 @@ fun Activity.hasDescription() = description != ""
 
 fun Activity.hasStartTime() = startTime != Timestamp(0, 0)
 
-fun Activity.hasEndDate() = endDate != Timestamp(0, 0)
+fun Activity.hasEndDate() = endTime != Timestamp(0, 0)

--- a/app/src/main/java/com/android/voyageur/model/activity/Activity.kt
+++ b/app/src/main/java/com/android/voyageur/model/activity/Activity.kt
@@ -2,7 +2,6 @@ package com.android.voyageur.model.activity
 
 import com.android.voyageur.model.location.Location
 import com.google.firebase.Timestamp
-import java.util.Date
 
 data class Activity(
     val title: String = "",

--- a/app/src/main/java/com/android/voyageur/model/activity/Activity.kt
+++ b/app/src/main/java/com/android/voyageur/model/activity/Activity.kt
@@ -8,7 +8,7 @@ data class Activity(
     val description: String,
     val location: Location,
     val startTime: Timestamp,
-    val endDate: Timestamp,
+    val endTime: Timestamp,
     val estimatedPrice: Number,
     val activityType: ActivityType,
 )

--- a/app/src/main/java/com/android/voyageur/ui/navigation/NavigationActions.kt
+++ b/app/src/main/java/com/android/voyageur/ui/navigation/NavigationActions.kt
@@ -27,7 +27,7 @@ object Screen {
   const val BY_DAY = "By Day Screen"
   const val BY_WEEK = "By Week Screen" // TODO: Add ByWeek screen
   const val ACTIVITIES = "Activities Screen"
-  const val ADD_ACTIVITY = "Add Activity Screen" // TODO: Add AddActivity screen
+  const val ADD_ACTIVITY = "Add Activity Screen"
   const val SETTINGS = "Settings Screen"
   const val TOP_TABS = "Top Tabs Screen"
 }

--- a/app/src/main/java/com/android/voyageur/ui/trip/AddActivity.kt
+++ b/app/src/main/java/com/android/voyageur/ui/trip/AddActivity.kt
@@ -44,7 +44,7 @@ fun AddActivityScreen(tripsViewModel: TripsViewModel, navigationActions: Navigat
   var selectedTimeField by remember { mutableStateOf<TimeField?>(null) }
   var startTime by remember { mutableStateOf<Long?>(null) }
   var endTime by remember { mutableStateOf<Long?>(null) }
-  var estimatedPrice by remember { mutableStateOf<Number>(0) }
+  var estimatedPrice by remember { mutableStateOf<Double>(0.0) }
   var activityType by remember { mutableStateOf(ActivityType.WALK) }
   var expanded by remember { mutableStateOf(false) }
 
@@ -298,7 +298,7 @@ fun AddActivityScreen(tripsViewModel: TripsViewModel, navigationActions: Navigat
                     value = estimatedPrice.toString(),
                     onValueChange = { input ->
                       val newValue = input.replace("[^0-9.]".toRegex(), "")
-                      estimatedPrice = newValue.toDoubleOrNull() ?: 0.0
+                      estimatedPrice = newValue.toDouble()
                     },
                     label = { Text("Estimated Price (CHF)") },
                     placeholder = { Text("Enter estimated price") },

--- a/app/src/main/java/com/android/voyageur/ui/trip/AddActivity.kt
+++ b/app/src/main/java/com/android/voyageur/ui/trip/AddActivity.kt
@@ -77,9 +77,9 @@ fun AddActivityScreen(tripsViewModel: TripsViewModel, navigationActions: Navigat
     }
 
     val today = normalizeToMidnight(Date())
-    val dateNormalized = normalizeToMidnight(Date(activityDate!!))
+    val dateNormalized = activityDate?.let { normalizeToMidnight(Date(it)) } ?: Date(0)
 
-    if (dateNormalized.before(today)) {
+    if (activityDate != null && dateNormalized.before(today)) {
       Toast.makeText(context, "The activity date cannot be in the past", Toast.LENGTH_SHORT).show()
       return
     }
@@ -101,7 +101,7 @@ fun AddActivityScreen(tripsViewModel: TripsViewModel, navigationActions: Navigat
                   }
                   .time
             }
-            ?.let { Timestamp(it) } ?: Timestamp(Date())
+            ?.let { Timestamp(it) } ?: Timestamp(0, 0)
 
     val endTimestamp =
         endTime
@@ -120,9 +120,11 @@ fun AddActivityScreen(tripsViewModel: TripsViewModel, navigationActions: Navigat
                   }
                   .time
             }
-            ?.let { Timestamp(it) } ?: Timestamp(Date())
+            ?.let { Timestamp(it) } ?: Timestamp(0, 0)
 
-    if (endTimestamp.toDate().before(startTimestamp.toDate())) {
+    if (startTime != null &&
+        endTime != null &&
+        endTimestamp.toDate().before(startTimestamp.toDate())) {
       Toast.makeText(context, "End time must be after start time", Toast.LENGTH_SHORT).show()
       return
     }

--- a/app/src/main/java/com/android/voyageur/ui/trip/AddActivity.kt
+++ b/app/src/main/java/com/android/voyageur/ui/trip/AddActivity.kt
@@ -23,6 +23,7 @@ import androidx.compose.ui.window.Dialog
 import com.android.voyageur.model.activity.Activity
 import com.android.voyageur.model.activity.ActivityType
 import com.android.voyageur.model.location.Location
+import com.android.voyageur.model.trip.Trip
 import com.android.voyageur.model.trip.TripsViewModel
 import com.android.voyageur.ui.navigation.NavigationActions
 import com.google.firebase.Timestamp
@@ -138,9 +139,17 @@ fun AddActivityScreen(tripsViewModel: TripsViewModel, navigationActions: Navigat
 
     val selectedTrip = tripsViewModel.selectedTrip.value!!
     val updatedTrip = selectedTrip.copy(activities = selectedTrip.activities + activity)
-    tripsViewModel.updateTrip(updatedTrip)
-
-    navigationActions.goBack()
+    tripsViewModel.updateTrip(
+        updatedTrip,
+        onSuccess = {
+          /*
+              This is a trick to force a recompose, because the reference wouldn't
+              change and update the UI.
+          */
+          tripsViewModel.selectTrip(Trip())
+          tripsViewModel.selectTrip(updatedTrip)
+          navigationActions.goBack()
+        })
   }
 
   Scaffold(

--- a/app/src/main/java/com/android/voyageur/ui/trip/AddActivity.kt
+++ b/app/src/main/java/com/android/voyageur/ui/trip/AddActivity.kt
@@ -1,0 +1,420 @@
+package com.android.voyageur.ui.trip
+
+import android.annotation.SuppressLint
+import android.widget.Toast
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.outlined.ArrowBack
+import androidx.compose.material3.*
+import androidx.compose.material3.TextFieldDefaults
+import androidx.compose.runtime.*
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.window.Dialog
+import com.android.voyageur.model.activity.Activity
+import com.android.voyageur.model.activity.ActivityType
+import com.android.voyageur.model.location.Location
+import com.android.voyageur.model.trip.TripsViewModel
+import com.android.voyageur.ui.navigation.NavigationActions
+import com.google.firebase.Timestamp
+import java.text.SimpleDateFormat
+import java.util.Calendar
+import java.util.Date
+import java.util.Locale
+
+@SuppressLint("StateFlowValueCalledInComposition")
+@OptIn(ExperimentalMaterial3Api::class, ExperimentalLayoutApi::class)
+@Composable
+fun AddActivityScreen(tripsViewModel: TripsViewModel, navigationActions: NavigationActions) {
+  var title by remember { mutableStateOf("") }
+  var description by remember { mutableStateOf("") }
+  var location by remember { mutableStateOf("") }
+  var showModal by remember { mutableStateOf(false) }
+  var activityDate by remember { mutableStateOf<Long?>(null) }
+  var showTime by remember { mutableStateOf(false) }
+  var selectedTimeField by remember { mutableStateOf<TimeField?>(null) }
+  var startTime by remember { mutableStateOf<Long?>(null) }
+  var endTime by remember { mutableStateOf<Long?>(null) }
+  var estimatedPrice by remember { mutableStateOf<Number>(0) }
+  var activityType by remember { mutableStateOf(ActivityType.WALK) }
+  var expanded by remember { mutableStateOf(false) }
+
+  val context = LocalContext.current
+
+  val dateFormat = SimpleDateFormat("dd MMM yyyy", Locale.getDefault())
+  val formattedDate = activityDate?.let { dateFormat.format(Date(it)) } ?: ""
+
+  val timeFormat = SimpleDateFormat("HH:mm", Locale.getDefault())
+  var formattedStartTime = startTime?.let { timeFormat.format(Date(it)) } ?: ""
+  var formattedEndTime = endTime?.let { timeFormat.format(Date(it)) } ?: ""
+
+  fun createActivity() {
+    if (activityDate == null && (startTime != null || endTime != null)) {
+      Toast.makeText(context, "Please select an activity date first", Toast.LENGTH_SHORT).show()
+      return
+    }
+
+    fun normalizeToMidnight(date: Date): Date {
+      val calendar =
+          Calendar.getInstance().apply {
+            time = date
+            set(Calendar.HOUR_OF_DAY, 0)
+            set(Calendar.MINUTE, 0)
+            set(Calendar.SECOND, 0)
+            set(Calendar.MILLISECOND, 0)
+          }
+      return calendar.time
+    }
+
+    val today = normalizeToMidnight(Date())
+    val dateNormalized = normalizeToMidnight(Date(activityDate!!))
+
+    if (dateNormalized.before(today)) {
+      Toast.makeText(context, "The activity date cannot be in the past", Toast.LENGTH_SHORT).show()
+      return
+    }
+
+    val startTimestamp =
+        startTime
+            ?.let {
+              Calendar.getInstance()
+                  .apply {
+                    time = dateNormalized
+                    set(
+                        Calendar.HOUR_OF_DAY,
+                        Calendar.getInstance()
+                            .apply { timeInMillis = it }
+                            .get(Calendar.HOUR_OF_DAY))
+                    set(
+                        Calendar.MINUTE,
+                        Calendar.getInstance().apply { timeInMillis = it }.get(Calendar.MINUTE))
+                  }
+                  .time
+            }
+            ?.let { Timestamp(it) } ?: Timestamp(Date())
+
+    val endTimestamp =
+        endTime
+            ?.let {
+              Calendar.getInstance()
+                  .apply {
+                    time = dateNormalized
+                    set(
+                        Calendar.HOUR_OF_DAY,
+                        Calendar.getInstance()
+                            .apply { timeInMillis = it }
+                            .get(Calendar.HOUR_OF_DAY))
+                    set(
+                        Calendar.MINUTE,
+                        Calendar.getInstance().apply { timeInMillis = it }.get(Calendar.MINUTE))
+                  }
+                  .time
+            }
+            ?.let { Timestamp(it) } ?: Timestamp(Date())
+
+    if (endTimestamp.toDate().before(startTimestamp.toDate())) {
+      Toast.makeText(context, "End time must be after start time", Toast.LENGTH_SHORT).show()
+      return
+    }
+
+    val activity =
+        Activity(
+            title = title,
+            description = description,
+            location = Location(country = "Unknown", city = "Unknown", county = null, zip = null),
+            startTime = startTimestamp,
+            endTime = endTimestamp,
+            estimatedPrice = estimatedPrice,
+            activityType = activityType)
+
+    val selectedTrip = tripsViewModel.selectedTrip.value!!
+    val updatedTrip = selectedTrip.copy(activities = selectedTrip.activities + activity)
+    tripsViewModel.updateTrip(updatedTrip)
+
+    navigationActions.goBack()
+  }
+
+  Scaffold(
+      modifier = Modifier.testTag("addActivity"),
+      topBar = {
+        TopAppBar(
+            title = { Text("Create a New Activity", Modifier.testTag("addActivityTitle")) },
+            navigationIcon = {
+              IconButton(
+                  onClick = { navigationActions.goBack() }, Modifier.testTag("goBackButton")) {
+                    Icon(
+                        imageVector = Icons.AutoMirrored.Outlined.ArrowBack,
+                        contentDescription = "Back",
+                    )
+                  }
+            })
+      }) { paddingValues ->
+        Column(modifier = Modifier.fillMaxSize().padding(paddingValues)) {
+          Column(
+              modifier = Modifier.weight(1f).verticalScroll(rememberScrollState()).padding(16.dp),
+              verticalArrangement = Arrangement.spacedBy(8.dp)) {
+                OutlinedTextField(
+                    value = title,
+                    onValueChange = { title = it },
+                    isError = title.isEmpty(),
+                    label = { Text("Title *") },
+                    placeholder = { Text("Name the activity") },
+                    modifier = Modifier.fillMaxWidth().testTag("inputActivityTitle"))
+
+                OutlinedTextField(
+                    value = description,
+                    onValueChange = { description = it },
+                    label = { Text("Description") },
+                    placeholder = { Text("Describe the activity") },
+                    modifier = Modifier.fillMaxWidth().testTag("inputActivityDescription"))
+
+                OutlinedTextField(
+                    value = location,
+                    onValueChange = { location = it },
+                    label = { Text("Location") },
+                    placeholder = { Text("Enter the location of the activity") },
+                    modifier = Modifier.fillMaxWidth().testTag("inputActivityLocation"))
+
+                OutlinedTextField(
+                    value = formattedDate,
+                    onValueChange = {},
+                    readOnly = true,
+                    enabled = false,
+                    label = { Text("Date") },
+                    colors =
+                        TextFieldDefaults.colors(
+                            disabledContainerColor = Color.Transparent,
+                            disabledTextColor = Color.Black),
+                    modifier =
+                        Modifier.fillMaxWidth().testTag("inputDate").clickable { showModal = true })
+
+                if (showModal) {
+                  DatePickerModal(
+                      onDateSelected = { selectedDate ->
+                        activityDate = selectedDate
+                        showModal = false
+                      },
+                      onDismiss = { showModal = false })
+                }
+
+                FlowRow(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.SpaceBetween,
+                ) {
+                  OutlinedTextField(
+                      value = formattedStartTime,
+                      onValueChange = {},
+                      readOnly = true,
+                      enabled = false,
+                      label = { Text("Start Time") },
+                      colors =
+                          TextFieldDefaults.colors(
+                              disabledContainerColor = Color.Transparent,
+                              disabledTextColor = Color.Black),
+                      modifier =
+                          Modifier.fillMaxWidth(0.49f).testTag("inputStartTime").clickable {
+                            selectedTimeField = TimeField.START
+                            showTime = true
+                          })
+
+                  OutlinedTextField(
+                      value = formattedEndTime,
+                      onValueChange = {},
+                      readOnly = true,
+                      enabled = false,
+                      label = { Text("End Time") },
+                      colors =
+                          TextFieldDefaults.colors(
+                              disabledContainerColor = Color.Transparent,
+                              disabledTextColor = Color.Black),
+                      modifier =
+                          Modifier.fillMaxWidth(0.49f).testTag("inputEndTime").clickable {
+                            selectedTimeField = TimeField.END
+                            showTime = true
+                          })
+                }
+
+                if (showTime) {
+                  Dialog(onDismissRequest = { showTime = false }) {
+                    TimePickerInput(
+                        initialHour =
+                            when (selectedTimeField) {
+                              TimeField.START ->
+                                  startTime?.let {
+                                    Calendar.getInstance()
+                                        .apply { timeInMillis = it }
+                                        .get(Calendar.HOUR_OF_DAY)
+                                  }
+                              TimeField.END ->
+                                  endTime?.let {
+                                    Calendar.getInstance()
+                                        .apply { timeInMillis = it }
+                                        .get(Calendar.HOUR_OF_DAY)
+                                  }
+                              else -> null
+                            },
+                        initialMinute =
+                            when (selectedTimeField) {
+                              TimeField.START ->
+                                  startTime?.let {
+                                    Calendar.getInstance()
+                                        .apply { timeInMillis = it }
+                                        .get(Calendar.MINUTE)
+                                  }
+                              TimeField.END ->
+                                  endTime?.let {
+                                    Calendar.getInstance()
+                                        .apply { timeInMillis = it }
+                                        .get(Calendar.MINUTE)
+                                  }
+                              else -> null
+                            },
+                        onTimeSelected = { selectedTime ->
+                          if (selectedTime != null) {
+                            if (selectedTimeField == TimeField.START) {
+                              startTime = selectedTime
+                              formattedStartTime = timeFormat.format(Date(startTime!!))
+                            } else {
+                              endTime = selectedTime
+                              formattedEndTime = timeFormat.format(Date(endTime!!))
+                            }
+                          }
+                          showTime = false
+                        },
+                        onDismiss = { showTime = false })
+                  }
+                }
+
+                OutlinedTextField(
+                    value = estimatedPrice.toString(),
+                    onValueChange = { input ->
+                      val newValue = input.replace("[^0-9.]".toRegex(), "")
+                      estimatedPrice = newValue.toDoubleOrNull() ?: 0.0
+                    },
+                    label = { Text("Estimated Price (CHF)") },
+                    placeholder = { Text("Enter estimated price") },
+                    keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
+                    modifier = Modifier.fillMaxWidth().testTag("inputActivityPrice"))
+
+                Spacer(modifier = Modifier.height(8.dp))
+
+                ExposedDropdownMenuBox(
+                    expanded = expanded, onExpandedChange = { expanded = !expanded }) {
+                      TextField(
+                          value = activityType.name,
+                          onValueChange = {},
+                          readOnly = true,
+                          label = { Text("Select Activity Type") },
+                          trailingIcon = {
+                            ExposedDropdownMenuDefaults.TrailingIcon(expanded = expanded)
+                          },
+                          modifier =
+                              Modifier.fillMaxWidth().menuAnchor().testTag("inputActivityType"))
+                      ExposedDropdownMenu(
+                          expanded = expanded, onDismissRequest = { expanded = false }) {
+                            ActivityType.entries.forEach { type ->
+                              DropdownMenuItem(
+                                  text = { Text(text = type.name) },
+                                  onClick = {
+                                    activityType = type
+                                    expanded = false
+                                  })
+                            }
+                          }
+                    }
+
+                Spacer(modifier = Modifier.height(16.dp))
+              }
+
+          Button(
+              onClick = { createActivity() },
+              enabled = title.isNotBlank(),
+              modifier = Modifier.fillMaxWidth().padding(16.dp).testTag("activitySave")) {
+                Text("Save")
+              }
+        }
+      }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun DatePickerModal(onDateSelected: (Long?) -> Unit, onDismiss: () -> Unit) {
+  val datePickerState = rememberDatePickerState()
+
+  DatePickerDialog(
+      onDismissRequest = onDismiss,
+      confirmButton = {
+        TextButton(
+            onClick = {
+              onDateSelected(datePickerState.selectedDateMillis)
+              onDismiss()
+            }) {
+              Text("OK")
+            }
+      },
+      dismissButton = { TextButton(onClick = onDismiss) { Text("Cancel") } }) {
+        DatePicker(state = datePickerState)
+      }
+}
+
+enum class TimeField {
+  START,
+  END
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun TimePickerInput(
+    initialHour: Int?,
+    initialMinute: Int?,
+    onTimeSelected: (Long?) -> Unit,
+    onDismiss: () -> Unit
+) {
+  val timeState = rememberTimePickerState(is24Hour = true)
+
+  if (initialHour != null && initialMinute != null) {
+    timeState.hour = initialHour
+    timeState.minute = initialMinute
+  }
+
+  Dialog(onDismissRequest = onDismiss) {
+    Surface(
+        shape = MaterialTheme.shapes.extraLarge,
+        tonalElevation = 10.dp,
+        modifier = Modifier.padding(16.dp)) {
+          Column(modifier = Modifier.padding(16.dp)) {
+            Text(
+                modifier = Modifier.fillMaxWidth().padding(bottom = 16.dp),
+                text = "Select time",
+                textAlign = TextAlign.Center,
+                style = MaterialTheme.typography.headlineMedium)
+            TimeInput(state = timeState)
+            Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.End) {
+              TextButton(onClick = onDismiss) { Text(text = "Cancel") }
+              TextButton(
+                  onClick = {
+                    val selectedTime =
+                        Calendar.getInstance()
+                            .apply {
+                              set(Calendar.HOUR_OF_DAY, timeState.hour)
+                              set(Calendar.MINUTE, timeState.minute)
+                            }
+                            .timeInMillis
+                    onTimeSelected(selectedTime)
+                  }) {
+                    Text(text = "OK")
+                  }
+            }
+          }
+        }
+  }
+}

--- a/app/src/main/java/com/android/voyageur/ui/trip/activities/Activities.kt
+++ b/app/src/main/java/com/android/voyageur/ui/trip/activities/Activities.kt
@@ -58,11 +58,11 @@ fun ActivitiesScreen(
 
   val drafts =
       trip.activities.filter { activity ->
-        activity.startTime == Timestamp(0, 0) || activity.endDate == Timestamp(0, 0)
+        activity.startTime == Timestamp(0, 0) || activity.endTime == Timestamp(0, 0)
       }
   val final =
       trip.activities.filter { activity ->
-        activity.startTime != Timestamp(0, 0) && activity.endDate != Timestamp(0, 0)
+        activity.startTime != Timestamp(0, 0) && activity.endTime != Timestamp(0, 0)
       }
 
   Scaffold(
@@ -124,7 +124,7 @@ fun ActivityItem(
   val startLocalDateTime =
       activity.startTime.toDate().toInstant().atZone(ZoneId.systemDefault()).toLocalDateTime()
   val endLocalDateTime =
-      activity.endDate.toDate().toInstant().atZone(ZoneId.systemDefault()).toLocalDateTime()
+      activity.endTime.toDate().toInstant().atZone(ZoneId.systemDefault()).toLocalDateTime()
 
   // Format the date and time
   val dateFormatted = dateFormat.format(startLocalDateTime)
@@ -227,7 +227,7 @@ val SAMPLE_ACTIVITIES =
             description = "",
             activityType = ActivityType.RESTAURANT,
             startTime = createTimestamp(2024, 11, 3, 10, 0),
-            endDate = createTimestamp(2024, 11, 3, 12, 30),
+            endTime = createTimestamp(2024, 11, 3, 12, 30),
             estimatedPrice = 20.25,
             location = Location()),
         Activity(
@@ -238,7 +238,7 @@ val SAMPLE_ACTIVITIES =
             description = "Dinner description",
             activityType = ActivityType.RESTAURANT,
             startTime = Timestamp.now(),
-            endDate = Timestamp.now(),
+            endTime = Timestamp.now(),
             estimatedPrice = 23.25,
             location = Location()),
         Activity(
@@ -246,7 +246,7 @@ val SAMPLE_ACTIVITIES =
             description = "",
             activityType = ActivityType.RESTAURANT,
             startTime = Timestamp.now(),
-            endDate = Timestamp.now(),
+            endTime = Timestamp.now(),
             estimatedPrice = 23.25,
             location = Location()),
         Activity(
@@ -254,7 +254,7 @@ val SAMPLE_ACTIVITIES =
             description = "",
             activityType = ActivityType.RESTAURANT,
             startTime = createTimestamp(2024, 11, 3, 19, 30),
-            endDate = createTimestamp(2024, 11, 3, 21, 0),
+            endTime = createTimestamp(2024, 11, 3, 21, 0),
             estimatedPrice = 23.25,
             location = Location()),
         Activity(
@@ -262,7 +262,7 @@ val SAMPLE_ACTIVITIES =
             description = "Too long description to be displayed on the Activity Box",
             activityType = ActivityType.RESTAURANT,
             startTime = Timestamp.now(),
-            endDate = Timestamp.now(),
+            endTime = Timestamp.now(),
             estimatedPrice = 23.25,
             location = Location()),
         Activity(
@@ -270,7 +270,7 @@ val SAMPLE_ACTIVITIES =
             description = "",
             activityType = ActivityType.RESTAURANT,
             startTime = Timestamp.now(),
-            endDate = Timestamp.now(),
+            endTime = Timestamp.now(),
             estimatedPrice = 23.25,
             location = Location()),
         Activity(
@@ -278,7 +278,7 @@ val SAMPLE_ACTIVITIES =
             description = "",
             activityType = ActivityType.OTHER,
             startTime = Timestamp.now(),
-            endDate = Timestamp.now(),
+            endTime = Timestamp.now(),
             estimatedPrice = 00.00,
             location = Location()),
         Activity(
@@ -286,6 +286,6 @@ val SAMPLE_ACTIVITIES =
             description = "",
             activityType = ActivityType.OTHER,
             startTime = Timestamp.now(),
-            endDate = Timestamp.now(),
+            endTime = Timestamp.now(),
             estimatedPrice = 00.00,
             location = Location()))

--- a/app/src/main/java/com/android/voyageur/ui/trip/schedule/ByDay.kt
+++ b/app/src/main/java/com/android/voyageur/ui/trip/schedule/ByDay.kt
@@ -12,7 +12,11 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.outlined.Add
 import androidx.compose.material3.Card
+import androidx.compose.material3.FloatingActionButton
+import androidx.compose.material3.Icon
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -32,6 +36,7 @@ import com.android.voyageur.model.trip.Trip
 import com.android.voyageur.ui.navigation.BottomNavigationMenu
 import com.android.voyageur.ui.navigation.LIST_TOP_LEVEL_DESTINATION
 import com.android.voyageur.ui.navigation.NavigationActions
+import com.android.voyageur.ui.navigation.Screen
 import com.google.firebase.Timestamp
 import java.time.LocalDate
 import java.time.ZoneId
@@ -45,6 +50,16 @@ fun ByDayScreen(
 ) {
   Scaffold(
       // TODO: Final implementation of ByDayScreen
+      floatingActionButton = {
+        FloatingActionButton(
+            onClick = { navigationActions.navigateTo(Screen.ADD_ACTIVITY) },
+            modifier = Modifier.testTag("createActivityButton")) {
+              Icon(
+                  Icons.Outlined.Add,
+                  "Floating action button",
+                  modifier = Modifier.testTag("addIcon"))
+            }
+      },
       modifier = Modifier.testTag("byDayScreen"),
       bottomBar = {
         BottomNavigationMenu(
@@ -64,7 +79,7 @@ fun ByDayScreen(
                     description = "",
                     activityType = ActivityType.RESTAURANT,
                     startTime = Timestamp.now(),
-                    endDate = Timestamp.now(),
+                    endTime = Timestamp.now(),
                     estimatedPrice = 20.25,
                     location = Location()),
                 Activity(
@@ -72,7 +87,7 @@ fun ByDayScreen(
                     description = "",
                     activityType = ActivityType.RESTAURANT,
                     startTime = Timestamp.now(),
-                    endDate = Timestamp.now(),
+                    endTime = Timestamp.now(),
                     estimatedPrice = 23.25,
                     location = Location()),
                 Activity(
@@ -80,7 +95,7 @@ fun ByDayScreen(
                     description = "",
                     activityType = ActivityType.RESTAURANT,
                     startTime = Timestamp.now(),
-                    endDate = Timestamp.now(),
+                    endTime = Timestamp.now(),
                     estimatedPrice = 23.25,
                     location = Location()),
                 Activity(
@@ -88,7 +103,7 @@ fun ByDayScreen(
                     description = "",
                     activityType = ActivityType.RESTAURANT,
                     startTime = Timestamp.now(),
-                    endDate = Timestamp.now(),
+                    endTime = Timestamp.now(),
                     estimatedPrice = 23.25,
                     location = Location()),
                 Activity(
@@ -96,7 +111,7 @@ fun ByDayScreen(
                     description = "",
                     activityType = ActivityType.RESTAURANT,
                     startTime = Timestamp.now(),
-                    endDate = Timestamp.now(),
+                    endTime = Timestamp.now(),
                     estimatedPrice = 23.25,
                     location = Location()),
                 Activity(
@@ -104,7 +119,7 @@ fun ByDayScreen(
                     description = "",
                     activityType = ActivityType.RESTAURANT,
                     startTime = Timestamp.now(),
-                    endDate = Timestamp.now(),
+                    endTime = Timestamp.now(),
                     estimatedPrice = 23.25,
                     location = Location()),
                 Activity(
@@ -112,7 +127,7 @@ fun ByDayScreen(
                     description = "",
                     activityType = ActivityType.OTHER,
                     startTime = Timestamp.now(),
-                    endDate = Timestamp.now(),
+                    endTime = Timestamp.now(),
                     estimatedPrice = 00.00,
                     location = Location()),
                 Activity(
@@ -120,7 +135,7 @@ fun ByDayScreen(
                     description = "",
                     activityType = ActivityType.OTHER,
                     startTime = oneDayAfterNow,
-                    endDate = oneDayAfterNow,
+                    endTime = Timestamp.now(),
                     estimatedPrice = 00.00,
                     location = Location()))
         val groupedActivities = groupActivitiesByDate(fakeActivities)

--- a/app/src/main/java/com/android/voyageur/ui/trip/schedule/ByDay.kt
+++ b/app/src/main/java/com/android/voyageur/ui/trip/schedule/ByDay.kt
@@ -70,7 +70,7 @@ fun ByDayScreen(
       content = { pd ->
         // TODO: HARDCODED ACTIVITY LIST to be removed when we have actual list
         // TODO: sort activities by their hour
-        // val tripActivities = trip.activities
+        val tripActivities = trip.activities
         val oneDayAfterNow = Timestamp(Timestamp.now().seconds + 86400, 0)
         val fakeActivities =
             listOf(
@@ -138,7 +138,7 @@ fun ByDayScreen(
                     endTime = Timestamp.now(),
                     estimatedPrice = 00.00,
                     location = Location()))
-        val groupedActivities = groupActivitiesByDate(fakeActivities)
+        val groupedActivities = groupActivitiesByDate(tripActivities)
         if (groupedActivities.isEmpty()) {
           Text(
               modifier = Modifier.padding(pd).testTag("emptyByDayPrompt"),

--- a/app/src/test/java/com/android/voyageur/model/activity/ActivityTest.kt
+++ b/app/src/test/java/com/android/voyageur/model/activity/ActivityTest.kt
@@ -10,14 +10,14 @@ class ActivityTest {
 
   private lateinit var location: Location
   private lateinit var startTime: Timestamp
-  private lateinit var endDate: Timestamp
+  private lateinit var endTime: Timestamp
 
   @Before
   fun setUp() {
     // Assuming Location has a constructor that takes latitude and longitude for simplicity
     location = Location()
     startTime = Timestamp.now()
-    endDate = Timestamp.now()
+    endTime = Timestamp.now()
   }
 
   @Test
@@ -28,7 +28,7 @@ class ActivityTest {
             description = "Exploring the famous art museum.",
             location = location,
             startTime = startTime,
-            endDate = endDate,
+            endTime = endTime,
             estimatedPrice = 15.50,
             activityType = ActivityType.MUSEUM)
 
@@ -36,7 +36,7 @@ class ActivityTest {
     assertEquals("Exploring the famous art museum.", activity.description)
     assertEquals(location, activity.location)
     assertEquals(startTime, activity.startTime)
-    assertEquals(endDate, activity.endDate)
+    assertEquals(endTime, activity.endTime)
     assertEquals(15.50, activity.estimatedPrice)
     assertEquals(ActivityType.MUSEUM, activity.activityType)
   }
@@ -49,7 +49,7 @@ class ActivityTest {
             description = "Fine dining at the Eiffel Tower.",
             location = location,
             startTime = startTime,
-            endDate = endDate,
+            endTime = endTime,
             estimatedPrice = 250,
             activityType = ActivityType.RESTAURANT)
 
@@ -57,7 +57,7 @@ class ActivityTest {
     assertEquals("Fine dining at the Eiffel Tower.", activity.description)
     assertEquals(location, activity.location)
     assertEquals(startTime, activity.startTime)
-    assertEquals(endDate, activity.endDate)
+    assertEquals(endTime, activity.endTime)
     assertEquals(250, activity.estimatedPrice)
     assertEquals(ActivityType.RESTAURANT, activity.activityType)
   }

--- a/app/src/test/java/com/android/voyageur/model/activity/ActivityTest.kt
+++ b/app/src/test/java/com/android/voyageur/model/activity/ActivityTest.kt
@@ -37,7 +37,7 @@ class ActivityTest {
     assertEquals(location, activity.location)
     assertEquals(startTime, activity.startTime)
     assertEquals(endTime, activity.endTime)
-    assertEquals(15.50, activity.estimatedPrice)
+    assertEquals(15.50, activity.estimatedPrice, 0.10)
     assertEquals(ActivityType.MUSEUM, activity.activityType)
   }
 
@@ -50,7 +50,7 @@ class ActivityTest {
             location = location,
             startTime = startTime,
             endTime = endTime,
-            estimatedPrice = 250,
+            estimatedPrice = 250.0,
             activityType = ActivityType.RESTAURANT)
 
     assertEquals("Dinner at Le Jules Verne", activity.title)
@@ -58,7 +58,7 @@ class ActivityTest {
     assertEquals(location, activity.location)
     assertEquals(startTime, activity.startTime)
     assertEquals(endTime, activity.endTime)
-    assertEquals(250, activity.estimatedPrice)
+    assertEquals(250.0, activity.estimatedPrice, 0.10)
     assertEquals(ActivityType.RESTAURANT, activity.activityType)
   }
 }


### PR DESCRIPTION
## Summary

The main change of this PR is adding the addActivityScreen and tests for it. However, I also did some small changes which I will enumerate in the next section. A new activity can be created after you click on a trip, in the By Day view.

## Changes

- Changed the endDate field of Activity with endTime, i.e. for now an activity is during only one day, with a start time and an end time
- Changed the type of estimatedPrice field from Number to Double

## Checklist

Ensure all / most of these are checked before the pull request is submitted.
- [x] This PR resolves #99 
- [x] Tests have been added for new functionality.
- [x] Screenshots or UI changes have been attached (if applicable).

##  Testing

Explain how this feature was tested and what kind of testing (unit, integration, UI) has been done. Mention platforms or configurations used for testing.
- **Manual Testing:**
    - [x] Tested on emulator / physical device.
- **Unit Tests**
    - [x] Added units tests for this

##  Related Issues/Tickets

Closes #99 

## Screenshots (if applicable)

Attach screenshots or screen recordings that show UI changes.

![Screenshot 2024-11-08 004950](https://github.com/user-attachments/assets/59ae123c-ec24-4d9f-963d-2a8bbd15d8f7)
![Screenshot 2024-11-08 004912](https://github.com/user-attachments/assets/3508ee22-9f96-463d-8512-54e744bb3457)
![Screenshot 2024-11-08 004804](https://github.com/user-attachments/assets/44ec633c-74db-4795-bd1d-01c853f9e18a)
 
