### PR TITLE
Remove the interval after the first successfull update

### DIFF
--- a/app/src/main/java/com/android/voyageur/ui/search/SearchScreen.kt
+++ b/app/src/main/java/com/android/voyageur/ui/search/SearchScreen.kt
@@ -101,6 +101,7 @@ fun SearchScreen(
             fastestInterval = 500
             priority = LocationRequest.PRIORITY_HIGH_ACCURACY
           }
+
       fusedLocationClient?.requestLocationUpdates(locationRequest, it, Looper.getMainLooper())
     }
   }
@@ -222,6 +223,8 @@ fun SearchScreen(
                     com.google.android.gms.maps.model.CameraPosition.fromLatLngZoom(
                         userLocation ?: LatLng(37.7749, -122.4194), // Default to SF
                         12f)
+                if (userLocation != null)
+                    fusedLocationClient.removeLocationUpdates(locationCallback)
               }
               if (userLocation != null || !requirePermission || denied)
                   GoogleMap(


### PR DESCRIPTION
## Summary

Remove the location update interval after the first non null location update.

## Changes


- **Bug Fixes/Improvements:** The bug was causing the map to recenter everytime the person moved and resulted in a bad user experience. This is not testable on an emulator, but you can see it on a physical android phone.

##  Testing

- **Manual Testing:**
    - [x] Tested on emulator / physical device.



