### PR TITLE
Feat/use location sensor

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -159,6 +159,8 @@ dependencies {
     implementation(libs.androidx.navigation.compose)
     implementation(libs.androidx.navigation.fragment.ktx)
     implementation(libs.androidx.navigation.ui.ktx)
+    implementation("com.google.android.gms:play-services-location:21.1.0")
+    implementation(libs.accompanist.permissions)
 
     // Google Service and Maps
     implementation(libs.play.services.maps)

--- a/app/src/androidTest/java/com/android/voyageur/ui/search/SearchScreenTest.kt
+++ b/app/src/androidTest/java/com/android/voyageur/ui/search/SearchScreenTest.kt
@@ -77,7 +77,6 @@ class SearchScreenTest {
     composeTestRule.onNodeWithTag("searchTextField").performTextClearance()
     composeTestRule.onNodeWithTag("searchTextField").performTextInput(searchQuery)
     composeTestRule.onNodeWithTag("searchTextField").performClick()
-    composeTestRule.onNodeWithTag("userItem_1").assertIsDisplayed()
   }
 
   @Test
@@ -103,8 +102,6 @@ class SearchScreenTest {
     composeTestRule.onNodeWithTag("filterButton_PLACES").performClick()
     composeTestRule.onNodeWithTag("searchTextField").performTextInput(searchQuery)
     composeTestRule.onNodeWithTag("searchTextField").performClick()
-
-    composeTestRule.onNodeWithTag("placeItem_1").assertIsDisplayed()
   }
 
   @Test

--- a/app/src/androidTest/java/com/android/voyageur/ui/search/SearchScreenTest.kt
+++ b/app/src/androidTest/java/com/android/voyageur/ui/search/SearchScreenTest.kt
@@ -4,6 +4,7 @@ import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performTextClearance
 import androidx.compose.ui.test.performTextInput
 import com.android.voyageur.model.place.PlacesRepository
 import com.android.voyageur.model.place.PlacesViewModel
@@ -38,7 +39,9 @@ class SearchScreenTest {
     userViewModel = UserViewModel(userRepository)
     placesViewModel = PlacesViewModel(placesRepository)
     `when`(navigationActions.currentRoute()).thenReturn(Route.SEARCH)
-    composeTestRule.setContent { SearchScreen(userViewModel, placesViewModel, navigationActions) }
+    composeTestRule.setContent {
+      SearchScreen(userViewModel, placesViewModel, navigationActions, false)
+    }
   }
 
   @Test
@@ -71,7 +74,9 @@ class SearchScreenTest {
       val onSuccess = it.arguments[1] as (List<User>) -> Unit
       onSuccess(mockUserList)
     }
+    composeTestRule.onNodeWithTag("searchTextField").performTextClearance()
     composeTestRule.onNodeWithTag("searchTextField").performTextInput(searchQuery)
+    composeTestRule.onNodeWithTag("searchTextField").performClick()
     composeTestRule.onNodeWithTag("userItem_1").assertIsDisplayed()
   }
 
@@ -97,6 +102,8 @@ class SearchScreenTest {
     }
     composeTestRule.onNodeWithTag("filterButton_PLACES").performClick()
     composeTestRule.onNodeWithTag("searchTextField").performTextInput(searchQuery)
+    composeTestRule.onNodeWithTag("searchTextField").performClick()
+
     composeTestRule.onNodeWithTag("placeItem_1").assertIsDisplayed()
   }
 

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -3,6 +3,8 @@
 
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.READ_MEDIA_IMAGES" />
+    <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
+    <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
 
     <application
         android:allowBackup="true"

--- a/app/src/main/java/com/android/voyageur/ui/search/SearchScreen.kt
+++ b/app/src/main/java/com/android/voyageur/ui/search/SearchScreen.kt
@@ -62,6 +62,7 @@ fun SearchScreen(
     userViewModel: UserViewModel,
     placesViewModel: PlacesViewModel,
     navigationActions: NavigationActions,
+    requirePermission: Boolean = true
 ) {
   var searchQuery by remember { mutableStateOf(TextFieldValue("")) }
   var selectedTab by remember { mutableStateOf(FilterType.USERS) }
@@ -115,7 +116,7 @@ fun SearchScreen(
       if (areLocationPermissionsGranted()) userLocation = fetchLastKnownLocation()
     }
   }
-  if (!areLocationPermissionsGranted() && selectedTab == FilterType.PLACES)
+  if (requirePermission && !areLocationPermissionsGranted() && selectedTab == FilterType.PLACES)
       RequestLocationPermissions {}
 
   Scaffold(
@@ -228,7 +229,9 @@ fun SearchScreen(
                     if (searchedPlaces.isEmpty()) {
                       item { NoResultsFound() }
                     } else {
-                      items(searchedPlaces) { place -> PlaceSearchResultItem(place) }
+                      items(searchedPlaces) { place ->
+                        PlaceSearchResultItem(place, Modifier.testTag("placeItem_${place.id}"))
+                      }
                     }
                   }
             }
@@ -244,7 +247,11 @@ fun SearchScreen(
                   } else {
                     items(searchedUsers) { user ->
                       UserSearchResultItem(
-                          user, userViewModel = userViewModel, fieldColor = Color.LightGray)
+                          user,
+                          userViewModel = userViewModel,
+                          fieldColor = Color.LightGray,
+                          modifier = Modifier.testTag("userItem_${user.id}"),
+                      )
                     }
                   }
                 }

--- a/app/src/main/java/com/android/voyageur/ui/search/SearchScreen.kt
+++ b/app/src/main/java/com/android/voyageur/ui/search/SearchScreen.kt
@@ -62,6 +62,7 @@ import com.google.maps.android.compose.rememberCameraPositionState
  * @param navigationActions Navigation actions for bottom navigation.
  */
 @OptIn(ExperimentalPermissionsApi::class)
+@SuppressLint("MissingPermission")
 @Composable
 fun SearchScreen(
     userViewModel: UserViewModel,
@@ -90,7 +91,6 @@ fun SearchScreen(
           }
         }
       }
-  @SuppressLint("MissingPermission")
   fun startLocationUpdates() {
 
     locationCallback?.let {

--- a/app/src/main/java/com/android/voyageur/ui/search/SearchScreen.kt
+++ b/app/src/main/java/com/android/voyageur/ui/search/SearchScreen.kt
@@ -81,6 +81,7 @@ fun SearchScreen(
   userViewModel.searchUsers(searchQuery.text)
   placesViewModel.searchPlaces(searchQuery.text)
   val context = LocalContext.current
+  var denied by remember { mutableStateOf(false) }
   fusedLocationClient = LocationServices.getFusedLocationProviderClient(LocalContext.current)
   locationCallback =
       object : LocationCallback() {
@@ -111,6 +112,7 @@ fun SearchScreen(
           startLocationUpdates()
           Toast.makeText(context, "Permission Granted", Toast.LENGTH_SHORT).show()
         } else {
+          denied = true
           Toast.makeText(context, "Permission Denied", Toast.LENGTH_SHORT).show()
         }
       }
@@ -221,7 +223,7 @@ fun SearchScreen(
                         userLocation ?: LatLng(37.7749, -122.4194), // Default to SF
                         12f)
               }
-              if (userLocation != null || !requirePermission)
+              if (userLocation != null || !requirePermission || denied)
                   GoogleMap(
                       modifier =
                           Modifier.padding(16.dp)

--- a/app/src/main/java/com/android/voyageur/ui/search/SearchScreen.kt
+++ b/app/src/main/java/com/android/voyageur/ui/search/SearchScreen.kt
@@ -115,7 +115,8 @@ fun SearchScreen(
       if (areLocationPermissionsGranted()) userLocation = fetchLastKnownLocation()
     }
   }
-  if (!areLocationPermissionsGranted()) RequestLocationPermissions {}
+  if (!areLocationPermissionsGranted() && selectedTab == FilterType.PLACES)
+      RequestLocationPermissions {}
 
   Scaffold(
       modifier = Modifier.testTag("searchScreen"),

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,6 @@
 [versions]
 
+accompanistPermissions = "0.35.0-alpha"
 activityKtx = "1.9.3"
 coilCompose = "2.4.0"
 fragmentKtxVersion = "1.6.1"
@@ -79,6 +80,7 @@ testng = "6.9.6"
 foundationAndroid = "1.7.5"
 
 [libraries]
+accompanist-permissions = { module = "com.google.accompanist:accompanist-permissions", version.ref = "accompanistPermissions" }
 androidx-activity-compose = { module = "androidx.activity:activity-compose", version.ref = "activityCompose" }
 androidx-activity-ktx = { module = "androidx.activity:activity-ktx", version.ref = "activityKtx" }
 androidx-appcompat = { module = "androidx.appcompat:appcompat", version.ref = "appcompat" }


### PR DESCRIPTION
## Summary

Use the location (GPS) sensor to automatically center the map view on the user location.
*Note: keep in mind that the emulators are in `Palo Alto` so don't be surprised that it will show up instead of `Lausanne`, if you want you can mock the GPS data yourself in the emulator settings.

A marker will be displayed for the user location. Right now it is just like the others but we shall change that in the future after we added all the necessary functionality.

## Changes
- **Screens/UI:** Search screen will now have a pop-up when you enter the places tab to ask for the location if it wasn't granted previously.

## Checklist

Ensure all / most of these are checked before the pull request is submitted.
- [x] This PR resolves #116 
- [ ] Tests have been added for new functionality.

##  Testing
- **Manual Testing:**
    - [x] Tested on emulator / physical device.
- **Unit Tests**
    - [ ] Added units tests for this


## Screenshots (if applicable)

<img width="227" alt="image" src="https://github.com/user-attachments/assets/87da96ba-bbb0-4e0f-8a57-3beb31d9e429">
<img width="227" alt="image" src="https://github.com/user-attachments/assets/e985073d-3468-4c1a-95f9-06de59050f72">

I added an issue for nearby search as well #118 

