### PR TITLE
Fix/Remember tabs and view when accessing other screens

### DIFF
--- a/app/src/androidTest/java/com/android/voyageur/ui/trip/TobTabsTest.kt
+++ b/app/src/androidTest/java/com/android/voyageur/ui/trip/TobTabsTest.kt
@@ -2,33 +2,32 @@ package com.android.voyageur.ui.trip
 
 import androidx.compose.ui.test.*
 import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.navigation.NavHostController
 import com.android.voyageur.model.trip.Trip
 import com.android.voyageur.model.trip.TripRepository
 import com.android.voyageur.model.trip.TripsViewModel
 import com.android.voyageur.ui.navigation.NavigationActions
-import com.android.voyageur.ui.navigation.Route
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.mockito.Mockito.mock
-import org.mockito.Mockito.`when`
 
 class TopTabsTest {
-  val sampleTrip = Trip(name = "Sample Trip")
+  private val sampleTrip = Trip(name = "Sample Trip")
 
   private lateinit var tripRepository: TripRepository
   private lateinit var navigationActions: NavigationActions
   private lateinit var tripsViewModel: TripsViewModel
+  private lateinit var navHostController: NavHostController
 
   @get:Rule val composeTestRule = createComposeRule()
 
   @Before
   fun setUp() {
     tripRepository = mock(TripRepository::class.java)
-    navigationActions = mock(NavigationActions::class.java)
+    navHostController = mock(NavHostController::class.java)
+    navigationActions = NavigationActions(navHostController)
     tripsViewModel = TripsViewModel(tripRepository)
-
-    `when`(navigationActions.currentRoute()).thenReturn(Route.TOP_TABS)
   }
 
   @Test
@@ -81,5 +80,24 @@ class TopTabsTest {
     composeTestRule.onNodeWithText("Settings").performClick()
     composeTestRule.onNodeWithText("Settings").assertIsSelected()
     composeTestRule.onNodeWithTag("settingsScreen").assertIsDisplayed()
+  }
+
+  @Test
+  fun testCurrentTabIndexForTrip_updatesProperly() {
+    tripsViewModel.selectTrip(sampleTrip)
+
+    composeTestRule.setContent { TopTabs(tripsViewModel, navigationActions) }
+
+    composeTestRule.onNodeWithText("Schedule").assertExists()
+    composeTestRule.onNodeWithText("Activities").assertExists()
+    composeTestRule.onNodeWithText("Settings").assertExists()
+
+    composeTestRule.onNodeWithText("Activities").performClick()
+    assert(navigationActions.currentTabIndexForTrip == 1)
+
+    composeTestRule.onNodeWithText("Settings").performClick()
+    assert(navigationActions.currentTabIndexForTrip == 2)
+    composeTestRule.onNodeWithText("Schedule").performClick()
+    assert(navigationActions.currentTabIndexForTrip == 0)
   }
 }

--- a/app/src/androidTest/java/com/android/voyageur/ui/trip/activities/ActivitiesScreenTest.kt
+++ b/app/src/androidTest/java/com/android/voyageur/ui/trip/activities/ActivitiesScreenTest.kt
@@ -11,11 +11,13 @@ import com.android.voyageur.model.activity.ActivityType
 import com.android.voyageur.model.trip.Trip
 import com.android.voyageur.ui.navigation.LIST_TOP_LEVEL_DESTINATION
 import com.android.voyageur.ui.navigation.NavigationActions
+import com.android.voyageur.ui.navigation.Screen
 import com.google.firebase.Timestamp
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.mockito.Mockito.mock
+import org.mockito.Mockito.verify
 
 fun createTimestamp(year: Int, month: Int, day: Int, hour: Int, minute: Int): Timestamp {
   val calendar = java.util.Calendar.getInstance()
@@ -153,5 +155,14 @@ class ActivitiesScreenTest {
 
     composeTestRule.onNodeWithTag("cardItem_${sampleActivity.title}").assertIsDisplayed()
     composeTestRule.onNodeWithText("01/01/2022 12:00 PM - 02:00 PM").assertIsDisplayed()
+  }
+
+  @Test
+  fun clickingCreateActivityButton_navigatesToAddActivityScreen() {
+    composeTestRule.setContent { ActivitiesScreen(sampleTrip, navigationActions) }
+
+    composeTestRule.onNodeWithTag("createActivityButton").performClick()
+
+    verify(navigationActions).navigateTo(Screen.ADD_ACTIVITY)
   }
 }

--- a/app/src/androidTest/java/com/android/voyageur/ui/trip/activities/ActivitiesScreenTest.kt
+++ b/app/src/androidTest/java/com/android/voyageur/ui/trip/activities/ActivitiesScreenTest.kt
@@ -17,6 +17,12 @@ import org.junit.Rule
 import org.junit.Test
 import org.mockito.Mockito.mock
 
+fun createTimestamp(year: Int, month: Int, day: Int, hour: Int, minute: Int): Timestamp {
+  val calendar = java.util.Calendar.getInstance()
+  calendar.set(year, month - 1, day, hour, minute) // Month is 0-based
+  return Timestamp(calendar.time)
+}
+
 class ActivitiesScreenTest {
   private val sampleTrip =
       Trip(
@@ -29,12 +35,19 @@ class ActivitiesScreenTest {
                       estimatedPrice = 0.0,
                       activityType = ActivityType.WALK),
                   Activity(
-                      title = "Final Activity",
+                      title = "Final Activity With Description",
                       description = "This is a final activity",
-                      startTime = Timestamp.now(),
-                      endTime = Timestamp.now(),
+                      startTime = createTimestamp(2022, 1, 1, 12, 0),
+                      endTime = createTimestamp(2022, 1, 1, 14, 0),
                       estimatedPrice = 20.0,
-                      activityType = ActivityType.RESTAURANT)))
+                      activityType = ActivityType.RESTAURANT),
+                  Activity(
+                      title = "Final Activity Without Description",
+                      estimatedPrice = 10.0,
+                      startTime = createTimestamp(2022, 1, 2, 12, 0),
+                      endTime = createTimestamp(2022, 1, 2, 14, 0),
+                      activityType = ActivityType.MUSEUM),
+              ))
 
   private lateinit var navigationActions: NavigationActions
 
@@ -50,6 +63,8 @@ class ActivitiesScreenTest {
     composeTestRule.setContent { ActivitiesScreen(sampleTrip, navigationActions) }
     composeTestRule.onNodeWithTag("activitiesScreen").assertIsDisplayed()
     composeTestRule.onNodeWithTag("bottomNavigationMenu").assertIsDisplayed()
+    composeTestRule.onNodeWithTag("createActivityButton").assertIsDisplayed()
+    composeTestRule.onNodeWithTag("lazyColumn").assertIsDisplayed()
   }
 
   @Test
@@ -65,8 +80,6 @@ class ActivitiesScreenTest {
 
   @Test
   fun activitiesScreen_displaysDraftAndFinalSections() {
-    val sampleTrip = Trip(name = "Sample Trip", activities = SAMPLE_ACTIVITIES)
-
     composeTestRule.setContent {
       ActivitiesScreen(trip = sampleTrip, navigationActions = navigationActions)
     }
@@ -78,11 +91,12 @@ class ActivitiesScreenTest {
 
   @Test
   fun activityItem_expandAndCollapse() {
-    val sampleActivity = SAMPLE_ACTIVITIES.first()
+    val sampleActivity = sampleTrip.activities.first()
 
-    composeTestRule.setContent { ActivityItem(activity = sampleActivity) }
+    composeTestRule.setContent { ActivitiesScreen(sampleTrip, navigationActions) }
 
     composeTestRule.onNodeWithText("Price").assertIsNotDisplayed()
+    composeTestRule.onNodeWithText("Type").assertIsNotDisplayed()
 
     composeTestRule
         .onNodeWithTag("expandIcon_${sampleActivity.title}")
@@ -92,15 +106,52 @@ class ActivitiesScreenTest {
     // Check if the expanded content is displayed
     composeTestRule.onNodeWithText("Price").assertIsDisplayed()
     composeTestRule.onNodeWithText("${sampleActivity.estimatedPrice} CHF").assertIsDisplayed()
+    composeTestRule.onNodeWithText("Type").assertIsDisplayed()
   }
 
   @Test
   fun activityCard_displaysCorrectTitle() {
-    val sampleActivity = SAMPLE_ACTIVITIES.first()
+    val sampleActivity = sampleTrip.activities.first()
 
-    composeTestRule.setContent { ActivityItem(activity = sampleActivity) }
+    composeTestRule.setContent { ActivitiesScreen(sampleTrip, navigationActions) }
 
     composeTestRule.onNodeWithTag("cardItem_${sampleActivity.title}").assertIsDisplayed()
     composeTestRule.onNodeWithText(sampleActivity.title).assertIsDisplayed()
+  }
+
+  @Test
+  fun activityCard_displaysCorrectDescription() {
+    val sampleActivity = sampleTrip.activities[1]
+
+    composeTestRule.setContent { ActivitiesScreen(sampleTrip, navigationActions) }
+    composeTestRule
+        .onNodeWithTag("expandIcon_${sampleActivity.title}")
+        .assertIsDisplayed()
+        .performClick()
+    composeTestRule.onNodeWithTag("cardItem_${sampleActivity.title}").assertIsDisplayed()
+    composeTestRule.onNodeWithText(sampleActivity.description).assertIsDisplayed()
+  }
+
+  @Test
+  fun activityCard_doesNotDisplayDescription() {
+    val sampleActivity = sampleTrip.activities[2]
+
+    composeTestRule.setContent { ActivitiesScreen(sampleTrip, navigationActions) }
+    composeTestRule
+        .onNodeWithTag("expandIcon_${sampleActivity.title}")
+        .assertIsDisplayed()
+        .performClick()
+    composeTestRule.onNodeWithTag("cardItem_${sampleActivity.title}").assertIsDisplayed()
+    composeTestRule.onNodeWithText(sampleActivity.description).assertIsNotDisplayed()
+  }
+
+  @Test
+  fun activityCard_displaysCorrectDateAndTime() {
+    val sampleActivity = sampleTrip.activities[1]
+
+    composeTestRule.setContent { ActivitiesScreen(sampleTrip, navigationActions) }
+
+    composeTestRule.onNodeWithTag("cardItem_${sampleActivity.title}").assertIsDisplayed()
+    composeTestRule.onNodeWithText("01/01/2022 12:00 PM - 02:00 PM").assertIsDisplayed()
   }
 }

--- a/app/src/androidTest/java/com/android/voyageur/ui/trip/schedule/ScheduleScreenTest.kt
+++ b/app/src/androidTest/java/com/android/voyageur/ui/trip/schedule/ScheduleScreenTest.kt
@@ -2,12 +2,12 @@ package com.android.voyageur.ui.trip.schedule
 
 import androidx.compose.ui.test.*
 import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.navigation.NavHostController
 import com.android.voyageur.model.activity.Activity
 import com.android.voyageur.model.activity.ActivityType
 import com.android.voyageur.model.location.Location
 import com.android.voyageur.model.trip.Trip
 import com.android.voyageur.ui.navigation.NavigationActions
-import com.android.voyageur.ui.navigation.Route
 import com.google.firebase.Timestamp
 import java.time.LocalDateTime
 import java.time.ZoneOffset
@@ -15,13 +15,14 @@ import java.util.*
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
-import org.mockito.Mockito
-import org.mockito.Mockito.`when`
+import org.mockito.Mockito.mock
 
 class ScheduleScreenTest {
   @get:Rule val composeTestRule = createComposeRule()
 
   private lateinit var navigationActions: NavigationActions
+  private lateinit var navHostController: NavHostController
+
   private lateinit var mockTrip: Trip
 
   @Before
@@ -29,8 +30,10 @@ class ScheduleScreenTest {
     // Set default locale for consistent testing
     Locale.setDefault(Locale.US)
 
-    navigationActions = Mockito.mock(NavigationActions::class.java)
-    `when`(navigationActions.currentRoute()).thenReturn(Route.TOP_TABS)
+    //    navigationActions = Mockito.mock(NavigationActions::class.java)
+    navHostController = mock(NavHostController::class.java)
+    navigationActions = NavigationActions(navHostController)
+    //    `when`(navigationActions.currentRoute()).thenReturn(Route.TOP_TABS)
 
     mockTrip =
         Trip(
@@ -165,5 +168,15 @@ class ScheduleScreenTest {
     composeTestRule.onNodeWithText("Weekly").performClick()
     composeTestRule.onNodeWithText("Daily").assertIsEnabled()
     composeTestRule.onNodeWithText("Weekly").assertIsEnabled()
+  }
+
+  @Test
+  fun checkIfIsDailyViewSelected_updatesProperly() {
+    assert(navigationActions.isDailyViewSelected)
+      composeTestRule.onNodeWithText("Weekly").performClick()
+
+    assert(!navigationActions.isDailyViewSelected)
+    composeTestRule.onNodeWithText("Daily").performClick()
+    assert(navigationActions.isDailyViewSelected)
   }
 }

--- a/app/src/androidTest/java/com/android/voyageur/ui/trip/schedule/ScheduleScreenTest.kt
+++ b/app/src/androidTest/java/com/android/voyageur/ui/trip/schedule/ScheduleScreenTest.kt
@@ -173,7 +173,7 @@ class ScheduleScreenTest {
   @Test
   fun checkIfIsDailyViewSelected_updatesProperly() {
     assert(navigationActions.isDailyViewSelected)
-      composeTestRule.onNodeWithText("Weekly").performClick()
+    composeTestRule.onNodeWithText("Weekly").performClick()
 
     assert(!navigationActions.isDailyViewSelected)
     composeTestRule.onNodeWithText("Daily").performClick()

--- a/app/src/main/java/com/android/voyageur/model/activity/Activity.kt
+++ b/app/src/main/java/com/android/voyageur/model/activity/Activity.kt
@@ -28,3 +28,5 @@ fun Activity.hasDescription() = description != ""
 fun Activity.hasStartTime() = startTime != Timestamp(0, 0)
 
 fun Activity.hasEndDate() = endTime != Timestamp(0, 0)
+
+fun Activity.isDraft() = !(hasStartTime() && hasEndDate())

--- a/app/src/main/java/com/android/voyageur/ui/TimePickers.kt
+++ b/app/src/main/java/com/android/voyageur/ui/TimePickers.kt
@@ -1,0 +1,96 @@
+package com.android.voyageur.ui
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.DatePicker
+import androidx.compose.material3.DatePickerDialog
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.material3.TimeInput
+import androidx.compose.material3.rememberDatePickerState
+import androidx.compose.material3.rememberTimePickerState
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.window.Dialog
+import java.util.Calendar
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun DatePickerModal(
+    onDateSelected: (Long?) -> Unit,
+    onDismiss: () -> Unit,
+    selectedDate: Long = System.currentTimeMillis()
+) {
+  val datePickerState = rememberDatePickerState(initialSelectedDateMillis = selectedDate)
+
+  DatePickerDialog(
+      onDismissRequest = onDismiss,
+      confirmButton = {
+        TextButton(
+            onClick = {
+              onDateSelected(datePickerState.selectedDateMillis)
+              onDismiss()
+            }) {
+              Text("OK")
+            }
+      },
+      dismissButton = { TextButton(onClick = onDismiss) { Text("Cancel") } }) {
+        DatePicker(state = datePickerState)
+      }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun TimePickerInput(
+    initialHour: Int?,
+    initialMinute: Int?,
+    onTimeSelected: (Long?) -> Unit,
+    onDismiss: () -> Unit
+) {
+  val timeState = rememberTimePickerState(is24Hour = true)
+
+  if (initialHour != null && initialMinute != null) {
+    timeState.hour = initialHour
+    timeState.minute = initialMinute
+  }
+
+  Dialog(onDismissRequest = onDismiss) {
+    Surface(
+        shape = MaterialTheme.shapes.extraLarge,
+        tonalElevation = 10.dp,
+        modifier = Modifier.padding(16.dp)) {
+          Column(modifier = Modifier.padding(16.dp)) {
+            Text(
+                modifier = Modifier.fillMaxWidth().padding(bottom = 16.dp),
+                text = "Select time",
+                textAlign = TextAlign.Center,
+                style = MaterialTheme.typography.headlineMedium)
+            TimeInput(state = timeState)
+            Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.End) {
+              TextButton(onClick = onDismiss) { Text(text = "Cancel") }
+              TextButton(
+                  onClick = {
+                    val selectedTime =
+                        Calendar.getInstance()
+                            .apply {
+                              set(Calendar.HOUR_OF_DAY, timeState.hour)
+                              set(Calendar.MINUTE, timeState.minute)
+                            }
+                            .timeInMillis
+                    onTimeSelected(selectedTime)
+                  }) {
+                    Text(text = "OK")
+                  }
+            }
+          }
+        }
+  }
+}

--- a/app/src/main/java/com/android/voyageur/ui/formFields/DatePicker.kt
+++ b/app/src/main/java/com/android/voyageur/ui/formFields/DatePicker.kt
@@ -1,0 +1,34 @@
+package com.android.voyageur.ui.formFields
+
+import androidx.compose.material3.DatePicker
+import androidx.compose.material3.DatePickerDialog
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.material3.rememberDatePickerState
+import androidx.compose.runtime.Composable
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun DatePickerModal(
+    onDateSelected: (Long?) -> Unit,
+    onDismiss: () -> Unit,
+    selectedDate: Long = System.currentTimeMillis()
+) {
+  val datePickerState = rememberDatePickerState(initialSelectedDateMillis = selectedDate)
+
+  DatePickerDialog(
+      onDismissRequest = onDismiss,
+      confirmButton = {
+        TextButton(
+            onClick = {
+              onDateSelected(datePickerState.selectedDateMillis)
+              onDismiss()
+            }) {
+              Text("OK")
+            }
+      },
+      dismissButton = { TextButton(onClick = onDismiss) { Text("Cancel") } }) {
+        DatePicker(state = datePickerState)
+      }
+}

--- a/app/src/main/java/com/android/voyageur/ui/formFields/TimePicker.kt
+++ b/app/src/main/java/com/android/voyageur/ui/formFields/TimePicker.kt
@@ -1,19 +1,16 @@
-package com.android.voyageur.ui
+package com.android.voyageur.ui.formFields
 
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
-import androidx.compose.material3.DatePicker
-import androidx.compose.material3.DatePickerDialog
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.material3.TimeInput
-import androidx.compose.material3.rememberDatePickerState
 import androidx.compose.material3.rememberTimePickerState
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
@@ -21,31 +18,6 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Dialog
 import java.util.Calendar
-
-@OptIn(ExperimentalMaterial3Api::class)
-@Composable
-fun DatePickerModal(
-    onDateSelected: (Long?) -> Unit,
-    onDismiss: () -> Unit,
-    selectedDate: Long = System.currentTimeMillis()
-) {
-  val datePickerState = rememberDatePickerState(initialSelectedDateMillis = selectedDate)
-
-  DatePickerDialog(
-      onDismissRequest = onDismiss,
-      confirmButton = {
-        TextButton(
-            onClick = {
-              onDateSelected(datePickerState.selectedDateMillis)
-              onDismiss()
-            }) {
-              Text("OK")
-            }
-      },
-      dismissButton = { TextButton(onClick = onDismiss) { Text("Cancel") } }) {
-        DatePicker(state = datePickerState)
-      }
-}
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable

--- a/app/src/main/java/com/android/voyageur/ui/navigation/NavigationActions.kt
+++ b/app/src/main/java/com/android/voyageur/ui/navigation/NavigationActions.kt
@@ -4,6 +4,10 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.outlined.Menu
 import androidx.compose.material.icons.outlined.Person
 import androidx.compose.material.icons.outlined.Search
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.navigation.NavGraph.Companion.findStartDestination
 import androidx.navigation.NavHostController
@@ -76,6 +80,24 @@ open class NavigationActions(
       restoreState = true
     }
   }
+
+  /**
+   * This is a mutable state that represents the current tab index for the trip. (0 for Schedule, 1
+   * for Activities, 2 for Settings) This is used to determine which tab is currently selected in
+   * the TobTabs composable for a trip. It needs to be part of the navigation actions in order to
+   * remember which tab was selecting when opening another screen and trying to go back. For
+   * example, when we open AddActivityScreen from the Activities tab, we want to go back to this
+   * tab.
+   */
+  var currentTabIndexForTrip by mutableIntStateOf(0) //defaults to schedule tab
+
+  /**
+   * This is a mutable state that represents whether the daily view is selected in the ByDayScreen.
+   * This is used to determine which view is currently selected in the Schedule Screen. Similarly to
+   * currentTabIndexForTrip, it needs to be part of the navigation actions in order to remember
+   * which view was selected when opening another screen and trying to go back.
+   */
+  var isDailyViewSelected by mutableStateOf(true) //defaults to daily view
 
   /**
    * Navigate to the specified screen.

--- a/app/src/main/java/com/android/voyageur/ui/navigation/NavigationActions.kt
+++ b/app/src/main/java/com/android/voyageur/ui/navigation/NavigationActions.kt
@@ -89,7 +89,7 @@ open class NavigationActions(
    * example, when we open AddActivityScreen from the Activities tab, we want to go back to this
    * tab.
    */
-  var currentTabIndexForTrip by mutableIntStateOf(0) //defaults to schedule tab
+  var currentTabIndexForTrip by mutableIntStateOf(0) // defaults to schedule tab
 
   /**
    * This is a mutable state that represents whether the daily view is selected in the ByDayScreen.
@@ -97,7 +97,7 @@ open class NavigationActions(
    * currentTabIndexForTrip, it needs to be part of the navigation actions in order to remember
    * which view was selected when opening another screen and trying to go back.
    */
-  var isDailyViewSelected by mutableStateOf(true) //defaults to daily view
+  var isDailyViewSelected by mutableStateOf(true) // defaults to daily view
 
   /**
    * Navigate to the specified screen.

--- a/app/src/main/java/com/android/voyageur/ui/overview/AddTrip.kt
+++ b/app/src/main/java/com/android/voyageur/ui/overview/AddTrip.kt
@@ -31,7 +31,7 @@ import com.android.voyageur.model.location.Location
 import com.android.voyageur.model.trip.Trip
 import com.android.voyageur.model.trip.TripType
 import com.android.voyageur.model.trip.TripsViewModel
-import com.android.voyageur.ui.DatePickerModal
+import com.android.voyageur.ui.formFields.DatePickerModal
 import com.android.voyageur.ui.navigation.NavigationActions
 import com.google.firebase.Firebase
 import com.google.firebase.Timestamp

--- a/app/src/main/java/com/android/voyageur/ui/overview/AddTrip.kt
+++ b/app/src/main/java/com/android/voyageur/ui/overview/AddTrip.kt
@@ -31,6 +31,7 @@ import com.android.voyageur.model.location.Location
 import com.android.voyageur.model.trip.Trip
 import com.android.voyageur.model.trip.TripType
 import com.android.voyageur.model.trip.TripsViewModel
+import com.android.voyageur.ui.DatePickerModal
 import com.android.voyageur.ui.navigation.NavigationActions
 import com.google.firebase.Firebase
 import com.google.firebase.Timestamp
@@ -65,9 +66,6 @@ fun AddTripScreen(
   val dateFormat = SimpleDateFormat("dd MMM yyyy", Locale.getDefault())
   val formattedStartDate = startDate?.let { dateFormat.format(Date(it)) } ?: ""
   val formattedEndDate = endDate?.let { dateFormat.format(Date(it)) } ?: ""
-
-  val disabledBorderColor = Color.DarkGray
-  val disabledTextColor = Color.Black
 
   val galleryLauncher =
       rememberLauncherForActivityResult(
@@ -345,30 +343,4 @@ fun AddTripScreen(
 enum class DateField {
   START,
   END
-}
-
-@OptIn(ExperimentalMaterial3Api::class)
-@Composable
-fun DatePickerModal(
-    onDateSelected: (Long?) -> Unit,
-    onDismiss: () -> Unit,
-    selectedDate: Long = System.currentTimeMillis()
-) {
-
-  val datePickerState = rememberDatePickerState(initialSelectedDateMillis = selectedDate)
-
-  DatePickerDialog(
-      onDismissRequest = onDismiss,
-      confirmButton = {
-        TextButton(
-            onClick = {
-              onDateSelected(datePickerState.selectedDateMillis)
-              onDismiss()
-            }) {
-              Text("OK")
-            }
-      },
-      dismissButton = { TextButton(onClick = onDismiss) { Text("Cancel") } }) {
-        DatePicker(state = datePickerState)
-      }
 }

--- a/app/src/main/java/com/android/voyageur/ui/trip/AddActivity.kt
+++ b/app/src/main/java/com/android/voyageur/ui/trip/AddActivity.kt
@@ -24,8 +24,8 @@ import com.android.voyageur.model.activity.ActivityType
 import com.android.voyageur.model.location.Location
 import com.android.voyageur.model.trip.Trip
 import com.android.voyageur.model.trip.TripsViewModel
-import com.android.voyageur.ui.DatePickerModal
-import com.android.voyageur.ui.TimePickerInput
+import com.android.voyageur.ui.formFields.DatePickerModal
+import com.android.voyageur.ui.formFields.TimePickerInput
 import com.android.voyageur.ui.navigation.NavigationActions
 import com.google.firebase.Timestamp
 import java.text.SimpleDateFormat

--- a/app/src/main/java/com/android/voyageur/ui/trip/AddActivity.kt
+++ b/app/src/main/java/com/android/voyageur/ui/trip/AddActivity.kt
@@ -17,7 +17,6 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.text.input.KeyboardType
-import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Dialog
 import com.android.voyageur.model.activity.Activity
@@ -25,6 +24,8 @@ import com.android.voyageur.model.activity.ActivityType
 import com.android.voyageur.model.location.Location
 import com.android.voyageur.model.trip.Trip
 import com.android.voyageur.model.trip.TripsViewModel
+import com.android.voyageur.ui.DatePickerModal
+import com.android.voyageur.ui.TimePickerInput
 import com.android.voyageur.ui.navigation.NavigationActions
 import com.google.firebase.Timestamp
 import java.text.SimpleDateFormat
@@ -214,7 +215,8 @@ fun AddActivityScreen(tripsViewModel: TripsViewModel, navigationActions: Navigat
                         activityDate = selectedDate
                         showModal = false
                       },
-                      onDismiss = { showModal = false })
+                      onDismiss = { showModal = false },
+                      selectedDate = System.currentTimeMillis())
                 }
 
                 FlowRow(
@@ -356,76 +358,7 @@ fun AddActivityScreen(tripsViewModel: TripsViewModel, navigationActions: Navigat
       }
 }
 
-@OptIn(ExperimentalMaterial3Api::class)
-@Composable
-fun DatePickerModal(onDateSelected: (Long?) -> Unit, onDismiss: () -> Unit) {
-  val datePickerState = rememberDatePickerState()
-
-  DatePickerDialog(
-      onDismissRequest = onDismiss,
-      confirmButton = {
-        TextButton(
-            onClick = {
-              onDateSelected(datePickerState.selectedDateMillis)
-              onDismiss()
-            }) {
-              Text("OK")
-            }
-      },
-      dismissButton = { TextButton(onClick = onDismiss) { Text("Cancel") } }) {
-        DatePicker(state = datePickerState)
-      }
-}
-
 enum class TimeField {
   START,
   END
-}
-
-@OptIn(ExperimentalMaterial3Api::class)
-@Composable
-fun TimePickerInput(
-    initialHour: Int?,
-    initialMinute: Int?,
-    onTimeSelected: (Long?) -> Unit,
-    onDismiss: () -> Unit
-) {
-  val timeState = rememberTimePickerState(is24Hour = true)
-
-  if (initialHour != null && initialMinute != null) {
-    timeState.hour = initialHour
-    timeState.minute = initialMinute
-  }
-
-  Dialog(onDismissRequest = onDismiss) {
-    Surface(
-        shape = MaterialTheme.shapes.extraLarge,
-        tonalElevation = 10.dp,
-        modifier = Modifier.padding(16.dp)) {
-          Column(modifier = Modifier.padding(16.dp)) {
-            Text(
-                modifier = Modifier.fillMaxWidth().padding(bottom = 16.dp),
-                text = "Select time",
-                textAlign = TextAlign.Center,
-                style = MaterialTheme.typography.headlineMedium)
-            TimeInput(state = timeState)
-            Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.End) {
-              TextButton(onClick = onDismiss) { Text(text = "Cancel") }
-              TextButton(
-                  onClick = {
-                    val selectedTime =
-                        Calendar.getInstance()
-                            .apply {
-                              set(Calendar.HOUR_OF_DAY, timeState.hour)
-                              set(Calendar.MINUTE, timeState.minute)
-                            }
-                            .timeInMillis
-                    onTimeSelected(selectedTime)
-                  }) {
-                    Text(text = "OK")
-                  }
-            }
-          }
-        }
-  }
 }

--- a/app/src/main/java/com/android/voyageur/ui/trip/Tabs.kt
+++ b/app/src/main/java/com/android/voyageur/ui/trip/Tabs.kt
@@ -7,8 +7,6 @@ import androidx.compose.material3.TabRow
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableIntStateOf
-import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
@@ -25,9 +23,6 @@ fun TopTabs(tripsViewModel: TripsViewModel, navigationActions: NavigationActions
   // Define tab items
   val tabs = listOf("Schedule", "Activities", "Settings")
 
-  // Remember the currently selected tab index
-  var selectedTabIndex by remember { mutableIntStateOf(0) }
-
   val trip =
       tripsViewModel.selectedTrip.value
           ?: return Text(text = "No trip selected. Should not happen", color = Color.Red)
@@ -37,33 +32,36 @@ fun TopTabs(tripsViewModel: TripsViewModel, navigationActions: NavigationActions
     TopBarWithImage(trip, navigationActions)
     // TabRow composable for creating top tabs
     TabRow(
-        selectedTabIndex = selectedTabIndex,
+        selectedTabIndex = navigationActions.currentTabIndexForTrip,
         modifier = Modifier.fillMaxWidth().testTag("tabRow"),
     ) {
       // Create each tab with a Tab composable
       tabs.forEachIndexed { index, title ->
         Tab(
-            selected = selectedTabIndex == index,
-            onClick = { selectedTabIndex = index },
+            selected = navigationActions.currentTabIndexForTrip == index,
+            onClick = { navigationActions.currentTabIndexForTrip = index },
             text = { Text(title) })
       }
     }
 
     // Display content based on selected tab
-    when (selectedTabIndex) {
-      0 -> ScheduleScreen(trip, navigationActions)
+    when (navigationActions.currentTabIndexForTrip) {
+      0 -> {
+        ScheduleScreen(trip, navigationActions)
+      }
       1 -> {
         ActivitiesScreen(trip, navigationActions)
       }
-      2 ->
-          SettingsScreen(
-              trip,
-              navigationActions,
-              tripsViewModel = tripsViewModel,
-              onUpdate = {
-                selectedTabIndex = 0
-                selectedTabIndex = 2
-              })
+      2 -> {
+        SettingsScreen(
+            trip,
+            navigationActions,
+            tripsViewModel = tripsViewModel,
+            onUpdate = {
+              navigationActions.currentTabIndexForTrip = 0
+              navigationActions.currentTabIndexForTrip = 2
+            })
+      }
     }
   }
 }

--- a/app/src/main/java/com/android/voyageur/ui/trip/Tabs.kt
+++ b/app/src/main/java/com/android/voyageur/ui/trip/Tabs.kt
@@ -16,7 +16,6 @@ import androidx.compose.ui.platform.testTag
 import com.android.voyageur.model.trip.TripsViewModel
 import com.android.voyageur.ui.navigation.NavigationActions
 import com.android.voyageur.ui.trip.activities.ActivitiesScreen
-import com.android.voyageur.ui.trip.activities.SAMPLE_ACTIVITIES
 import com.android.voyageur.ui.trip.schedule.ScheduleScreen
 import com.android.voyageur.ui.trip.schedule.TopBarWithImage
 import com.android.voyageur.ui.trip.settings.SettingsScreen
@@ -54,7 +53,6 @@ fun TopTabs(tripsViewModel: TripsViewModel, navigationActions: NavigationActions
     when (selectedTabIndex) {
       0 -> ScheduleScreen(trip, navigationActions)
       1 -> {
-        trip.activities = SAMPLE_ACTIVITIES
         ActivitiesScreen(trip, navigationActions)
       }
       2 ->

--- a/app/src/main/java/com/android/voyageur/ui/trip/activities/Activities.kt
+++ b/app/src/main/java/com/android/voyageur/ui/trip/activities/Activities.kt
@@ -14,8 +14,10 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.ArrowDropDown
+import androidx.compose.material.icons.outlined.Add
 import androidx.compose.material.icons.twotone.Delete
 import androidx.compose.material3.Card
+import androidx.compose.material3.FloatingActionButton
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
@@ -35,15 +37,14 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.android.voyageur.model.activity.Activity
-import com.android.voyageur.model.activity.ActivityType
 import com.android.voyageur.model.activity.hasDescription
 import com.android.voyageur.model.activity.hasEndDate
 import com.android.voyageur.model.activity.hasStartTime
-import com.android.voyageur.model.location.Location
 import com.android.voyageur.model.trip.Trip
 import com.android.voyageur.ui.navigation.BottomNavigationMenu
 import com.android.voyageur.ui.navigation.LIST_TOP_LEVEL_DESTINATION
 import com.android.voyageur.ui.navigation.NavigationActions
+import com.android.voyageur.ui.navigation.Screen
 import com.google.firebase.Timestamp
 import java.time.ZoneId
 import java.time.format.DateTimeFormatter
@@ -61,9 +62,15 @@ fun ActivitiesScreen(
         activity.startTime == Timestamp(0, 0) || activity.endTime == Timestamp(0, 0)
       }
   val final =
-      trip.activities.filter { activity ->
-        activity.startTime != Timestamp(0, 0) && activity.endTime != Timestamp(0, 0)
-      }
+      trip.activities
+          .filter { activity ->
+            activity.startTime != Timestamp(0, 0) && activity.endTime != Timestamp(0, 0)
+          }
+          .sortedWith(
+              compareBy(
+                  { it.startTime }, // First, sort by startTime
+                  { it.endTime } // If startTime is equal, sort by endTime
+                  ))
 
   Scaffold(
       // TODO: Search Bar
@@ -73,6 +80,16 @@ fun ActivitiesScreen(
             onTabSelect = { route -> navigationActions.navigateTo(route) },
             tabList = LIST_TOP_LEVEL_DESTINATION,
             selectedItem = navigationActions.currentRoute())
+      },
+      floatingActionButton = {
+        FloatingActionButton(
+            onClick = { navigationActions.navigateTo(Screen.ADD_ACTIVITY) },
+            modifier = Modifier.testTag("createActivityButton")) {
+              Icon(
+                  Icons.Outlined.Add,
+                  "Floating action button",
+                  modifier = Modifier.testTag("addIcon"))
+            }
       },
       content = { pd ->
         LazyColumn(
@@ -213,79 +230,3 @@ fun ActivityItem(
         }
       })
 }
-
-fun createTimestamp(year: Int, month: Int, day: Int, hour: Int, minute: Int): Timestamp {
-  val calendar = java.util.Calendar.getInstance()
-  calendar.set(year, month - 1, day, hour, minute) // Month is 0-based
-  return Timestamp(calendar.time)
-}
-
-val SAMPLE_ACTIVITIES =
-    listOf(
-        Activity(
-            title = "Breakfast",
-            description = "",
-            activityType = ActivityType.RESTAURANT,
-            startTime = createTimestamp(2024, 11, 3, 10, 0),
-            endTime = createTimestamp(2024, 11, 3, 12, 30),
-            estimatedPrice = 20.25,
-            location = Location()),
-        Activity(
-            title = "Lunch",
-        ),
-        Activity(
-            title = "Dinner",
-            description = "Dinner description",
-            activityType = ActivityType.RESTAURANT,
-            startTime = Timestamp.now(),
-            endTime = Timestamp.now(),
-            estimatedPrice = 23.25,
-            location = Location()),
-        Activity(
-            title = "Dinner2",
-            description = "",
-            activityType = ActivityType.RESTAURANT,
-            startTime = Timestamp.now(),
-            endTime = Timestamp.now(),
-            estimatedPrice = 23.25,
-            location = Location()),
-        Activity(
-            title = "Dinner3",
-            description = "",
-            activityType = ActivityType.RESTAURANT,
-            startTime = createTimestamp(2024, 11, 3, 19, 30),
-            endTime = createTimestamp(2024, 11, 3, 21, 0),
-            estimatedPrice = 23.25,
-            location = Location()),
-        Activity(
-            title = "Dinner4",
-            description = "Too long description to be displayed on the Activity Box",
-            activityType = ActivityType.RESTAURANT,
-            startTime = Timestamp.now(),
-            endTime = Timestamp.now(),
-            estimatedPrice = 23.25,
-            location = Location()),
-        Activity(
-            title = "Dinner5",
-            description = "",
-            activityType = ActivityType.RESTAURANT,
-            startTime = Timestamp.now(),
-            endTime = Timestamp.now(),
-            estimatedPrice = 23.25,
-            location = Location()),
-        Activity(
-            title = "Too long name to be displayed on the Activity Box",
-            description = "",
-            activityType = ActivityType.OTHER,
-            startTime = Timestamp.now(),
-            endTime = Timestamp.now(),
-            estimatedPrice = 00.00,
-            location = Location()),
-        Activity(
-            title = "Visit city",
-            description = "",
-            activityType = ActivityType.OTHER,
-            startTime = Timestamp.now(),
-            endTime = Timestamp.now(),
-            estimatedPrice = 00.00,
-            location = Location()))

--- a/app/src/main/java/com/android/voyageur/ui/trip/schedule/ScheduleScreen.kt
+++ b/app/src/main/java/com/android/voyageur/ui/trip/schedule/ScheduleScreen.kt
@@ -11,8 +11,6 @@ import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -23,7 +21,7 @@ import com.android.voyageur.ui.navigation.NavigationActions
 
 @Composable
 fun ScheduleScreen(trip: Trip, navigationActions: NavigationActions) {
-  var isDailySelected by remember { mutableStateOf(true) }
+  //  var isDailySelected by remember { mutableStateOf(navigationActions.isDailyViewSelected) }
 
   Column(modifier = Modifier.fillMaxSize().padding(top = 8.dp)) {
     // Row for the "Daily" and "Weekly" buttons
@@ -31,38 +29,42 @@ fun ScheduleScreen(trip: Trip, navigationActions: NavigationActions) {
         modifier = Modifier.fillMaxWidth().padding(bottom = 8.dp, end = 16.dp),
         horizontalArrangement = Arrangement.End,
         verticalAlignment = Alignment.CenterVertically) {
-          TextButton(onClick = { isDailySelected = true }) {
+          TextButton(onClick = { navigationActions.isDailyViewSelected = true }) {
             Text(
                 text = "Daily",
                 style = MaterialTheme.typography.bodyMedium,
                 color =
-                    if (isDailySelected) MaterialTheme.colorScheme.primary
+                    if (navigationActions.isDailyViewSelected) MaterialTheme.colorScheme.primary
                     else MaterialTheme.colorScheme.onSurface.copy(alpha = 0.6f),
-                fontWeight = if (isDailySelected) FontWeight.Bold else FontWeight.Normal)
+                fontWeight =
+                    if (navigationActions.isDailyViewSelected) FontWeight.Bold
+                    else FontWeight.Normal)
           }
           Text(
               text = " / ",
               style = MaterialTheme.typography.bodyMedium,
               color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.6f))
-          TextButton(onClick = { isDailySelected = false }) {
+          TextButton(onClick = { navigationActions.isDailyViewSelected = false }) {
             Text(
                 text = "Weekly",
                 style = MaterialTheme.typography.bodyMedium,
                 color =
-                    if (!isDailySelected) MaterialTheme.colorScheme.primary
+                    if (!navigationActions.isDailyViewSelected) MaterialTheme.colorScheme.primary
                     else MaterialTheme.colorScheme.onSurface.copy(alpha = 0.6f),
-                fontWeight = if (!isDailySelected) FontWeight.Bold else FontWeight.Normal)
+                fontWeight =
+                    if (!navigationActions.isDailyViewSelected) FontWeight.Bold
+                    else FontWeight.Normal)
           }
         }
 
-    // Conditionally show content based on isDailySelected
-    if (isDailySelected) {
+    // Conditionally show content based on isDailyViewSelected
+    if (navigationActions.isDailyViewSelected) {
       ByDayScreen(trip, navigationActions)
     } else {
       WeeklyViewScreen(
           trip = trip,
           navigationActions = navigationActions,
-          onDaySelected = { isDailySelected = true })
+          onDaySelected = { navigationActions.isDailyViewSelected = true })
     }
   }
 }


### PR DESCRIPTION
## Summary

Previously, when navigation changed from Tob Tabs to another screen (e.g. Add Activity Screen) and the user wanted to go back, the Schedule tab with Daily view was always displayed, even if the users invoked the screen from the Activities tab, or the Weekly view.
This bugfix solves this issue. Now the navigation actions remember which tab and view is selected

## Changes
- **Logic/Controllers:** NavigationActions now remembers the currentTripTab and if the daily view is selected or not.
- **Bug Fixes/Improvements:** same as summary, navigation is improved

## Checklist

Ensure all / most of these are checked before the pull request is submitted.
- [x] This PR resolves #135 
- [x] Tests have been added for new functionality.
- [x] Screenshots or UI changes have been attached (if applicable).
- [x] Documentation has been updated (if applicable).

##  Testing

- **Manual Testing:**
    - [x] Tested on emulator / physical device.
- **Unit Tests**
    - [x] Added units tests for this


## Screenshots (if applicable)

[Screen_recording_20241111_151327.webm](https://github.com/user-attachments/assets/3d09887d-efe4-46e0-8ecf-2570fbd816be)
