### PR TITLE
Feat: add nearby search

### DIFF
--- a/app/src/androidTest/java/com/android/voyageur/ui/search/SearchScreenTest.kt
+++ b/app/src/androidTest/java/com/android/voyageur/ui/search/SearchScreenTest.kt
@@ -95,7 +95,7 @@ class SearchScreenTest {
     val searchQuery = "test"
     val mockPlaceList =
         listOf(Place.builder().setName("Test Place 1").setId("1").setRating(4.0).build())
-    `when`(placesRepository.searchPlaces(eq(searchQuery), any(), any())).thenAnswer {
+    `when`(placesRepository.searchPlaces(eq(searchQuery), any(), any(), any())).thenAnswer {
       val onSuccess = it.arguments[1] as (List<Place>) -> Unit
       onSuccess(mockPlaceList)
     }
@@ -107,7 +107,7 @@ class SearchScreenTest {
   @Test
   fun testNoResultsFoundPlaces() {
     val searchQuery = "test"
-    `when`(placesRepository.searchPlaces(eq(searchQuery), any(), any())).thenAnswer {
+    `when`(placesRepository.searchPlaces(eq(searchQuery), any(), any(), any())).thenAnswer {
       val onSuccess = it.arguments[1] as (List<Place>) -> Unit
       onSuccess(emptyList())
     }

--- a/app/src/main/java/com/android/voyageur/model/place/GooglePlacesRepository.kt
+++ b/app/src/main/java/com/android/voyageur/model/place/GooglePlacesRepository.kt
@@ -1,14 +1,47 @@
 package com.android.voyageur.model.place
 
+import com.google.android.gms.maps.model.LatLng
 import com.google.android.libraries.places.api.model.AutocompleteSessionToken
 import com.google.android.libraries.places.api.model.Place
+import com.google.android.libraries.places.api.model.RectangularBounds
+import com.google.android.libraries.places.api.model.kotlin.circularBounds
 import com.google.android.libraries.places.api.net.FetchPlaceRequest
 import com.google.android.libraries.places.api.net.FindAutocompletePredictionsRequest
 import com.google.android.libraries.places.api.net.PlacesClient
+import kotlin.math.cos
 
 class GooglePlacesRepository(private val placesClient: PlacesClient) : PlacesRepository {
+  private val placeFields =
+      listOf(
+          Place.Field.ID,
+          Place.Field.DISPLAY_NAME,
+          Place.Field.ADDRESS,
+          Place.Field.PHOTO_METADATAS,
+          Place.Field.INTERNATIONAL_PHONE_NUMBER,
+          Place.Field.WEBSITE_URI,
+          Place.Field.OPENING_HOURS,
+          Place.Field.RATING,
+          Place.Field.USER_RATINGS_TOTAL,
+          Place.Field.LAT_LNG,
+          Place.Field.PRICE_LEVEL)
+
+  private fun circularBounds(center: LatLng, radius: Double): RectangularBounds {
+    val earthRadius = 6371000.0 // Earth's radius in meters
+
+    val latDelta = radius / earthRadius * (180 / Math.PI) // Convert to degrees
+    val lngDelta =
+        radius / (earthRadius * cos(Math.toRadians(center.latitude))) *
+            (180 / Math.PI) // Adjust for latitude
+
+    val southwest = LatLng(center.latitude - latDelta, center.longitude - lngDelta)
+    val northeast = LatLng(center.latitude + latDelta, center.longitude + lngDelta)
+
+    return RectangularBounds.newInstance(southwest, northeast)
+  }
+
   override fun searchPlaces(
       query: String,
+      location: LatLng?,
       onSuccess: (List<Place>) -> Unit,
       onFailure: (Exception) -> Unit
   ) {
@@ -16,14 +49,14 @@ class GooglePlacesRepository(private val placesClient: PlacesClient) : PlacesRep
 
     // For now, we only want to search for restaurants, bars, and cafes
     val filter = listOf("restaurant", "bar", "cafe")
-
-    val request =
+    val bounds = location?.let { circularBounds(it, 10000.0) }
+    var builder =
         FindAutocompletePredictionsRequest.builder()
             .setSessionToken(token)
             .setQuery(query)
             .setTypesFilter(filter)
-            .build()
-
+    if (bounds != null) builder = builder.setLocationRestriction(bounds)
+    val request = builder.build()
     placesClient
         .findAutocompletePredictions(request)
         .addOnSuccessListener { response ->
@@ -42,19 +75,7 @@ class GooglePlacesRepository(private val placesClient: PlacesClient) : PlacesRep
     var failedRequests = 0
 
     // Define which fields to retrieve for each place
-    val placeFields =
-        listOf(
-            Place.Field.ID,
-            Place.Field.DISPLAY_NAME,
-            Place.Field.ADDRESS,
-            Place.Field.PHOTO_METADATAS,
-            Place.Field.INTERNATIONAL_PHONE_NUMBER,
-            Place.Field.WEBSITE_URI,
-            Place.Field.OPENING_HOURS,
-            Place.Field.RATING,
-            Place.Field.USER_RATINGS_TOTAL,
-            Place.Field.LAT_LNG,
-            Place.Field.PRICE_LEVEL)
+
     placeIds.forEach { placeId ->
       val request = FetchPlaceRequest.builder(placeId, placeFields).build()
       placesClient

--- a/app/src/main/java/com/android/voyageur/model/place/GooglePlacesRepository.kt
+++ b/app/src/main/java/com/android/voyageur/model/place/GooglePlacesRepository.kt
@@ -25,6 +25,14 @@ class GooglePlacesRepository(private val placesClient: PlacesClient) : PlacesRep
           Place.Field.LAT_LNG,
           Place.Field.PRICE_LEVEL)
 
+  /**
+   * This function is used to convert a circular radius around a location (LatLng) to a rectangular
+   * bounds, as the maps sdk doesn't support circular bounds
+   *
+   * @param center the location used as the user location
+   * @param radius the radius area for the circle search
+   * @return the converted bounds around the center point
+   */
   private fun circularBounds(center: LatLng, radius: Double): RectangularBounds {
     val earthRadius = 6371000.0 // Earth's radius in meters
 

--- a/app/src/main/java/com/android/voyageur/model/place/PlacesRepository.kt
+++ b/app/src/main/java/com/android/voyageur/model/place/PlacesRepository.kt
@@ -1,7 +1,13 @@
 package com.android.voyageur.model.place
 
+import com.google.android.gms.maps.model.LatLng
 import com.google.android.libraries.places.api.model.Place
 
 interface PlacesRepository {
-  fun searchPlaces(query: String, onSuccess: (List<Place>) -> Unit, onFailure: (Exception) -> Unit)
+  fun searchPlaces(
+      query: String,
+      location: LatLng?,
+      onSuccess: (List<Place>) -> Unit,
+      onFailure: (Exception) -> Unit
+  )
 }

--- a/app/src/main/java/com/android/voyageur/model/place/PlacesViewModel.kt
+++ b/app/src/main/java/com/android/voyageur/model/place/PlacesViewModel.kt
@@ -4,6 +4,7 @@ import android.util.Log
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.viewModelScope
+import com.google.android.gms.maps.model.LatLng
 import com.google.android.libraries.places.api.model.Place
 import com.google.android.libraries.places.api.net.PlacesClient
 import kotlinx.coroutines.Job
@@ -22,21 +23,22 @@ open class PlacesViewModel(private val placesRepository: PlacesRepository) : Vie
   // Job to manage debounce coroutine
   private var debounceJob: Job? = null
 
-  fun setQuery(query: String) {
+  fun setQuery(query: String, location: LatLng?) {
     debounceJob?.cancel()
     _query.value = query
     debounceJob =
         viewModelScope.launch {
           delay(200) // debounce for 2s
           if (query.isNotEmpty()) {
-            searchPlaces(query)
+            searchPlaces(query, location)
           }
         }
   }
 
-  fun searchPlaces(query: String) {
+  fun searchPlaces(query: String, location: LatLng?) {
     placesRepository.searchPlaces(
         query,
+        location,
         onSuccess = { places -> _searchedPlaces.value = places },
         onFailure = { exception -> Log.e("PlacesViewModel", "Failed to search places", exception) })
   }

--- a/app/src/main/java/com/android/voyageur/ui/search/SearchScreen.kt
+++ b/app/src/main/java/com/android/voyageur/ui/search/SearchScreen.kt
@@ -79,7 +79,7 @@ fun SearchScreen(
   var locationCallback: LocationCallback? = null
   var fusedLocationClient: FusedLocationProviderClient? = null
   userViewModel.searchUsers(searchQuery.text)
-  placesViewModel.searchPlaces(searchQuery.text)
+  placesViewModel.searchPlaces(searchQuery.text, userLocation)
   val context = LocalContext.current
   var denied by remember { mutableStateOf(false) }
   fusedLocationClient = LocationServices.getFusedLocationProviderClient(LocalContext.current)
@@ -185,7 +185,7 @@ fun SearchScreen(
                     onValueChange = {
                       searchQuery = it
                       userViewModel.setQuery(searchQuery.text)
-                      placesViewModel.setQuery(searchQuery.text)
+                      placesViewModel.setQuery(searchQuery.text, userLocation)
                     },
                     modifier = Modifier.weight(1f).padding(8.dp).testTag("searchTextField"),
                     textStyle = LocalTextStyle.current.copy(fontSize = 18.sp))


### PR DESCRIPTION
## Summary

In this PR I address the issue #118.
If the user has granted the necessary permissions, we will only search / filter the places in a small radius centered around the user location.
If the user has not granted location permissions, the default location will be used / no boundaries applied => it will show places all around the globe.
If the user has granted permissions but has location disabled, a dialog will pop up to request the user to enable the location in the settings

## Changes

- **Repositories:** Updated the repository for places ( and googlesearch repo) to allow an optional location parameter
- **Bug Fixes/Improvements:** Fix the user pin and enable the maps recenter properties.

## Checklist

Ensure all / most of these are checked before the pull request is submitted.
- [x] This PR resolves #118 
- [] Tests have been added for new functionality.
- [x] Screenshots or UI changes have been attached (if applicable).

##  Testing
- **Manual Testing:**
    - [x] Tested on emulator / physical device.
- **Unit Tests**
    - [ ] Added units tests for this

If you haven't added tests, please create a new issue and assign it.

## Screenshots (if applicable)

<img width="271" alt="image" src="https://github.com/user-attachments/assets/9145134c-f88d-437c-9cfd-607a6ab6f1c4">
<img width="271" alt="image" src="https://github.com/user-attachments/assets/aedcf6cb-e8be-45a6-bf05-2c390c5faeb7">
<img width="271" alt="image" src="https://github.com/user-attachments/assets/332abbed-50c4-417e-95d3-7ae86d89cfcd">

