### PR TITLE
fix behavior when selecting only the date

### DIFF
--- a/app/src/androidTest/java/com/android/voyageur/ui/trip/AddActivityTest.kt
+++ b/app/src/androidTest/java/com/android/voyageur/ui/trip/AddActivityTest.kt
@@ -44,8 +44,9 @@ class AddActivityScreenTest {
     whenever(tripsViewModel.getNewTripId()).thenReturn("mockTripId")
     doNothing().`when`(tripRepository).updateTrip(any(), any(), any())
 
+    val toastMock = mockk<Toast>(relaxed = true)
     mockkStatic(Toast::class)
-    every { Toast.makeText(any(), any<String>(), any()) } returns mockk()
+    every { Toast.makeText(any(), any<String>(), any()) } returns toastMock
   }
 
   @Test

--- a/app/src/main/java/com/android/voyageur/ui/trip/AddActivity.kt
+++ b/app/src/main/java/com/android/voyageur/ui/trip/AddActivity.kt
@@ -102,7 +102,7 @@ fun AddActivityScreen(tripsViewModel: TripsViewModel, navigationActions: Navigat
                   }
                   .time
             }
-            ?.let { Timestamp(it) } ?: Timestamp(0, 0)
+            ?.let { Timestamp(it) } ?: Timestamp(dateNormalized)
 
     val endTimestamp =
         endTime
@@ -121,7 +121,7 @@ fun AddActivityScreen(tripsViewModel: TripsViewModel, navigationActions: Navigat
                   }
                   .time
             }
-            ?.let { Timestamp(it) } ?: Timestamp(0, 0)
+            ?.let { Timestamp(it) } ?: Timestamp(dateNormalized)
 
     if (startTime != null &&
         endTime != null &&

--- a/app/src/main/java/com/android/voyageur/ui/trip/AddActivity.kt
+++ b/app/src/main/java/com/android/voyageur/ui/trip/AddActivity.kt
@@ -65,6 +65,11 @@ fun AddActivityScreen(tripsViewModel: TripsViewModel, navigationActions: Navigat
       return
     }
 
+    if (startTime == null && endTime != null){
+        Toast.makeText(context, "Please select a start time first", Toast.LENGTH_SHORT).show()
+        return
+    }
+
     fun normalizeToMidnight(date: Date): Date {
       val calendar =
           Calendar.getInstance().apply {
@@ -85,7 +90,7 @@ fun AddActivityScreen(tripsViewModel: TripsViewModel, navigationActions: Navigat
       return
     }
 
-    val startTimestamp =
+    val startTimestamp = Timestamp(
         startTime
             ?.let {
               Calendar.getInstance()
@@ -102,9 +107,16 @@ fun AddActivityScreen(tripsViewModel: TripsViewModel, navigationActions: Navigat
                   }
                   .time
             }
-            ?.let { Timestamp(it) } ?: Timestamp(dateNormalized)
+            ?: dateNormalized.apply {
+                Calendar.getInstance().apply {
+                    time = dateNormalized
+                    set(Calendar.HOUR_OF_DAY, 0)
+                    set(Calendar.MINUTE, 0)
+                }.time
+            }
+      )
 
-    val endTimestamp =
+    val endTimestamp = Timestamp(
         endTime
             ?.let {
               Calendar.getInstance()
@@ -121,7 +133,14 @@ fun AddActivityScreen(tripsViewModel: TripsViewModel, navigationActions: Navigat
                   }
                   .time
             }
-            ?.let { Timestamp(it) } ?: Timestamp(dateNormalized)
+            ?: dateNormalized.apply {
+                Calendar.getInstance().apply {
+                    time = dateNormalized
+                    set(Calendar.HOUR_OF_DAY, 23)
+                    set(Calendar.MINUTE, 59)
+                }.time
+            }
+    )
 
     if (startTime != null &&
         endTime != null &&

--- a/app/src/main/java/com/android/voyageur/ui/trip/AddActivity.kt
+++ b/app/src/main/java/com/android/voyageur/ui/trip/AddActivity.kt
@@ -151,6 +151,14 @@ fun AddActivityScreen(tripsViewModel: TripsViewModel, navigationActions: Navigat
       return
     }
 
+    if (startTime == null && endTime == null)
+        Toast.makeText(context, "No times selected, defaults to 00:00 - 23:59", Toast.LENGTH_SHORT)
+            .show()
+
+    if (startTime != null && endTime == null)
+        Toast.makeText(context, "No end time selected, defaults to 23:59", Toast.LENGTH_SHORT)
+            .show()
+
     val activity =
         Activity(
             title = title,

--- a/app/src/main/java/com/android/voyageur/ui/trip/AddActivity.kt
+++ b/app/src/main/java/com/android/voyageur/ui/trip/AddActivity.kt
@@ -65,9 +65,9 @@ fun AddActivityScreen(tripsViewModel: TripsViewModel, navigationActions: Navigat
       return
     }
 
-    if (startTime == null && endTime != null){
-        Toast.makeText(context, "Please select a start time first", Toast.LENGTH_SHORT).show()
-        return
+    if (startTime == null && endTime != null) {
+      Toast.makeText(context, "Please select a start time first", Toast.LENGTH_SHORT).show()
+      return
     }
 
     fun normalizeToMidnight(date: Date): Date {
@@ -90,9 +90,9 @@ fun AddActivityScreen(tripsViewModel: TripsViewModel, navigationActions: Navigat
       return
     }
 
-    val startTimestamp = Timestamp(
-        startTime
-            ?.let {
+    val startTimestamp =
+        Timestamp(
+            startTime?.let {
               Calendar.getInstance()
                   .apply {
                     time = dateNormalized
@@ -107,18 +107,19 @@ fun AddActivityScreen(tripsViewModel: TripsViewModel, navigationActions: Navigat
                   }
                   .time
             }
-            ?: dateNormalized.apply {
-                Calendar.getInstance().apply {
-                    time = dateNormalized
-                    set(Calendar.HOUR_OF_DAY, 0)
-                    set(Calendar.MINUTE, 0)
-                }.time
-            }
-      )
+                ?: dateNormalized.apply {
+                  Calendar.getInstance()
+                      .apply {
+                        time = dateNormalized
+                        set(Calendar.HOUR_OF_DAY, 0)
+                        set(Calendar.MINUTE, 0)
+                      }
+                      .time
+                })
 
-    val endTimestamp = Timestamp(
-        endTime
-            ?.let {
+    val endTimestamp =
+        Timestamp(
+            endTime?.let {
               Calendar.getInstance()
                   .apply {
                     time = dateNormalized
@@ -133,14 +134,15 @@ fun AddActivityScreen(tripsViewModel: TripsViewModel, navigationActions: Navigat
                   }
                   .time
             }
-            ?: dateNormalized.apply {
-                Calendar.getInstance().apply {
-                    time = dateNormalized
-                    set(Calendar.HOUR_OF_DAY, 23)
-                    set(Calendar.MINUTE, 59)
-                }.time
-            }
-    )
+                ?: dateNormalized.apply {
+                  Calendar.getInstance()
+                      .apply {
+                        time = dateNormalized
+                        set(Calendar.HOUR_OF_DAY, 23)
+                        set(Calendar.MINUTE, 59)
+                      }
+                      .time
+                })
 
     if (startTime != null &&
         endTime != null &&

--- a/app/src/main/java/com/android/voyageur/ui/trip/AddActivity.kt
+++ b/app/src/main/java/com/android/voyageur/ui/trip/AddActivity.kt
@@ -134,15 +134,15 @@ fun AddActivityScreen(tripsViewModel: TripsViewModel, navigationActions: Navigat
                   }
                   .time
             }
-                ?: dateNormalized.apply {
-                  Calendar.getInstance()
-                      .apply {
-                        time = dateNormalized
-                        set(Calendar.HOUR_OF_DAY, 23)
-                        set(Calendar.MINUTE, 59)
-                      }
-                      .time
-                })
+                ?: Calendar.getInstance()
+                    .apply {
+                      time = dateNormalized
+                      set(Calendar.HOUR_OF_DAY, 23)
+                      set(Calendar.MINUTE, 59)
+                      set(Calendar.SECOND, 59)
+                      set(Calendar.MILLISECOND, 999)
+                    }
+                    .time)
 
     if (startTime != null &&
         endTime != null &&
@@ -151,9 +151,12 @@ fun AddActivityScreen(tripsViewModel: TripsViewModel, navigationActions: Navigat
       return
     }
 
-    if (startTime == null && endTime == null)
+    if (activityDate != null && startTime == null && endTime == null)
         Toast.makeText(context, "No times selected, defaults to 00:00 - 23:59", Toast.LENGTH_SHORT)
             .show()
+
+    if (activityDate == null)
+        Toast.makeText(context, "No date assigned, created as draft", Toast.LENGTH_SHORT).show()
 
     if (startTime != null && endTime == null)
         Toast.makeText(context, "No end time selected, defaults to 23:59", Toast.LENGTH_SHORT)


### PR DESCRIPTION
## Summary

When creating an activity, if you selected just the date and no startTime/endTime it was creating the activity at timestamp(0, 0). Now, it is created at the specified date (at midnight).
If not selected, set default startTime to 00:00 and endTime to 23:59. Moreover, we decided that you cannot have activities created just with endTime, but you can have activities created only with a startTime.

## Changes

- **Bug Fixes/Improvements:** 
- #132 
- #134 

## Checklist

Ensure all / most of these are checked before the pull request is submitted.
- [x] This PR resolves #132 .
- [x] This PR resolves #134 .  
- [ ] Tests have been added for new functionality.
- [ ] Screenshots or UI changes have been attached (if applicable).
- [ ] Documentation has been updated (if applicable).

##  Testing

Explain how this feature was tested and what kind of testing (unit, integration, UI) has been done. Mention platforms or configurations used for testing.
- **Manual Testing:**
    - [x] Tested on emulator / physical device.
- **Unit Tests**
    - [ ] Added units tests for this

If you haven't added tests, please create a new issue and assign it.

##  Related Issues/Tickets

Closes #132 
Closes #134 

