### PR TITLE
Fix: add trip screen keep activities

### DIFF
--- a/app/src/main/java/com/android/voyageur/ui/overview/AddTrip.kt
+++ b/app/src/main/java/com/android/voyageur/ui/overview/AddTrip.kt
@@ -144,7 +144,9 @@ fun AddTripScreen(
                 },
             startDate = startTimestamp,
             endDate = endTimestamp,
-            activities = listOf(),
+            activities = if (isEditMode)
+                tripsViewModel.selectedTrip.value?.activities ?: listOf()
+                else listOf(),
             type = tripType,
             imageUri = imageUrl)
     if (!isEditMode) {

--- a/app/src/main/java/com/android/voyageur/ui/overview/AddTrip.kt
+++ b/app/src/main/java/com/android/voyageur/ui/overview/AddTrip.kt
@@ -144,8 +144,8 @@ fun AddTripScreen(
                 },
             startDate = startTimestamp,
             endDate = endTimestamp,
-            activities = if (isEditMode)
-                tripsViewModel.selectedTrip.value?.activities ?: listOf()
+            activities =
+                if (isEditMode) tripsViewModel.selectedTrip.value?.activities ?: listOf()
                 else listOf(),
             type = tripType,
             imageUri = imageUrl)


### PR DESCRIPTION
## Summary
Fixed a bug where the activities would dissapear from the trip when saving the trip in the settings screen.
Solves #138 