### PR TITLE
Fix: remember tab navigation

### DIFF
--- a/app/src/androidTest/java/com/android/voyageur/ui/gallery/PermissionButtonGalleryTest.kt
+++ b/app/src/androidTest/java/com/android/voyageur/ui/gallery/PermissionButtonGalleryTest.kt
@@ -1,0 +1,91 @@
+package com.android.voyageur.ui.gallery
+
+import android.content.Context
+import android.content.pm.PackageManager.PERMISSION_DENIED
+import android.content.pm.PackageManager.PERMISSION_GRANTED
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithText
+import androidx.core.content.ContextCompat
+import junit.framework.TestCase.assertFalse
+import junit.framework.TestCase.assertTrue
+import org.junit.Rule
+import org.junit.Test
+import org.mockito.Mockito.mock
+import org.mockito.Mockito.`when`
+
+class PermissionButtonForGalleryTest {
+
+  @get:Rule val composeTestRule = createComposeRule()
+
+  @Test
+  fun buttonIsDisplayedWithCorrectText() {
+    val message = "Open Gallery"
+    composeTestRule.setContent {
+      PermissionButtonForGallery(
+          onUriSelected = {},
+          messageToShow = message,
+          dialogMessage = "Permission is required to access the gallery.")
+    }
+    composeTestRule.onNodeWithText(message).assertExists().assertIsDisplayed()
+  }
+
+  @Test
+  fun checkPermissionReturnsTrue() {
+    // Mock context
+    val context = mock(Context::class.java)
+    // Mock full permission granted to return PERMISSION_GRANTED
+    `when`(ContextCompat.checkSelfPermission(context, "android.permission.READ_MEDIA_IMAGES"))
+        .thenReturn(PERMISSION_GRANTED)
+
+    val result = checkFullPermission(context)
+    assertTrue(result)
+  }
+
+  @Test
+  fun checkPermissionReturnsFalse() {
+    // Mock context
+    val context = mock(Context::class.java)
+
+    // Mock the permission check to return PERMISSION_DENIED
+    `when`(ContextCompat.checkSelfPermission(context, "android.permission.READ_MEDIA_IMAGES"))
+        .thenReturn(PERMISSION_DENIED)
+    `when`(
+            ContextCompat.checkSelfPermission(
+                context, "android.permission.READ_MEDIA_VISUAL_USER_SELECTED"))
+        .thenReturn(PERMISSION_DENIED)
+    `when`(ContextCompat.checkSelfPermission(context, "android.permission.READ_EXTERNAL_STORAGE"))
+        .thenReturn(PERMISSION_DENIED)
+
+    val result = checkFullPermission(context)
+    assertFalse(result)
+  }
+
+  @Test
+  fun checkLimitedPermissionReturnsTrue() {
+    // Mock the context
+    val context = mock(Context::class.java)
+
+    // Mock the permission check to return PERMISSION_GRANTED for limited access
+    `when`(
+            ContextCompat.checkSelfPermission(
+                context, "android.permission.READ_MEDIA_VISUAL_USER_SELECTED"))
+        .thenReturn(PERMISSION_GRANTED)
+
+    val result = checkLimitedPermission(context)
+    assertTrue(result)
+  }
+
+  @Test
+  fun checkLimitedPermissionReturnsFalse() {
+    val context = mock(Context::class.java)
+
+    `when`(
+            ContextCompat.checkSelfPermission(
+                context, "android.permission.READ_MEDIA_VISUAL_USER_SELECTED"))
+        .thenReturn(PERMISSION_DENIED)
+
+    val result = checkLimitedPermission(context)
+    assertFalse(result)
+  }
+}

--- a/app/src/androidTest/java/com/android/voyageur/ui/overview/AddTripTest.kt
+++ b/app/src/androidTest/java/com/android/voyageur/ui/overview/AddTripTest.kt
@@ -1,7 +1,5 @@
 package com.android.voyageur.ui.overview
 
-import android.content.Context
-import android.content.pm.PackageManager
 import android.icu.util.GregorianCalendar
 import android.icu.util.TimeZone
 import androidx.compose.ui.test.assertHasClickAction
@@ -16,7 +14,6 @@ import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.performTextInput
-import androidx.core.content.ContextCompat
 import com.android.voyageur.model.location.Location
 import com.android.voyageur.model.trip.Trip
 import com.android.voyageur.model.trip.TripRepository
@@ -27,8 +24,6 @@ import com.android.voyageur.ui.navigation.Screen
 import com.google.firebase.Timestamp
 import com.google.firebase.auth.FirebaseAuth
 import java.util.Date
-import junit.framework.TestCase.assertFalse
-import junit.framework.TestCase.assertTrue
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
@@ -331,7 +326,7 @@ class AddTripScreenTest {
     assert(result == null)
   }
 
-  @Test
+  /*@Test
   fun checkPermissionReturnsTrue() {
     // Mock context
     val context = mock(Context::class.java)
@@ -342,9 +337,9 @@ class AddTripScreenTest {
 
     val result = checkFullPermission(context)
     assertTrue(result) // Expecting true because permission is granted
-  }
+  }*/
 
-  @Test
+  /*@Test
   fun checkPermissionReturnsTrueLimitedPermission() {
     // Mock context
     val context = mock(Context::class.java)
@@ -357,28 +352,28 @@ class AddTripScreenTest {
 
     val result = checkLimitedPermission(context)
     assertTrue(result) // Expecting true because permission is granted
-  }
+  }*/
 
-  @Test
-  fun checkPermissionReturnsFalse() {
-    // Mock context
-    val context = mock(Context::class.java)
+  /*@Test
+    fun checkPermissionReturnsFalse() {
+      // Mock context
+      val context = mock(Context::class.java)
 
-    // Mock the permission check to return PERMISSION_DENIED
-    `when`(ContextCompat.checkSelfPermission(context, "android.permission.READ_MEDIA_IMAGES"))
-        .thenReturn(PackageManager.PERMISSION_DENIED)
-    `when`(
-            ContextCompat.checkSelfPermission(
-                context, "android.permission.READ_MEDIA_VISUAL_USER_SELECTED"))
-        .thenReturn(PackageManager.PERMISSION_DENIED)
-    `when`(ContextCompat.checkSelfPermission(context, "android.permission.READ_EXTERNAL_STORAGE"))
-        .thenReturn(PackageManager.PERMISSION_DENIED)
+      // Mock the permission check to return PERMISSION_DENIED
+      `when`(ContextCompat.checkSelfPermission(context, "android.permission.READ_MEDIA_IMAGES"))
+          .thenReturn(PackageManager.PERMISSION_DENIED)
+      `when`(
+              ContextCompat.checkSelfPermission(
+                  context, "android.permission.READ_MEDIA_VISUAL_USER_SELECTED"))
+          .thenReturn(PackageManager.PERMISSION_DENIED)
+      `when`(ContextCompat.checkSelfPermission(context, "android.permission.READ_EXTERNAL_STORAGE"))
+          .thenReturn(PackageManager.PERMISSION_DENIED)
 
-    val result = checkFullPermission(context)
-    assertFalse(result) // Expecting false because permission is not granted
-  }
-
-  @Test
+      val result = checkFullPermission(context)
+      assertFalse(result) // Expecting false because permission is not granted
+    }
+  */
+  /*@Test
   fun checkLimitedPermissionReturnsTrue() {
     // Mock the context
     val context = mock(Context::class.java)
@@ -391,9 +386,9 @@ class AddTripScreenTest {
 
     val result = checkLimitedPermission(context)
     assertTrue(result) // Expecting true because limited permission is granted
-  }
+  }*/
 
-  @Test
+  /*@Test
   fun checkLimitedPermissionReturnsFalse() {
     // Mock the context
     val context = mock(Context::class.java)
@@ -406,5 +401,5 @@ class AddTripScreenTest {
 
     val result = checkLimitedPermission(context)
     assertFalse(result) // Expecting false because limited permission is not granted
-  }
+  }*/
 }

--- a/app/src/androidTest/java/com/android/voyageur/ui/profile/EditProfileScreenTest.kt
+++ b/app/src/androidTest/java/com/android/voyageur/ui/profile/EditProfileScreenTest.kt
@@ -172,16 +172,6 @@ class EditProfileScreenTest {
     composeTestRule.onNodeWithTag("emailField").assertIsNotEnabled()
   }
 
-  @Test
-  fun noUserDataDisplaysMessage() {
-    // Arrange: Set user to null and isLoading to false
-    userViewModel._user.value = null
-    userViewModel._isLoading.value = false
-
-    // Assert: Check that the "No user data available" text is displayed
-    composeTestRule.onNodeWithTag("noUserData").assertIsDisplayed()
-    composeTestRule.onNodeWithText("No user data available").assertIsDisplayed()
-  }
   // New test: Add Interest
   @Test
   fun addInterestSuccessfully() {

--- a/app/src/androidTest/java/com/android/voyageur/ui/profile/ProfileScreenTest.kt
+++ b/app/src/androidTest/java/com/android/voyageur/ui/profile/ProfileScreenTest.kt
@@ -122,19 +122,16 @@ class ProfileScreenTest {
 
   @Test
   fun displayProfilePictureWhenUserHasProfilePicture() {
-    // Arrange: Mock a user with a profile picture
     val user =
         User(
             "123",
             "Jane Doe",
             "jane@example.com",
-            profilePicture = "http://example.com/profile.jpg",
-            interests = emptyList())
+            profilePicture = "http://example.com/profile.jpg")
     userViewModel._user.value = user
     userViewModel._isLoading.value = false
 
-    // Assert: Check that the profile picture is displayed
-    composeTestRule.onNodeWithTag("profilePicture").assertIsDisplayed()
+    composeTestRule.onNodeWithTag("userProfilePicture").assertIsDisplayed()
   }
 
   @Test

--- a/app/src/androidTest/java/com/android/voyageur/ui/search/SearchUserProfileTest.kt
+++ b/app/src/androidTest/java/com/android/voyageur/ui/search/SearchUserProfileTest.kt
@@ -1,0 +1,122 @@
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.onNodeWithText
+import com.android.voyageur.model.user.User
+import com.android.voyageur.model.user.UserRepository
+import com.android.voyageur.model.user.UserViewModel
+import com.android.voyageur.ui.navigation.NavigationActions
+import com.android.voyageur.ui.navigation.Route
+import com.android.voyageur.ui.search.SearchUserProfileScreen
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.mockito.Mockito.*
+
+class SearchUserProfileScreenTest {
+
+  private lateinit var navigationActions: NavigationActions
+  private lateinit var userRepository: UserRepository
+  private lateinit var userViewModel: UserViewModel
+
+  @get:Rule val composeTestRule = createComposeRule()
+
+  @Before
+  fun setUp() {
+    navigationActions = mock(NavigationActions::class.java)
+    userRepository = mock(UserRepository::class.java)
+    userViewModel = UserViewModel(userRepository)
+
+    // Initialize 'user' with a valid User instance
+    userViewModel._user.value =
+        User(id = "123", name = "Test User", email = "test@example.com", contacts = mutableListOf())
+    val selectedUser =
+        User("123", "Test User", "test@example.com", interests = listOf("Reading", "Travel"))
+    userViewModel._selectedUser.value = selectedUser
+
+    composeTestRule.setContent {
+      SearchUserProfileScreen(userViewModel = userViewModel, navigationActions = navigationActions)
+    }
+  }
+
+  @Test
+  fun testUserProfileContentDisplaysCorrectly() {
+    composeTestRule.onNodeWithTag("userProfileContent").assertIsDisplayed()
+    composeTestRule.onNodeWithTag("userName").assertIsDisplayed()
+    composeTestRule.onNodeWithTag("userEmail").assertIsDisplayed()
+    composeTestRule.onNodeWithTag("interestsFlowRow").assertIsDisplayed()
+    composeTestRule.onNodeWithText("Reading").assertIsDisplayed()
+    composeTestRule.onNodeWithText("Travel").assertIsDisplayed()
+  }
+
+  @Test
+  fun testLoadingIndicatorDisplaysWhenLoading() {
+    userViewModel._isLoading.value = true
+    userViewModel._selectedUser.value = null
+    composeTestRule.onNodeWithTag("userProfileLoadingIndicator").assertIsDisplayed()
+  }
+
+  @Test
+  fun testDefaultProfilePictureDisplaysWhenNoPicture() {
+    val userWithoutPicture = User("123", "Test User", "test@example.com", profilePicture = "")
+    userViewModel._selectedUser.value = userWithoutPicture
+    userViewModel._isLoading.value = false
+
+    composeTestRule.onNodeWithTag("defaultProfilePicture").assertIsDisplayed()
+  }
+
+  @Test
+  fun testProfilePictureDisplaysWhenUserHasPicture() {
+    val userWithPicture =
+        User(
+            "123",
+            "Test User",
+            "test@example.com",
+            profilePicture = "http://example.com/profile.jpg")
+    userViewModel._selectedUser.value = userWithPicture
+    userViewModel._isLoading.value = false
+
+    composeTestRule.onNodeWithTag("userProfilePicture").assertIsDisplayed()
+  }
+
+  @Test
+  fun testDisplaysNoNameAndNoEmailWhenEmptyFields() {
+    val userWithEmptyFields = User("123", "", "", interests = emptyList())
+    userViewModel._selectedUser.value = userWithEmptyFields
+    userViewModel._isLoading.value = false
+
+    composeTestRule.onNodeWithTag("userName").assertIsDisplayed()
+    composeTestRule.onNodeWithText("No name available").assertIsDisplayed()
+    composeTestRule.onNodeWithTag("userEmail").assertIsDisplayed()
+    composeTestRule.onNodeWithText("No email available").assertIsDisplayed()
+  }
+
+  @Test
+  fun testNoInterestsMessageDisplaysWhenUserHasNoInterests() {
+    val userWithNoInterests = User("123", "Test User", "test@example.com", interests = emptyList())
+    userViewModel._selectedUser.value = userWithNoInterests
+    userViewModel._isLoading.value = false
+
+    composeTestRule.onNodeWithTag("noInterests").assertIsDisplayed()
+    composeTestRule.onNodeWithText("No interests added yet").assertIsDisplayed()
+  }
+
+  @Test
+  fun testAddContactButtonWhenContactNotAdded() {
+    val user = User("123", "Test User", "test@example.com")
+    userViewModel._selectedUser.value = user
+    userViewModel._isLoading.value = false
+
+    composeTestRule.onNodeWithTag("userProfileAddRemoveContactButton").assertIsDisplayed()
+    composeTestRule.onNodeWithText("Add to contacts").assertIsDisplayed()
+  }
+
+  @Test
+  fun testNavigateBackToSearchWhenNoUserDataAvailable() {
+    userViewModel._selectedUser.value = null
+    userViewModel._isLoading.value = false
+
+    composeTestRule.onNodeWithTag("userProfileScreen").assertDoesNotExist()
+    verify(navigationActions).navigateTo(Route.SEARCH)
+  }
+}

--- a/app/src/androidTest/java/com/android/voyageur/ui/trip/AddActivityTest.kt
+++ b/app/src/androidTest/java/com/android/voyageur/ui/trip/AddActivityTest.kt
@@ -44,8 +44,9 @@ class AddActivityScreenTest {
     whenever(tripsViewModel.getNewTripId()).thenReturn("mockTripId")
     doNothing().`when`(tripRepository).updateTrip(any(), any(), any())
 
+    val toastMock = mockk<Toast>(relaxed = true)
     mockkStatic(Toast::class)
-    every { Toast.makeText(any(), any<String>(), any()) } returns mockk()
+    every { Toast.makeText(any(), any<String>(), any()) } returns toastMock
   }
 
   @Test

--- a/app/src/androidTest/java/com/android/voyageur/ui/trip/TobTabsTest.kt
+++ b/app/src/androidTest/java/com/android/voyageur/ui/trip/TobTabsTest.kt
@@ -32,14 +32,6 @@ class TopTabsTest {
   }
 
   @Test
-  fun displayTextWhenNoTripSelected() {
-    composeTestRule.setContent { TopTabs(tripsViewModel, navigationActions) }
-
-    // Verify that the "No trip selected" text is displayed
-    composeTestRule.onNodeWithText("No trip selected. Should not happen").assertIsDisplayed()
-  }
-
-  @Test
   fun topAppBar_DisplaysTripName() {
     tripsViewModel.selectTrip(sampleTrip)
     composeTestRule.setContent { TopTabs(tripsViewModel, navigationActions) }

--- a/app/src/androidTest/java/com/android/voyageur/ui/trip/TobTabsTest.kt
+++ b/app/src/androidTest/java/com/android/voyageur/ui/trip/TobTabsTest.kt
@@ -2,16 +2,15 @@ package com.android.voyageur.ui.trip
 
 import androidx.compose.ui.test.*
 import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.navigation.NavHostController
 import com.android.voyageur.model.trip.Trip
 import com.android.voyageur.model.trip.TripRepository
 import com.android.voyageur.model.trip.TripsViewModel
 import com.android.voyageur.ui.navigation.NavigationActions
-import com.android.voyageur.ui.navigation.Route
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.mockito.Mockito.mock
-import org.mockito.Mockito.`when`
 
 class TopTabsTest {
   val sampleTrip = Trip(name = "Sample Trip")
@@ -19,16 +18,16 @@ class TopTabsTest {
   private lateinit var tripRepository: TripRepository
   private lateinit var navigationActions: NavigationActions
   private lateinit var tripsViewModel: TripsViewModel
+  private lateinit var navHostController: NavHostController
 
   @get:Rule val composeTestRule = createComposeRule()
 
   @Before
   fun setUp() {
     tripRepository = mock(TripRepository::class.java)
-    navigationActions = mock(NavigationActions::class.java)
+    navHostController = mock(NavHostController::class.java)
+    navigationActions = NavigationActions(navHostController)
     tripsViewModel = TripsViewModel(tripRepository)
-
-    `when`(navigationActions.currentRoute()).thenReturn(Route.TOP_TABS)
   }
 
   @Test
@@ -73,5 +72,37 @@ class TopTabsTest {
     composeTestRule.onNodeWithText("Settings").performClick()
     composeTestRule.onNodeWithText("Settings").assertIsSelected()
     composeTestRule.onNodeWithTag("settingsScreen").assertIsDisplayed()
+  }
+
+  @Test
+  fun testCurrentTabIndexForTrip_updatesProperly() {
+    // Select the sample trip to set up the test state
+    tripsViewModel.selectTrip(sampleTrip)
+
+    // Set the content to launch the composable
+    composeTestRule.setContent { TopTabs(tripsViewModel, navigationActions) }
+
+    // Verify that each tab is displayed with the correct title
+    composeTestRule.onNodeWithText("Schedule").assertExists()
+    composeTestRule.onNodeWithText("Activities").assertExists()
+    composeTestRule.onNodeWithText("Settings").assertExists()
+
+    // Click on "Activities" tab
+    composeTestRule.onNodeWithText("Activities").performClick()
+
+    // Assert that the currentTabIndexForTrip has been updated to 1 (Activities tab)
+    assert(navigationActions.getNavigationState().currentTabIndexForTrip == 1)
+
+    // Click on "Settings" tab
+    composeTestRule.onNodeWithText("Settings").performClick()
+
+    // Assert that the currentTabIndexForTrip has been updated to 2 (Settings tab)
+    assert(navigationActions.getNavigationState().currentTabIndexForTrip == 2)
+
+    // Click on "Schedule" tab
+    composeTestRule.onNodeWithText("Schedule").performClick()
+
+    // Assert that the currentTabIndexForTrip has been updated to 0 (Schedule tab)
+    assert(navigationActions.getNavigationState().currentTabIndexForTrip == 0)
   }
 }

--- a/app/src/androidTest/java/com/android/voyageur/ui/trip/TobTabsTest.kt
+++ b/app/src/androidTest/java/com/android/voyageur/ui/trip/TobTabsTest.kt
@@ -13,7 +13,7 @@ import org.junit.Test
 import org.mockito.Mockito.mock
 
 class TopTabsTest {
-  val sampleTrip = Trip(name = "Sample Trip")
+  private val sampleTrip = Trip(name = "Sample Trip")
 
   private lateinit var tripRepository: TripRepository
   private lateinit var navigationActions: NavigationActions

--- a/app/src/androidTest/java/com/android/voyageur/ui/trip/schedule/ByDayScreenTest.kt
+++ b/app/src/androidTest/java/com/android/voyageur/ui/trip/schedule/ByDayScreenTest.kt
@@ -4,16 +4,77 @@ import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import com.android.voyageur.model.activity.Activity
+import com.android.voyageur.model.activity.ActivityType
 import com.android.voyageur.model.trip.Trip
 import com.android.voyageur.ui.navigation.LIST_TOP_LEVEL_DESTINATION
 import com.android.voyageur.ui.navigation.NavigationActions
+import com.android.voyageur.ui.navigation.Screen
+import com.android.voyageur.ui.trip.activities.createTimestamp
+import java.time.LocalDate
+import junit.framework.TestCase.assertEquals
+import junit.framework.TestCase.assertTrue
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.mockito.Mockito.mock
+import org.mockito.Mockito.verify
 
 class ByDayScreenTest {
-  private val sampleTrip = Trip(name = "Sample Trip")
+  // Create one activity trip to check for activity box and Day card
+  private val oneActivityTrip =
+      Trip(
+          name = "One Activity Trip",
+          activities =
+              listOf(
+                  Activity(
+                      title = "Final Activity With Description",
+                      description = "This is a final activity",
+                      // This uses the createTimestamp method from ActivitiesScreenTest
+                      startTime = createTimestamp(2022, 1, 1, 12, 0),
+                      endTime = createTimestamp(2022, 1, 1, 14, 0),
+                      estimatedPrice = 20.0,
+                      activityType = ActivityType.RESTAURANT),
+              ))
+
+  // Create multiple activities sample trip to check for groupedActivitiesByDate function
+  private val sampleTrip =
+      Trip(
+          name = "Sample Trip",
+          activities =
+              listOf(
+                  // The activities on 2nd of January have different start time
+                  Activity(
+                      title = "Activity 3",
+                      description = "2 January activity",
+                      startTime = createTimestamp(2022, 1, 2, 12, 0),
+                      endTime = createTimestamp(2022, 1, 2, 14, 0),
+                      estimatedPrice = 20.0,
+                      activityType = ActivityType.RESTAURANT),
+                  Activity(
+                      title = "Activity 2",
+                      description = "2 January activity",
+                      startTime = createTimestamp(2022, 1, 2, 11, 0),
+                      endTime = createTimestamp(2022, 1, 2, 14, 0),
+                      estimatedPrice = 20.0,
+                      activityType = ActivityType.RESTAURANT),
+                  // The activities on 1st of January have the same startTime, but different endTime
+                  Activity(
+                      title = "Activity 1",
+                      description = " 1 January activity",
+                      estimatedPrice = 10.0,
+                      startTime = createTimestamp(2022, 1, 1, 12, 0),
+                      endTime = createTimestamp(2022, 1, 1, 14, 0),
+                      activityType = ActivityType.MUSEUM),
+                  Activity(
+                      title = "Activity 1",
+                      description = " 1 January activity",
+                      estimatedPrice = 10.0,
+                      startTime = createTimestamp(2022, 1, 1, 12, 0),
+                      endTime = createTimestamp(2022, 1, 1, 13, 0),
+                      activityType = ActivityType.MUSEUM),
+              ))
 
   private lateinit var navigationActions: NavigationActions
 
@@ -26,26 +87,14 @@ class ByDayScreenTest {
 
   @Test
   fun hasRequiredComponents() {
-    composeTestRule.setContent { ByDayScreen(sampleTrip, navigationActions) }
+    composeTestRule.setContent { ByDayScreen(oneActivityTrip, navigationActions) }
     composeTestRule.onNodeWithTag("byDayScreen").assertIsDisplayed()
     composeTestRule.onNodeWithTag("bottomNavigationMenu").assertIsDisplayed()
-    // composeTestRule.onNodeWithTag("emptyByDayPrompt").assertIsDisplayed()
   }
-  /*
-   @Test
-   fun displaysCorrectTripName() {
-     composeTestRule.setContent { ByDayScreen(sampleTrip, navigationActions) }
-     composeTestRule
-         .onNodeWithTag("emptyByDayPrompt")
-         .assertTextContains(
-             "You're viewing the ByDay screen for Sample Trip, but it's not implemented yet.")
-   }
-  */
 
   @Test
   fun displaysBottomNavigationCorrectly() {
-    //    tripsViewModel.selectTrip(Trip(name = "Sample Trip"))
-    composeTestRule.setContent { ByDayScreen(sampleTrip, navigationActions) }
+    composeTestRule.setContent { ByDayScreen(oneActivityTrip, navigationActions) }
 
     // Check that the bottom navigation menu is displayed
     composeTestRule.onNodeWithTag("bottomNavigationMenu").assertIsDisplayed()
@@ -53,6 +102,159 @@ class ByDayScreenTest {
     // Verify that the bottom navigation has items with correct actions
     LIST_TOP_LEVEL_DESTINATION.forEach { destination ->
       composeTestRule.onNodeWithText(destination.textId).assertExists()
+    }
+  }
+
+  // Add test for floating action button
+  @Test
+  fun floatingActionButtonIsDisplayed() {
+    composeTestRule.setContent { ByDayScreen(oneActivityTrip, navigationActions) }
+    // Test floating button is displayed
+    composeTestRule.onNodeWithTag("createActivityButton").assertIsDisplayed()
+    // Test correct icon is displayed
+    composeTestRule.onNodeWithTag("addIcon", useUnmergedTree = true).assertIsDisplayed()
+  }
+
+  @Test
+  fun displaysEmptyPromptWhenNoActivities() {
+    // Create a trip with no activities
+    val emptyTrip = Trip(name = "Empty Trip", activities = emptyList())
+
+    composeTestRule.setContent { ByDayScreen(emptyTrip, navigationActions) }
+
+    // Check that the empty state message is displayed
+    composeTestRule.onNodeWithTag("emptyByDayPrompt").assertIsDisplayed()
+    composeTestRule.onNodeWithText("You have no activities yet. Schedule one.").assertIsDisplayed()
+  }
+
+  @Test
+  fun displaysAndMoreTextWhenMoreThanFourActivities() {
+    // Create a trip with more than 4 activities on the same day
+    val tripWithManyActivities =
+        Trip(
+            name = "Busy Trip",
+            activities =
+                List(5) { index ->
+                  Activity(
+                      title = "Activity $index",
+                      startTime = createTimestamp(2022, 1, 1, 10 + index, 0),
+                      endTime = createTimestamp(2022, 1, 1, 11 + index, 0),
+                      activityType = ActivityType.OTHER)
+                })
+    composeTestRule.setContent { ByDayScreen(tripWithManyActivities, navigationActions) }
+
+    // Check that the "and X more" text is displayed
+    composeTestRule.onNodeWithText("and 1 more").assertIsDisplayed()
+  }
+
+  @Test
+  fun dayCardIsDisplayed() {
+    // Create a trip with only one activity to check for day card
+    composeTestRule.setContent { ByDayScreen(oneActivityTrip, navigationActions) }
+    composeTestRule.onNodeWithTag("cardItem", useUnmergedTree = true).assertIsDisplayed()
+  }
+
+  @Test
+  fun activityBoxIsCorrectlyDisplayed() {
+    // Create a trip with only one activity to check for activity box
+    composeTestRule.setContent { ByDayScreen(oneActivityTrip, navigationActions) }
+    // Check activity box is displayed
+    composeTestRule.onNodeWithTag("activityBox", useUnmergedTree = true).assertIsDisplayed()
+    // Check if activity title is displayed
+    composeTestRule
+        .onNodeWithText(oneActivityTrip.activities[0].title, useUnmergedTree = true)
+        .assertIsDisplayed()
+  }
+
+  @Test
+  fun formatDailyDateDisplaysCorrectFormatForValidDate() {
+    val date = LocalDate.of(2024, 1, 1)
+    val expected = "Monday, 1 January"
+    val result = formatDailyDate(date)
+    assertEquals(expected, result)
+  }
+
+  @Test
+  fun activitiesAreGroupedByStartTime() {
+    val diffStartTimeTrip =
+        Trip(
+            name = "Sample Trip",
+            activities =
+                listOf(
+                    // The activities on 2nd of January have different start time
+                    Activity(
+                        title = "Activity 3",
+                        description = "2 January activity",
+                        startTime = createTimestamp(2022, 1, 2, 12, 0),
+                        endTime = createTimestamp(2022, 1, 2, 14, 0),
+                        estimatedPrice = 20.0,
+                        activityType = ActivityType.RESTAURANT),
+                    Activity(
+                        title = "Activity 2",
+                        description = "2 January activity",
+                        startTime = createTimestamp(2022, 1, 2, 11, 0),
+                        endTime = createTimestamp(2022, 1, 2, 14, 0),
+                        estimatedPrice = 20.0,
+                        activityType = ActivityType.RESTAURANT),
+                ))
+
+    val groupedActivities = groupActivitiesByDate(diffStartTimeTrip.activities)
+    // Take the 2 activities which are on the same day, same start time
+    val sortedActivitiesByStart = groupedActivities[LocalDate.of(2022, 1, 2)]
+
+    assertTrue(
+        "Activities are not sorted by start time",
+        sortedActivitiesByStart!![0].startTime <= sortedActivitiesByStart[1].startTime)
+  }
+
+  @Test
+  fun clickingCreateActivityButton_navigatesToAddActivityScreen() {
+    composeTestRule.setContent { ByDayScreen(sampleTrip, navigationActions) }
+
+    composeTestRule.onNodeWithTag("createActivityButton").performClick()
+
+    verify(navigationActions).navigateTo(Screen.ADD_ACTIVITY)
+  }
+
+  @Test
+  fun draftActivitiesAreNotDisplayed() {
+    val tripWithDraftActivities =
+        Trip(
+            name = "Trip with Draft Activities",
+            activities =
+                listOf(
+                    // Draft activity, doesn't have start and end times
+                    Activity(
+                        title = "Draft activity",
+                        description = "This is a published activity",
+                        estimatedPrice = 30.0,
+                        activityType = ActivityType.RESTAURANT,
+                    ),
+                    Activity(
+                        title = "Activity",
+                        description = "2 January activity",
+                        startTime = createTimestamp(2022, 1, 2, 12, 0),
+                        endTime = createTimestamp(2022, 1, 2, 14, 0),
+                        estimatedPrice = 20.0,
+                        activityType = ActivityType.RESTAURANT),
+                ))
+
+    composeTestRule.setContent { ByDayScreen(tripWithDraftActivities, navigationActions) }
+
+    // Check that the non-draft activity is displayed
+    composeTestRule.onNodeWithText("Activity").assertIsDisplayed()
+
+    // Check that the draft activity is NOT displayed
+    composeTestRule.onNodeWithText("Draft Activity").assertDoesNotExist()
+  }
+
+  @Test
+  fun formatDailyDate_ReturnsInvalidDate_ForExceptionScenario() {
+    try {
+      val invalidDate = LocalDate.of(2024, 2, 30) // February 30th does not exist
+      formatDailyDate(invalidDate)
+    } catch (e: Exception) {
+      assertEquals("Invalid date", "Invalid date")
     }
   }
 }

--- a/app/src/androidTest/java/com/android/voyageur/ui/trip/schedule/ScheduleScreenTest.kt
+++ b/app/src/androidTest/java/com/android/voyageur/ui/trip/schedule/ScheduleScreenTest.kt
@@ -2,12 +2,12 @@ package com.android.voyageur.ui.trip.schedule
 
 import androidx.compose.ui.test.*
 import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.navigation.NavHostController
 import com.android.voyageur.model.activity.Activity
 import com.android.voyageur.model.activity.ActivityType
 import com.android.voyageur.model.location.Location
 import com.android.voyageur.model.trip.Trip
 import com.android.voyageur.ui.navigation.NavigationActions
-import com.android.voyageur.ui.navigation.Route
 import com.google.firebase.Timestamp
 import java.time.LocalDateTime
 import java.time.ZoneOffset
@@ -16,21 +16,21 @@ import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.mockito.Mockito
-import org.mockito.Mockito.`when`
 
 class ScheduleScreenTest {
   @get:Rule val composeTestRule = createComposeRule()
 
   private lateinit var navigationActions: NavigationActions
   private lateinit var mockTrip: Trip
+  private lateinit var navHostController: NavHostController
 
   @Before
   fun setUp() {
     // Set default locale for consistent testing
     Locale.setDefault(Locale.US)
 
-    navigationActions = Mockito.mock(NavigationActions::class.java)
-    `when`(navigationActions.currentRoute()).thenReturn(Route.TOP_TABS)
+    navHostController = Mockito.mock(NavHostController::class.java)
+    navigationActions = NavigationActions(navHostController)
 
     mockTrip =
         Trip(
@@ -99,20 +99,6 @@ class ScheduleScreenTest {
   }
 
   @Test
-  fun scheduleScreen_weeklyToDaily_viaActivityClick() {
-    // Switch to Weekly view first
-    composeTestRule.onNodeWithText("Weekly").performClick()
-    composeTestRule.onNodeWithTag("weeklyViewScreen").assertExists()
-
-    // Find and click a day with activities
-    composeTestRule.onNodeWithText("T 3", useUnmergedTree = true).performClick()
-
-    // Verify we're back in Daily view
-    composeTestRule.onNodeWithTag("byDayScreen").assertExists()
-    composeTestRule.onNodeWithTag("weeklyViewScreen").assertDoesNotExist()
-  }
-
-  @Test
   fun scheduleScreen_verifyViewToggleVisuals() {
     // Verify both buttons and separator exist
     composeTestRule.onNodeWithText("Daily").assertExists()
@@ -165,5 +151,15 @@ class ScheduleScreenTest {
     composeTestRule.onNodeWithText("Weekly").performClick()
     composeTestRule.onNodeWithText("Daily").assertIsEnabled()
     composeTestRule.onNodeWithText("Weekly").assertIsEnabled()
+  }
+
+  @Test
+  fun checkIfIsDailyViewSelected_updatesProperly() {
+    assert(navigationActions.getNavigationState().isDailyViewSelected)
+    composeTestRule.onNodeWithText("Weekly").performClick()
+
+    assert(!navigationActions.getNavigationState().isDailyViewSelected)
+    composeTestRule.onNodeWithText("Daily").performClick()
+    assert(navigationActions.getNavigationState().isDailyViewSelected)
   }
 }

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -2,6 +2,7 @@
     xmlns:tools="http://schemas.android.com/tools">
 
     <uses-permission android:name="android.permission.INTERNET" />
+
     <!-- Devices running Android 12L (API level 32) or lower  -->
     <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" android:maxSdkVersion="32" />
 
@@ -11,6 +12,7 @@
     <!-- To handle the reselection within the app on devices running Android 14
          or higher if your app targets Android 14 (API level 34) or higher.  -->
     <uses-permission android:name="android.permission.READ_MEDIA_VISUAL_USER_SELECTED" />
+
     <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
     <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
 

--- a/app/src/main/java/com/android/voyageur/App.kt
+++ b/app/src/main/java/com/android/voyageur/App.kt
@@ -18,6 +18,7 @@ import com.android.voyageur.ui.overview.OverviewScreen
 import com.android.voyageur.ui.profile.EditProfileScreen
 import com.android.voyageur.ui.profile.ProfileScreen
 import com.android.voyageur.ui.search.SearchScreen
+import com.android.voyageur.ui.search.SearchUserProfileScreen
 import com.android.voyageur.ui.trip.AddActivityScreen
 import com.android.voyageur.ui.trip.TopTabs
 import com.google.android.libraries.places.api.net.PlacesClient
@@ -50,6 +51,9 @@ fun VoyageurApp(placesClient: PlacesClient) {
         route = Route.SEARCH,
     ) {
       composable(Screen.SEARCH) { SearchScreen(userViewModel, placesViewModel, navigationActions) }
+      composable(Screen.SEARCH_USER_PROFILE) {
+        SearchUserProfileScreen(userViewModel, navigationActions)
+      }
     }
     navigation(
         startDestination = Screen.PROFILE,

--- a/app/src/main/java/com/android/voyageur/model/place/CustomPlace.kt
+++ b/app/src/main/java/com/android/voyageur/model/place/CustomPlace.kt
@@ -1,0 +1,9 @@
+package com.android.voyageur.model.place
+
+import androidx.compose.ui.graphics.ImageBitmap
+import com.google.android.libraries.places.api.model.Place
+
+data class CustomPlace(
+    val place: Place,
+    val photos: List<ImageBitmap>,
+)

--- a/app/src/main/java/com/android/voyageur/model/place/GooglePlacesRepository.kt
+++ b/app/src/main/java/com/android/voyageur/model/place/GooglePlacesRepository.kt
@@ -1,15 +1,24 @@
 package com.android.voyageur.model.place
 
+import android.util.Log
+import androidx.compose.ui.graphics.ImageBitmap
+import androidx.compose.ui.graphics.asImageBitmap
 import com.google.android.gms.maps.model.LatLng
 import com.google.android.libraries.places.api.model.AutocompleteSessionToken
+import com.google.android.libraries.places.api.model.PhotoMetadata
 import com.google.android.libraries.places.api.model.Place
 import com.google.android.libraries.places.api.model.RectangularBounds
-import com.google.android.libraries.places.api.model.kotlin.circularBounds
+import com.google.android.libraries.places.api.net.FetchPhotoRequest
 import com.google.android.libraries.places.api.net.FetchPlaceRequest
 import com.google.android.libraries.places.api.net.FindAutocompletePredictionsRequest
 import com.google.android.libraries.places.api.net.PlacesClient
 import kotlin.math.cos
 
+/**
+ * Repository class for interacting with the Google Places API.
+ *
+ * @property placesClient The PlacesClient used to make API requests.
+ */
 class GooglePlacesRepository(private val placesClient: PlacesClient) : PlacesRepository {
   private val placeFields =
       listOf(
@@ -26,12 +35,11 @@ class GooglePlacesRepository(private val placesClient: PlacesClient) : PlacesRep
           Place.Field.PRICE_LEVEL)
 
   /**
-   * This function is used to convert a circular radius around a location (LatLng) to a rectangular
-   * bounds, as the maps sdk doesn't support circular bounds
+   * Converts a circular radius around a location (LatLng) to rectangular bounds.
    *
-   * @param center the location used as the user location
-   * @param radius the radius area for the circle search
-   * @return the converted bounds around the center point
+   * @param center The center location.
+   * @param radius The radius in meters.
+   * @return The rectangular bounds around the center point.
    */
   private fun circularBounds(center: LatLng, radius: Double): RectangularBounds {
     val earthRadius = 6371000.0 // Earth's radius in meters
@@ -47,10 +55,18 @@ class GooglePlacesRepository(private val placesClient: PlacesClient) : PlacesRep
     return RectangularBounds.newInstance(southwest, northeast)
   }
 
+  /**
+   * Searches for places based on a query and location.
+   *
+   * @param query The search query.
+   * @param location The location to search around.
+   * @param onSuccess Callback invoked with the list of found places.
+   * @param onFailure Callback invoked with an exception if the search fails.
+   */
   override fun searchPlaces(
       query: String,
       location: LatLng?,
-      onSuccess: (List<Place>) -> Unit,
+      onSuccess: (List<CustomPlace>) -> Unit,
       onFailure: (Exception) -> Unit
   ) {
     val token = AutocompleteSessionToken.newInstance()
@@ -63,7 +79,7 @@ class GooglePlacesRepository(private val placesClient: PlacesClient) : PlacesRep
             .setSessionToken(token)
             .setQuery(query)
             .setTypesFilter(filter)
-    if (bounds != null) builder = builder.setLocationRestriction(bounds)
+    if (bounds != null) builder = builder.setLocationBias(bounds)
     val request = builder.build()
     placesClient
         .findAutocompletePredictions(request)
@@ -74,22 +90,46 @@ class GooglePlacesRepository(private val placesClient: PlacesClient) : PlacesRep
         .addOnFailureListener { exception -> onFailure(exception) }
   }
 
-  private fun fetchPlaceDetails(
+  /**
+   * Fetches detailed information for a list of place IDs.
+   *
+   * @param placeIds The list of place IDs to fetch details for.
+   * @param onSuccess Callback invoked with the list of detailed places.
+   * @param onFailure Callback invoked with an exception if the fetch fails.
+   */
+  fun fetchPlaceDetails(
       placeIds: List<String>,
-      onSuccess: (List<Place>) -> Unit,
+      onSuccess: (List<CustomPlace>) -> Unit,
       onFailure: (Exception) -> Unit
   ) {
-    val places = mutableListOf<Place>()
+    val places = mutableListOf<CustomPlace>()
     var failedRequests = 0
 
     // Define which fields to retrieve for each place
-
     placeIds.forEach { placeId ->
       val request = FetchPlaceRequest.builder(placeId, placeFields).build()
       placesClient
           .fetchPlace(request)
           .addOnSuccessListener { response ->
-            places.add(response.place)
+            val place = response.place
+            val bitmaps = mutableListOf<ImageBitmap>()
+
+            val photosMetadata =
+                (place.photoMetadatas?.map { it } ?: emptyList<PhotoMetadata>()).take(3)
+            for (photoMetadata in photosMetadata) {
+              val photoRequest = FetchPhotoRequest.builder(photoMetadata).build()
+              placesClient
+                  .fetchPhoto(photoRequest)
+                  .addOnSuccessListener { fetchPhotoResponse ->
+                    val bitmap = fetchPhotoResponse.bitmap.asImageBitmap()
+                    bitmaps.add(bitmap)
+                  }
+                  .addOnFailureListener { exception ->
+                    Log.e("PlacesRepository", "Failed to fetch photo for $placeId", exception)
+                  }
+            }
+            places.add(CustomPlace(place, bitmaps))
+
             if (places.size + failedRequests == placeIds.size) {
               onSuccess(places)
             }

--- a/app/src/main/java/com/android/voyageur/model/place/PlacesRepository.kt
+++ b/app/src/main/java/com/android/voyageur/model/place/PlacesRepository.kt
@@ -1,13 +1,12 @@
 package com.android.voyageur.model.place
 
 import com.google.android.gms.maps.model.LatLng
-import com.google.android.libraries.places.api.model.Place
 
 interface PlacesRepository {
   fun searchPlaces(
       query: String,
       location: LatLng?,
-      onSuccess: (List<Place>) -> Unit,
+      onSuccess: (List<CustomPlace>) -> Unit,
       onFailure: (Exception) -> Unit
   )
 }

--- a/app/src/main/java/com/android/voyageur/model/place/PlacesViewModel.kt
+++ b/app/src/main/java/com/android/voyageur/model/place/PlacesViewModel.kt
@@ -5,7 +5,6 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.viewModelScope
 import com.google.android.gms.maps.model.LatLng
-import com.google.android.libraries.places.api.model.Place
 import com.google.android.libraries.places.api.net.PlacesClient
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
@@ -13,16 +12,27 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
 
+/**
+ * ViewModel class for managing place search queries and results.
+ *
+ * @property placesRepository The repository used to search for places.
+ */
 open class PlacesViewModel(private val placesRepository: PlacesRepository) : ViewModel() {
   private val _query = MutableStateFlow("")
   val query: StateFlow<String> = _query
 
-  private val _searchedPlaces = MutableStateFlow<List<Place>>(emptyList())
-  val searchedPlaces: StateFlow<List<Place>> = _searchedPlaces
+  private val _searchedPlaces = MutableStateFlow<List<CustomPlace>>(emptyList())
+  val searchedPlaces: StateFlow<List<CustomPlace>> = _searchedPlaces
 
   // Job to manage debounce coroutine
   private var debounceJob: Job? = null
 
+  /**
+   * Sets the search query and triggers a search after a debounce period.
+   *
+   * @param query The search query.
+   * @param location The location to search around.
+   */
   fun setQuery(query: String, location: LatLng?) {
     debounceJob?.cancel()
     _query.value = query
@@ -35,6 +45,12 @@ open class PlacesViewModel(private val placesRepository: PlacesRepository) : Vie
         }
   }
 
+  /**
+   * Searches for places based on the query and location.
+   *
+   * @param query The search query.
+   * @param location The location to search around.
+   */
   fun searchPlaces(query: String, location: LatLng?) {
     placesRepository.searchPlaces(
         query,
@@ -44,6 +60,12 @@ open class PlacesViewModel(private val placesRepository: PlacesRepository) : Vie
   }
 
   companion object {
+    /**
+     * Provides a factory to create an instance of PlacesViewModel.
+     *
+     * @param placesClient The PlacesClient used to make API requests.
+     * @return A ViewModelProvider.Factory to create PlacesViewModel instances.
+     */
     fun provideFactory(placesClient: PlacesClient): ViewModelProvider.Factory =
         object : ViewModelProvider.Factory {
           @Suppress("UNCHECKED_CAST")

--- a/app/src/main/java/com/android/voyageur/ui/components/UserProfileContent.kt
+++ b/app/src/main/java/com/android/voyageur/ui/components/UserProfileContent.kt
@@ -1,0 +1,138 @@
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ExperimentalLayoutApi
+import androidx.compose.foundation.layout.FlowRow
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.AccountCircle
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.semantics.Role.Companion.Image
+import androidx.compose.ui.unit.dp
+import coil.compose.rememberAsyncImagePainter
+import com.android.voyageur.model.user.User
+import com.android.voyageur.ui.profile.interests.InterestChip
+
+/**
+ * Composable function to display a user's profile information, including their profile picture,
+ * name, email, and interests. It also provides options to edit the profile, sign out, or add/remove
+ * the user as a contact based on the input parameters.
+ *
+ * @param userData The `User` object containing details such as the profile picture, name, email,
+ *   and interests.
+ * @param showEditAndSignOutButtons A Boolean flag that, if true, displays the Edit and Sign Out
+ *   buttons. Default is false.
+ * @param isContactAdded A Boolean flag indicating if the user is already added as a contact. Used
+ *   to toggle the Add/Remove Contact button text and color. Default is false.
+ * @param onSignOut A lambda function that executes when the Sign Out button is clicked. Optional.
+ * @param onEdit A lambda function that executes when the Edit button is clicked. Optional.
+ * @param onAddOrRemoveContact A lambda function that executes when the Add/Remove Contact button is
+ *   clicked. Optional.
+ */
+@OptIn(ExperimentalLayoutApi::class)
+@Composable
+fun UserProfileContent(
+    userData: User,
+    showEditAndSignOutButtons: Boolean = false,
+    isContactAdded: Boolean = false,
+    onSignOut: (() -> Unit)? = null,
+    onEdit: (() -> Unit)? = null,
+    onAddOrRemoveContact: (() -> Unit)? = null
+) {
+  Column(
+      modifier = Modifier.fillMaxSize().padding(16.dp).testTag("userProfileContent"),
+      verticalArrangement = Arrangement.Center,
+      horizontalAlignment = Alignment.CenterHorizontally) {
+        // Display user's profile picture or a default icon if no picture is available
+        if (userData.profilePicture.isNotEmpty()) {
+          Image(
+              painter = rememberAsyncImagePainter(model = userData.profilePicture),
+              contentDescription = "Profile Picture",
+              modifier = Modifier.size(128.dp).clip(CircleShape).testTag("userProfilePicture"))
+        } else {
+          Icon(
+              imageVector = Icons.Default.AccountCircle,
+              contentDescription = "Default Profile Picture",
+              modifier = Modifier.size(128.dp).testTag("defaultProfilePicture"))
+        }
+
+        Spacer(modifier = Modifier.height(16.dp))
+
+        // Display user's name and email, with fallback text if unavailable
+        Text(
+            text = userData.name.takeIf { it.isNotEmpty() } ?: "No name available",
+            style = MaterialTheme.typography.titleLarge,
+            modifier = Modifier.testTag("userName"))
+        Text(
+            text = userData.email.takeIf { it.isNotEmpty() } ?: "No email available",
+            style = MaterialTheme.typography.bodyMedium,
+            modifier = Modifier.testTag("userEmail"))
+
+        Spacer(modifier = Modifier.height(16.dp))
+
+        // Display the user's interests or a message if no interests are added
+        Text(
+            text = "Interests:",
+            style = MaterialTheme.typography.titleMedium,
+            modifier = Modifier.padding(vertical = 8.dp))
+
+        if (userData.interests.isNotEmpty()) {
+          FlowRow(
+              modifier =
+                  Modifier.fillMaxWidth().padding(horizontal = 16.dp).testTag("interestsFlowRow"),
+              horizontalArrangement = Arrangement.Center) {
+                userData.interests.forEach { interest ->
+                  InterestChip(interest = interest, modifier = Modifier.padding(4.dp))
+                }
+              }
+        } else {
+          Text(
+              text = "No interests added yet",
+              style = MaterialTheme.typography.bodyMedium,
+              modifier = Modifier.testTag("noInterests"))
+        }
+
+        Spacer(modifier = Modifier.height(16.dp))
+
+        // Conditional buttons for editing, signing out, or adding/removing as contact
+        Row {
+          if (showEditAndSignOutButtons && onEdit != null && onSignOut != null) {
+            Button(onClick = onEdit, modifier = Modifier.testTag("editButton")) {
+              Text(text = "Edit")
+            }
+            Spacer(modifier = Modifier.width(16.dp))
+            Button(onClick = onSignOut, modifier = Modifier.testTag("signOutButton")) {
+              Text(text = "Sign Out")
+            }
+          } else if (onAddOrRemoveContact != null) {
+            Button(
+                onClick = onAddOrRemoveContact,
+                colors =
+                    ButtonDefaults.buttonColors(
+                        containerColor =
+                            if (isContactAdded) MaterialTheme.colorScheme.error
+                            else MaterialTheme.colorScheme.primary),
+                modifier = Modifier.testTag("userProfileAddRemoveContactButton")) {
+                  Text(text = if (isContactAdded) "Remove from contacts" else "Add to contacts")
+                }
+          }
+        }
+      }
+}

--- a/app/src/main/java/com/android/voyageur/ui/components/UserProfileContent.kt
+++ b/app/src/main/java/com/android/voyageur/ui/components/UserProfileContent.kt
@@ -50,6 +50,7 @@ import com.android.voyageur.ui.profile.interests.InterestChip
 @Composable
 fun UserProfileContent(
     userData: User,
+    signedInUserId: String,
     showEditAndSignOutButtons: Boolean = false,
     isContactAdded: Boolean = false,
     onSignOut: (() -> Unit)? = null,
@@ -60,7 +61,7 @@ fun UserProfileContent(
       modifier = Modifier.fillMaxSize().padding(16.dp).testTag("userProfileContent"),
       verticalArrangement = Arrangement.Center,
       horizontalAlignment = Alignment.CenterHorizontally) {
-        // Display user's profile picture or a default icon if no picture is available
+        // Display profile picture
         if (userData.profilePicture.isNotEmpty()) {
           Image(
               painter = rememberAsyncImagePainter(model = userData.profilePicture),
@@ -75,7 +76,7 @@ fun UserProfileContent(
 
         Spacer(modifier = Modifier.height(16.dp))
 
-        // Display user's name and email, with fallback text if unavailable
+        // Display name and email
         Text(
             text = userData.name.takeIf { it.isNotEmpty() } ?: "No name available",
             style = MaterialTheme.typography.titleLarge,
@@ -87,7 +88,7 @@ fun UserProfileContent(
 
         Spacer(modifier = Modifier.height(16.dp))
 
-        // Display the user's interests or a message if no interests are added
+        // Display interests
         Text(
             text = "Interests:",
             style = MaterialTheme.typography.titleMedium,
@@ -111,7 +112,7 @@ fun UserProfileContent(
 
         Spacer(modifier = Modifier.height(16.dp))
 
-        // Conditional buttons for editing, signing out, or adding/removing as contact
+        // Display buttons conditionally
         Row {
           if (showEditAndSignOutButtons && onEdit != null && onSignOut != null) {
             Button(onClick = onEdit, modifier = Modifier.testTag("editButton")) {
@@ -121,7 +122,7 @@ fun UserProfileContent(
             Button(onClick = onSignOut, modifier = Modifier.testTag("signOutButton")) {
               Text(text = "Sign Out")
             }
-          } else if (onAddOrRemoveContact != null) {
+          } else if (userData.id != signedInUserId && onAddOrRemoveContact != null) {
             Button(
                 onClick = onAddOrRemoveContact,
                 colors =

--- a/app/src/main/java/com/android/voyageur/ui/gallery/PermissionButtonForGallery.kt
+++ b/app/src/main/java/com/android/voyageur/ui/gallery/PermissionButtonForGallery.kt
@@ -1,0 +1,163 @@
+package com.android.voyageur.ui.gallery
+
+import android.Manifest.permission.READ_EXTERNAL_STORAGE
+import android.Manifest.permission.READ_MEDIA_IMAGES
+import android.Manifest.permission.READ_MEDIA_VISUAL_USER_SELECTED
+import android.content.Context
+import android.content.ContextWrapper
+import android.content.pm.PackageManager.PERMISSION_GRANTED
+import android.net.Uri
+import android.os.Build
+import android.widget.Toast
+import androidx.activity.ComponentActivity
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.Button
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.core.app.ActivityCompat
+import androidx.core.content.ContextCompat
+
+@Composable
+/**
+ * A Composable function that displays a button for selecting a photo from the gallery, handling
+ * permission requests and rationale dialogs if needed.
+ *
+ * @param onUriSelected Callback invoked with the selected image URI or `null` if no image is
+ *   selected.
+ * @param messageToShow The text displayed on the button.
+ * @param dialogMessage The message shown in the rationale dialog when permission is denied.
+ * @param modifier Modifier to style the button layout and add test tags.
+ */
+fun PermissionButtonForGallery(
+    onUriSelected: (Uri?) -> Unit,
+    messageToShow: String,
+    dialogMessage: String,
+    modifier: Modifier = Modifier
+) {
+  val context = LocalContext.current
+  val compActivity = context.findActivity()
+  var showRationaleDialog by remember { mutableStateOf(false) }
+  val permissionVersion =
+      if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+        READ_MEDIA_IMAGES
+      } else {
+        READ_EXTERNAL_STORAGE
+      }
+  val galleryLauncher =
+      rememberLauncherForActivityResult(ActivityResultContracts.GetContent()) { uri: Uri? ->
+        if (uri != null) {
+          onUriSelected(uri)
+        } else {
+          Toast.makeText(context, "No image selected", Toast.LENGTH_SHORT).show()
+        }
+      }
+  val permissionLauncher =
+      rememberLauncherForActivityResult(ActivityResultContracts.RequestPermission()) { isGranted ->
+        when {
+          isGranted -> galleryLauncher.launch("image/*")
+          checkLimitedPermission(context) -> galleryLauncher.launch("image/*")
+          else -> {
+            // Permission is denied, show a toast to the user
+            Toast.makeText(
+                    context, "Permission denied. Unable to select photo.", Toast.LENGTH_SHORT)
+                .show()
+          }
+        }
+      }
+  Button(
+      onClick = {
+        when {
+          checkFullPermission(context) || checkLimitedPermission(context) -> {
+            // If permission is granted, launch the gallery
+            galleryLauncher.launch("image/*")
+          }
+          compActivity != null &&
+              ActivityCompat.shouldShowRequestPermissionRationale(
+                  compActivity, permissionVersion) -> {
+            // Show rationale
+            showRationaleDialog = true
+          }
+          else -> {
+            permissionLauncher.launch(permissionVersion)
+          }
+        }
+      },
+      modifier = modifier) {
+        // Shows message corresponding to the screen
+        Text(messageToShow)
+        // Show rationale dialog if needed
+        if (showRationaleDialog) {
+          AlertDialog(
+              onDismissRequest = { showRationaleDialog = false },
+              title = { Text("Permission Required") },
+              text = { Text(dialogMessage) },
+              confirmButton = {
+                TextButton(
+                    onClick = {
+                      showRationaleDialog = false
+                      permissionLauncher.launch(permissionVersion)
+                    }) {
+                      Text("Allow")
+                    }
+              },
+              dismissButton = {
+                TextButton(
+                    onClick = {
+                      showRationaleDialog = false
+                      Toast.makeText(
+                              context,
+                              "Permission denied. Unable to select photo.",
+                              Toast.LENGTH_SHORT)
+                          .show()
+                    }) {
+                      Text("Cancel")
+                    }
+              })
+        }
+      }
+}
+
+/**
+ * Checks if the app has full permission to read media images or external storage, depending on the
+ * Android version.
+ */
+fun checkFullPermission(context: Context): Boolean {
+  return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+    ContextCompat.checkSelfPermission(context, READ_MEDIA_IMAGES) == PERMISSION_GRANTED
+  } else {
+    ContextCompat.checkSelfPermission(context, READ_EXTERNAL_STORAGE) == PERMISSION_GRANTED
+  }
+}
+/**
+ * Checks if the app has limited permission to read user-selected media on Android versions that
+ * support it.
+ */
+fun checkLimitedPermission(context: Context): Boolean {
+  return (Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE &&
+      ContextCompat.checkSelfPermission(context, READ_MEDIA_VISUAL_USER_SELECTED) ==
+          PERMISSION_GRANTED)
+}
+/**
+ * Returns Component Activity associated with Context to show dialog. Unwraps context on which it is
+ * called upon.
+ * *
+ */
+fun Context.findActivity(): ComponentActivity? {
+  var context = this
+  while (context is ContextWrapper) {
+    if (context is ComponentActivity) {
+      return context
+    }
+    context = context.baseContext
+  }
+  return null
+}

--- a/app/src/main/java/com/android/voyageur/ui/navigation/NavigationActions.kt
+++ b/app/src/main/java/com/android/voyageur/ui/navigation/NavigationActions.kt
@@ -4,6 +4,8 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.outlined.Menu
 import androidx.compose.material.icons.outlined.Person
 import androidx.compose.material.icons.outlined.Search
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.navigation.NavGraph.Companion.findStartDestination
 import androidx.navigation.NavHostController
@@ -99,4 +101,20 @@ open class NavigationActions(
    * @return The current route
    */
   open fun currentRoute(): String = navController.currentDestination?.route ?: ""
+
+  // A Map to hold various state values
+  private val navigationStateMap = mutableMapOf<String, Any>(
+    "currentTabIndexForTrip" to 0, // Default: schedule tab
+    "isDailyViewSelected" to true  // Default: daily view
+  )
+
+  // Function to update or retrieve values from the navigation state map
+  open fun <T> getNavigationState(key: String, defaultValue: T): T {
+    @Suppress("UNCHECKED_CAST")
+    return navigationStateMap[key] as? T ?: defaultValue
+  }
+
+  open fun <T : Any> setNavigationState(key: String, value: T) {
+    navigationStateMap[key] = value
+  }
 }

--- a/app/src/main/java/com/android/voyageur/ui/navigation/NavigationActions.kt
+++ b/app/src/main/java/com/android/voyageur/ui/navigation/NavigationActions.kt
@@ -4,8 +4,10 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.outlined.Menu
 import androidx.compose.material.icons.outlined.Person
 import androidx.compose.material.icons.outlined.Search
+import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.navigation.NavGraph.Companion.findStartDestination
 import androidx.navigation.NavHostController
@@ -27,11 +29,7 @@ object Screen {
   const val AUTH = "SignIn Screen"
   const val ADD_TRIP = "Add Trip Screen"
   const val EDIT_PROFILE = "Edit Profile Screen"
-  const val BY_DAY = "By Day Screen"
-  const val BY_WEEK = "By Week Screen"
-  const val ACTIVITIES = "Activities Screen"
   const val ADD_ACTIVITY = "Add Activity Screen"
-  const val SETTINGS = "Settings Screen"
   const val TOP_TABS = "Top Tabs Screen"
   const val SEARCH_USER_PROFILE = "Search User Profile Screen"
 }
@@ -53,6 +51,26 @@ object TopLevelDestinations {
 
 val LIST_TOP_LEVEL_DESTINATION =
     listOf(TopLevelDestinations.OVERVIEW, TopLevelDestinations.SEARCH, TopLevelDestinations.PROFILE)
+
+/** State for the navigation of the app */
+open class NavigationState {
+  /**
+   * This is a mutable state that represents the current tab index for the trip. (0 for Schedule, 1
+   * for Activities, 2 for Settings) This is used to determine which tab is currently selected in
+   * the TobTabs composable for a trip. It needs to be part of the navigation actions in order to
+   * remember which tab was selecting when opening another screen and trying to go back. For
+   * example, when we open AddActivityScreen from the Activities tab, we want to go back to this
+   * tab.
+   */
+  var currentTabIndexForTrip by mutableIntStateOf(0) // Default to 0 (Schedule tab)
+  /**
+   * This is a mutable state that represents whether the daily view is selected in the ByDayScreen.
+   * This is used to determine which view is currently selected in the Schedule Screen. Similarly to
+   * currentTabIndexForTrip, it needs to be part of the navigation actions in order to remember
+   * which view was selected when opening another screen and trying to go back.
+   */
+  var isDailyViewSelected by mutableStateOf(true) // Default to true (Daily view selected)
+}
 
 open class NavigationActions(
     private val navController: NavHostController,
@@ -102,19 +120,9 @@ open class NavigationActions(
    */
   open fun currentRoute(): String = navController.currentDestination?.route ?: ""
 
-  // A Map to hold various state values
-  private val navigationStateMap = mutableMapOf<String, Any>(
-    "currentTabIndexForTrip" to 0, // Default: schedule tab
-    "isDailyViewSelected" to true  // Default: daily view
-  )
+  private val navigationState = NavigationState()
 
-  // Function to update or retrieve values from the navigation state map
-  open fun <T> getNavigationState(key: String, defaultValue: T): T {
-    @Suppress("UNCHECKED_CAST")
-    return navigationStateMap[key] as? T ?: defaultValue
-  }
-
-  open fun <T : Any> setNavigationState(key: String, value: T) {
-    navigationStateMap[key] = value
+  open fun getNavigationState(): NavigationState {
+    return navigationState
   }
 }

--- a/app/src/main/java/com/android/voyageur/ui/navigation/NavigationActions.kt
+++ b/app/src/main/java/com/android/voyageur/ui/navigation/NavigationActions.kt
@@ -15,6 +15,7 @@ object Route {
   const val EDIT_PROFILE = "Edit Profile Screen"
   const val AUTH = "Auth"
   const val TOP_TABS = "TopTabs"
+  const val SEARCH_USER_PROFILE = "Search User Profile Screen"
 }
 
 object Screen {
@@ -30,6 +31,7 @@ object Screen {
   const val ADD_ACTIVITY = "Add Activity Screen"
   const val SETTINGS = "Settings Screen"
   const val TOP_TABS = "Top Tabs Screen"
+  const val SEARCH_USER_PROFILE = "Search User Profile Screen"
 }
 
 data class TopLevelDestination(

--- a/app/src/main/java/com/android/voyageur/ui/overview/AddTrip.kt
+++ b/app/src/main/java/com/android/voyageur/ui/overview/AddTrip.kt
@@ -2,15 +2,10 @@ package com.android.voyageur.ui.overview
 
 import android.Manifest.permission.READ_EXTERNAL_STORAGE
 import android.Manifest.permission.READ_MEDIA_IMAGES
-import android.Manifest.permission.READ_MEDIA_VISUAL_USER_SELECTED
 import android.annotation.SuppressLint
-import android.content.Context
-import android.content.pm.PackageManager.PERMISSION_GRANTED
 import android.net.Uri
 import android.os.Build
 import android.widget.Toast
-import androidx.activity.compose.rememberLauncherForActivityResult
-import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
@@ -28,7 +23,6 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.outlined.ArrowBack
-import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Button
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
@@ -37,7 +31,6 @@ import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.RadioButton
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
-import androidx.compose.material3.TextButton
 import androidx.compose.material3.TextFieldDefaults
 import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
@@ -54,8 +47,6 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.unit.dp
-import androidx.core.app.ActivityCompat
-import androidx.core.content.ContextCompat
 import androidx.lifecycle.viewmodel.compose.viewModel
 import coil.compose.rememberAsyncImagePainter
 import com.android.voyageur.R
@@ -64,8 +55,8 @@ import com.android.voyageur.model.trip.Trip
 import com.android.voyageur.model.trip.TripType
 import com.android.voyageur.model.trip.TripsViewModel
 import com.android.voyageur.ui.formFields.DatePickerModal
+import com.android.voyageur.ui.gallery.PermissionButtonForGallery
 import com.android.voyageur.ui.navigation.NavigationActions
-import com.android.voyageur.ui.profile.findActivity
 import com.google.firebase.Firebase
 import com.google.firebase.Timestamp
 import com.google.firebase.auth.auth
@@ -106,25 +97,6 @@ fun AddTripScreen(
         READ_MEDIA_IMAGES
       } else {
         READ_EXTERNAL_STORAGE
-      }
-  val galleryLauncher =
-      rememberLauncherForActivityResult(
-          contract = ActivityResultContracts.GetContent(),
-          onResult = { uri -> uri?.let { imageUri = it.toString() } })
-  val permissionLauncher =
-      rememberLauncherForActivityResult(ActivityResultContracts.RequestPermission()) { isGranted ->
-        when {
-          isGranted -> galleryLauncher.launch("image/*")
-          checkLimitedPermission(context) -> galleryLauncher.launch("image/*")
-          else -> {
-            // Permission is denied, show a message to the user
-            Toast.makeText(
-                    context,
-                    "Please allow access to select images from your gallery.",
-                    Toast.LENGTH_SHORT)
-                .show()
-          }
-        }
       }
 
   LaunchedEffect(isEditMode) {
@@ -260,27 +232,11 @@ fun AddTripScreen(
                 }
 
                 Spacer(modifier = Modifier.height(16.dp))
-
-                Button(
-                    onClick = {
-                      when {
-                        checkFullPermission(context) || checkLimitedPermission(context) -> {
-                          // If permission is granted, launch the gallery
-                          galleryLauncher.launch("image/*")
-                        }
-                        ActivityCompat.shouldShowRequestPermissionRationale(
-                            context.findActivity(), permissionVersion) -> {
-                          // Show rationale
-                          showRationaleDialog = true
-                        }
-                        else -> {
-                          permissionLauncher.launch(permissionVersion)
-                        }
-                      }
-                    },
-                    modifier = Modifier.fillMaxWidth()) {
-                      Text("Select Image from Gallery")
-                    }
+                PermissionButtonForGallery(
+                    onUriSelected = { uri -> imageUri = uri.toString() },
+                    "Select Image from Gallery",
+                    "This app needs access to your photos to allow you to select an image for your trip.",
+                    Modifier.fillMaxWidth())
 
                 OutlinedTextField(
                     value = name,
@@ -409,48 +365,10 @@ fun AddTripScreen(
                 Text("Save Trip")
               }
         }
-        // Show rationale dialog if needed
-        if (showRationaleDialog) {
-          AlertDialog(
-              onDismissRequest = { showRationaleDialog = false },
-              title = { Text("Permission Required") },
-              text = {
-                Text(
-                    "This app needs access to your photos to allow you to select an image for your trip.")
-              },
-              confirmButton = {
-                TextButton(
-                    onClick = {
-                      showRationaleDialog = false
-                      permissionLauncher.launch(permissionVersion)
-                    }) {
-                      Text("Allow")
-                    }
-              },
-              dismissButton = {
-                TextButton(onClick = { showRationaleDialog = false }) { Text("Cancel") }
-              })
-        }
       }
 }
 
 enum class DateField {
   START,
   END
-}
-
-// Function to check if full permission is granted
-fun checkFullPermission(context: Context): Boolean {
-  return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
-    ContextCompat.checkSelfPermission(context, READ_MEDIA_IMAGES) == PERMISSION_GRANTED
-  } else {
-    ContextCompat.checkSelfPermission(context, READ_EXTERNAL_STORAGE) == PERMISSION_GRANTED
-  }
-}
-
-// Function to check if limited access permission is granted
-fun checkLimitedPermission(context: Context): Boolean {
-  return (Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE &&
-      ContextCompat.checkSelfPermission(context, READ_MEDIA_VISUAL_USER_SELECTED) ==
-          PERMISSION_GRANTED)
 }

--- a/app/src/main/java/com/android/voyageur/ui/overview/Overview.kt
+++ b/app/src/main/java/com/android/voyageur/ui/overview/Overview.kt
@@ -109,10 +109,12 @@ fun OverviewScreen(
 
 @Composable
 fun TripItem(tripsViewModel: TripsViewModel, trip: Trip, navigationActions: NavigationActions) {
-  // TODO: add a clickable once we implement the Schedule screens
   val dateRange = trip.startDate.toDateString() + "-" + trip.endDate.toDateString()
   Card(
       onClick = {
+        // When opening a trip, navigate to the Schedule screen, with the daily view enabled
+        navigationActions.getNavigationState().currentTabIndexForTrip = 0
+        navigationActions.getNavigationState().isDailyViewSelected = true
         navigationActions.navigateTo(Screen.TOP_TABS)
         tripsViewModel.selectTrip(trip)
       },

--- a/app/src/main/java/com/android/voyageur/ui/profile/EditProfileScreen.kt
+++ b/app/src/main/java/com/android/voyageur/ui/profile/EditProfileScreen.kt
@@ -55,6 +55,11 @@ import com.android.voyageur.ui.profile.interests.InterestChipEditable
 fun EditProfileScreen(userViewModel: UserViewModel, navigationActions: NavigationActions) {
   val user by userViewModel.user.collectAsState()
   val isLoading by userViewModel.isLoading.collectAsState()
+  // Check if user is null and navigate back to the Profile screen if true
+  if (user == null && !isLoading) {
+    navigationActions.navigateTo(Route.PROFILE)
+    return
+  }
 
   var name by remember { mutableStateOf(user?.name ?: "") }
   var email by remember { mutableStateOf(user?.email ?: "") }

--- a/app/src/main/java/com/android/voyageur/ui/profile/EditProfileScreen.kt
+++ b/app/src/main/java/com/android/voyageur/ui/profile/EditProfileScreen.kt
@@ -1,15 +1,6 @@
 package com.android.voyageur.ui.profile
 
-import android.Manifest
-import android.content.Context
-import android.content.ContextWrapper
-import android.content.pm.PackageManager
 import android.net.Uri
-import android.os.Build
-import android.widget.Toast
-import androidx.activity.ComponentActivity
-import androidx.activity.compose.rememberLauncherForActivityResult
-import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -29,7 +20,6 @@ import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.AccountCircle
-import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Button
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3Api
@@ -38,7 +28,6 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
-import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
@@ -49,14 +38,12 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
-import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.unit.dp
-import androidx.core.app.ActivityCompat
-import androidx.core.content.ContextCompat
 import coil.compose.rememberAsyncImagePainter
 import com.android.voyageur.model.user.UserViewModel
+import com.android.voyageur.ui.gallery.PermissionButtonForGallery
 import com.android.voyageur.ui.navigation.BottomNavigationMenu
 import com.android.voyageur.ui.navigation.LIST_TOP_LEVEL_DESTINATION
 import com.android.voyageur.ui.navigation.NavigationActions
@@ -78,27 +65,6 @@ fun EditProfileScreen(userViewModel: UserViewModel, navigationActions: Navigatio
   // State variables for interests
   var interests by remember { mutableStateOf(user?.interests?.toMutableList() ?: mutableListOf()) }
   var newInterest by remember { mutableStateOf("") }
-
-  // Context and permission state variables
-  val context = LocalContext.current
-  var showPermissionRationale by remember { mutableStateOf(false) }
-  var permissionToRequest by remember { mutableStateOf("") }
-  // Photo picker launcher
-  val pickPhotoLauncher =
-      rememberLauncherForActivityResult(ActivityResultContracts.GetContent()) { uri: Uri? ->
-        uri?.let { profilePictureUri = it }
-      }
-
-  // Permission launcher
-  val permissionLauncher =
-      rememberLauncherForActivityResult(ActivityResultContracts.RequestPermission()) { isGranted ->
-        if (isGranted) {
-          pickPhotoLauncher.launch("image/*")
-        } else {
-          Toast.makeText(context, "Permission denied. Unable to select photo.", Toast.LENGTH_SHORT)
-              .show()
-        }
-      }
 
   if (isSaving) {
     LaunchedEffect(isSaving) {
@@ -158,38 +124,11 @@ fun EditProfileScreen(userViewModel: UserViewModel, navigationActions: Navigatio
                               contentDescription = "Default Profile Picture",
                               modifier = Modifier.size(128.dp).testTag("defaultProfilePicture"))
                         }
-
-                        Button(
-                            onClick = {
-                              val permission =
-                                  if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
-                                    Manifest.permission.READ_MEDIA_IMAGES
-                                  } else {
-                                    Manifest.permission.READ_EXTERNAL_STORAGE
-                                  }
-
-                              permissionToRequest = permission
-
-                              when {
-                                ContextCompat.checkSelfPermission(context, permission) ==
-                                    PackageManager.PERMISSION_GRANTED -> {
-                                  // Permission is granted
-                                  pickPhotoLauncher.launch("image/*")
-                                }
-                                ActivityCompat.shouldShowRequestPermissionRationale(
-                                    context.findActivity(), permission) -> {
-                                  // Show rationale
-                                  showPermissionRationale = true
-                                }
-                                else -> {
-                                  // Request permission
-                                  permissionLauncher.launch(permission)
-                                }
-                              }
-                            },
-                            modifier = Modifier.testTag("editImageButton")) {
-                              Text("Edit Profile Picture")
-                            }
+                        PermissionButtonForGallery(
+                            onUriSelected = { profilePictureUri = it },
+                            "Edit Profile Picture",
+                            "This app needs access to your photos to allow you to select a profile picture.",
+                            Modifier.testTag("editImageButton"))
 
                         Spacer(modifier = Modifier.height(16.dp))
 
@@ -280,30 +219,6 @@ fun EditProfileScreen(userViewModel: UserViewModel, navigationActions: Navigatio
                             modifier = Modifier.testTag("saveButton")) {
                               Text("Save")
                             }
-                        // Show rationale dialog if needed
-                        if (showPermissionRationale) {
-                          AlertDialog(
-                              onDismissRequest = { showPermissionRationale = false },
-                              title = { Text("Permission Required") },
-                              text = {
-                                Text(
-                                    "This app needs access to your photos to allow you to select a profile picture.")
-                              },
-                              confirmButton = {
-                                TextButton(
-                                    onClick = {
-                                      showPermissionRationale = false
-                                      permissionLauncher.launch(permissionToRequest)
-                                    }) {
-                                      Text("Allow")
-                                    }
-                              },
-                              dismissButton = {
-                                TextButton(onClick = { showPermissionRationale = false }) {
-                                  Text("Cancel")
-                                }
-                              })
-                        }
                       }
                 }
                     ?: run {
@@ -316,15 +231,4 @@ fun EditProfileScreen(userViewModel: UserViewModel, navigationActions: Navigatio
               }
             }
       })
-}
-
-fun Context.findActivity(): ComponentActivity {
-  var context = this
-  while (context is ContextWrapper) {
-    if (context is ComponentActivity) {
-      return context
-    }
-    context = context.baseContext
-  }
-  throw IllegalStateException("No Activity found")
 }

--- a/app/src/main/java/com/android/voyageur/ui/profile/ProfileScreen.kt
+++ b/app/src/main/java/com/android/voyageur/ui/profile/ProfileScreen.kt
@@ -71,6 +71,7 @@ fun ProfileScreen(userViewModel: UserViewModel, navigationActions: NavigationAct
                 user != null -> {
                   ProfileContent(
                       userData = user!!,
+                      signedInUserId = user!!.id,
                       onSignOut = { isSigningOut = true },
                       onEdit = { navigationActions.navigateTo(Route.EDIT_PROFILE) })
                 }
@@ -83,7 +84,16 @@ fun ProfileScreen(userViewModel: UserViewModel, navigationActions: NavigationAct
 }
 
 @Composable
-fun ProfileContent(userData: User, onSignOut: () -> Unit, onEdit: () -> Unit) {
+fun ProfileContent(
+    userData: User,
+    signedInUserId: String,
+    onSignOut: () -> Unit,
+    onEdit: () -> Unit
+) {
   UserProfileContent(
-      userData = userData, showEditAndSignOutButtons = true, onSignOut = onSignOut, onEdit = onEdit)
+      userData = userData,
+      signedInUserId = signedInUserId,
+      showEditAndSignOutButtons = true,
+      onSignOut = onSignOut,
+      onEdit = onEdit)
 }

--- a/app/src/main/java/com/android/voyageur/ui/profile/ProfileScreen.kt
+++ b/app/src/main/java/com/android/voyageur/ui/profile/ProfileScreen.kt
@@ -1,26 +1,10 @@
 package com.android.voyageur.ui.profile
 
-import androidx.compose.foundation.Image
-import androidx.compose.foundation.layout.Arrangement
+import UserProfileContent
 import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.ExperimentalLayoutApi
-import androidx.compose.foundation.layout.FlowRow
-import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.layout.width
-import androidx.compose.foundation.shape.CircleShape
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.AccountCircle
-import androidx.compose.material3.Button
 import androidx.compose.material3.CircularProgressIndicator
-import androidx.compose.material3.Icon
-import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -32,17 +16,13 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.clip
 import androidx.compose.ui.platform.testTag
-import androidx.compose.ui.unit.dp
-import coil.compose.rememberAsyncImagePainter
 import com.android.voyageur.model.user.User
 import com.android.voyageur.model.user.UserViewModel
 import com.android.voyageur.ui.navigation.BottomNavigationMenu
 import com.android.voyageur.ui.navigation.LIST_TOP_LEVEL_DESTINATION
 import com.android.voyageur.ui.navigation.NavigationActions
 import com.android.voyageur.ui.navigation.Route
-import com.android.voyageur.ui.profile.interests.InterestChip
 
 @Composable
 fun ProfileScreen(userViewModel: UserViewModel, navigationActions: NavigationActions) {
@@ -102,75 +82,8 @@ fun ProfileScreen(userViewModel: UserViewModel, navigationActions: NavigationAct
       })
 }
 
-@OptIn(ExperimentalLayoutApi::class)
 @Composable
 fun ProfileContent(userData: User, onSignOut: () -> Unit, onEdit: () -> Unit) {
-  Column(
-      modifier = Modifier.fillMaxSize().padding(16.dp).testTag("profileContent"),
-      verticalArrangement = Arrangement.Center,
-      horizontalAlignment = Alignment.CenterHorizontally) {
-        // Display the profile picture if available
-        if (userData.profilePicture.isNotEmpty()) {
-          Image(
-              painter = rememberAsyncImagePainter(model = userData.profilePicture),
-              contentDescription = "Profile Picture",
-              modifier = Modifier.size(128.dp).clip(CircleShape).testTag("profilePicture"))
-        } else {
-          Icon(
-              imageVector = Icons.Default.AccountCircle,
-              contentDescription = "Default Profile Picture",
-              modifier = Modifier.size(128.dp).testTag("defaultProfilePicture"))
-        }
-
-        Spacer(modifier = Modifier.height(16.dp))
-
-        // Display user name and email
-        Text(
-            text = userData.name.takeIf { it.isNotEmpty() } ?: "No name available",
-            style = MaterialTheme.typography.titleLarge,
-            modifier = Modifier.testTag("userName"))
-        Text(
-            text = userData.email.takeIf { it.isNotEmpty() } ?: "No email available",
-            style = MaterialTheme.typography.bodyMedium,
-            modifier = Modifier.testTag("userEmail"))
-
-        Spacer(modifier = Modifier.height(16.dp))
-
-        // Display interests
-        Text(
-            text = "Interests:",
-            style = MaterialTheme.typography.titleMedium,
-            modifier = Modifier.padding(vertical = 8.dp))
-
-        if (userData.interests.isNotEmpty()) {
-          // Display interests using FlowRow for better layout
-          FlowRow(
-              modifier =
-                  Modifier.fillMaxWidth().padding(horizontal = 16.dp).testTag("interestsFlowRow"),
-              horizontalArrangement = Arrangement.Center) {
-                userData.interests.forEach { interest ->
-                  InterestChip(interest = interest, modifier = Modifier.padding(4.dp))
-                }
-              }
-        } else {
-          // Display message when no interests are added
-          Text(
-              text = "No interests added yet",
-              style = MaterialTheme.typography.bodyMedium,
-              modifier = Modifier.testTag("noInterests"))
-        }
-
-        Spacer(modifier = Modifier.height(16.dp))
-
-        // Edit and Sign out buttons
-        Row {
-          Button(onClick = onEdit, modifier = Modifier.testTag("editButton")) {
-            Text(text = "Edit")
-          }
-          Spacer(modifier = Modifier.width(16.dp))
-          Button(onClick = onSignOut, modifier = Modifier.testTag("signOutButton")) {
-            Text(text = "Sign Out")
-          }
-        }
-      }
+  UserProfileContent(
+      userData = userData, showEditAndSignOutButtons = true, onSignOut = onSignOut, onEdit = onEdit)
 }

--- a/app/src/main/java/com/android/voyageur/ui/search/SearchScreen.kt
+++ b/app/src/main/java/com/android/voyageur/ui/search/SearchScreen.kt
@@ -13,6 +13,7 @@ import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
@@ -76,6 +77,7 @@ import com.android.voyageur.model.user.UserViewModel
 import com.android.voyageur.ui.navigation.BottomNavigationMenu
 import com.android.voyageur.ui.navigation.LIST_TOP_LEVEL_DESTINATION
 import com.android.voyageur.ui.navigation.NavigationActions
+import com.android.voyageur.ui.navigation.Screen
 import com.google.android.gms.location.FusedLocationProviderClient
 import com.google.android.gms.location.LocationCallback
 import com.google.android.gms.location.LocationRequest
@@ -354,7 +356,7 @@ fun SearchScreen(
                           userViewModel = userViewModel,
                           fieldColor = Color.LightGray,
                           modifier = Modifier.testTag("userItem_${user.id}"),
-                      )
+                          navigationActions = navigationActions)
                     }
                   }
                 }
@@ -377,7 +379,8 @@ fun UserSearchResultItem(
     user: User,
     modifier: Modifier = Modifier,
     userViewModel: UserViewModel,
-    fieldColor: Color
+    fieldColor: Color,
+    navigationActions: NavigationActions
 ) {
   val isContactAdded =
       userViewModel.user.collectAsState().value?.contacts?.contains(user.id) ?: false
@@ -387,6 +390,11 @@ fun UserSearchResultItem(
           modifier
               .fillMaxWidth()
               .padding(vertical = 8.dp, horizontal = 16.dp)
+              .clickable {
+                // Navigate to the user profile screen with userId
+                userViewModel.selectUser(user)
+                navigationActions.navigateTo(Screen.SEARCH_USER_PROFILE)
+              } // Make the Row clickable
               .background(Color.White, shape = RoundedCornerShape(8.dp))
               .padding(16.dp),
       horizontalArrangement = Arrangement.SpaceBetween,

--- a/app/src/main/java/com/android/voyageur/ui/search/SearchUserProfile.kt
+++ b/app/src/main/java/com/android/voyageur/ui/search/SearchUserProfile.kt
@@ -1,0 +1,101 @@
+package com.android.voyageur.ui.search
+
+import UserProfileContent
+import androidx.compose.foundation.layout.*
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.ArrowBack
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
+import com.android.voyageur.model.user.User
+import com.android.voyageur.model.user.UserViewModel
+import com.android.voyageur.ui.navigation.NavigationActions
+import com.android.voyageur.ui.navigation.Route
+
+/**
+ * Composable function for displaying a detailed profile of a selected user. Displays a loading
+ * indicator if data is loading and navigates back to search if no user data is available.
+ *
+ * @param userViewModel The UserViewModel used for managing user data and interactions.
+ * @param navigationActions The NavigationActions used for handling navigation actions within the
+ *   app.
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun SearchUserProfileScreen(userViewModel: UserViewModel, navigationActions: NavigationActions) {
+  // Observing the selected user and loading state from the ViewModel
+  val user by userViewModel.selectedUser.collectAsState()
+  val isLoading by userViewModel.isLoading.collectAsState()
+
+  // Navigate back to search if no user data is available and loading is complete
+  if (user == null && !isLoading) {
+    LaunchedEffect(Unit) { navigationActions.navigateTo(Route.SEARCH) }
+    return
+  }
+
+  // Scaffold layout containing top bar for navigation and content for displaying user details
+  Scaffold(
+      modifier = Modifier.testTag("userProfileScreen"),
+      topBar = {
+        TopAppBar(
+            title = { Text("${user?.name ?: "User"}'s Profile") },
+            navigationIcon = {
+              IconButton(
+                  onClick = {
+                    userViewModel.deselectUser() // Clears selected user in the ViewModel
+                    navigationActions.goBack() // Navigate back
+                  }) {
+                    Icon(
+                        imageVector = Icons.Default.ArrowBack,
+                        contentDescription = "Back",
+                        modifier = Modifier.testTag("userProfileBackButton"))
+                  }
+            })
+      },
+      content = { paddingValues ->
+        Box(
+            modifier =
+                Modifier.fillMaxSize().padding(paddingValues).testTag("userProfileScreenContent"),
+            contentAlignment = Alignment.Center) {
+              // Display appropriate content based on loading and user state
+              when {
+                isLoading -> {
+                  CircularProgressIndicator(
+                      modifier = Modifier.testTag("userProfileLoadingIndicator"))
+                }
+                user != null -> {
+                  SearchUserProfileContent(userData = user!!, userViewModel = userViewModel)
+                }
+                else -> {
+                  Text("No user data available", modifier = Modifier.testTag("userProfileNoData"))
+                }
+              }
+            }
+      })
+}
+
+/**
+ * Composable function for displaying the details of a selected user. Displays profile picture,
+ * name, email, interests, and an "Add Contact" button.
+ *
+ * @param userData The selected User object containing user details.
+ * @param userViewModel The UserViewModel used for managing user data and interactions.
+ */
+@Composable
+fun SearchUserProfileContent(userData: User, userViewModel: UserViewModel) {
+  val isContactAdded by remember {
+    derivedStateOf { userViewModel.user.value?.contacts?.contains(userData.id) ?: false }
+  }
+  UserProfileContent(
+      userData = userData,
+      isContactAdded = isContactAdded,
+      onAddOrRemoveContact = {
+        if (isContactAdded) {
+          userViewModel.removeContact(userData.id)
+        } else {
+          userViewModel.addContact(userData.id)
+        }
+      })
+}

--- a/app/src/main/java/com/android/voyageur/ui/search/SearchUserProfile.kt
+++ b/app/src/main/java/com/android/voyageur/ui/search/SearchUserProfile.kt
@@ -88,8 +88,11 @@ fun SearchUserProfileContent(userData: User, userViewModel: UserViewModel) {
   val isContactAdded by remember {
     derivedStateOf { userViewModel.user.value?.contacts?.contains(userData.id) ?: false }
   }
+  val signedInUserId = userViewModel.user.value?.id ?: ""
+
   UserProfileContent(
       userData = userData,
+      signedInUserId = signedInUserId,
       isContactAdded = isContactAdded,
       onAddOrRemoveContact = {
         if (isContactAdded) {

--- a/app/src/main/java/com/android/voyageur/ui/trip/AddActivity.kt
+++ b/app/src/main/java/com/android/voyageur/ui/trip/AddActivity.kt
@@ -65,6 +65,11 @@ fun AddActivityScreen(tripsViewModel: TripsViewModel, navigationActions: Navigat
       return
     }
 
+    if (startTime == null && endTime != null) {
+      Toast.makeText(context, "Please select a start time first", Toast.LENGTH_SHORT).show()
+      return
+    }
+
     fun normalizeToMidnight(date: Date): Date {
       val calendar =
           Calendar.getInstance().apply {
@@ -86,8 +91,8 @@ fun AddActivityScreen(tripsViewModel: TripsViewModel, navigationActions: Navigat
     }
 
     val startTimestamp =
-        startTime
-            ?.let {
+        Timestamp(
+            startTime?.let {
               Calendar.getInstance()
                   .apply {
                     time = dateNormalized
@@ -102,11 +107,19 @@ fun AddActivityScreen(tripsViewModel: TripsViewModel, navigationActions: Navigat
                   }
                   .time
             }
-            ?.let { Timestamp(it) } ?: Timestamp(0, 0)
+                ?: dateNormalized.apply {
+                  Calendar.getInstance()
+                      .apply {
+                        time = dateNormalized
+                        set(Calendar.HOUR_OF_DAY, 0)
+                        set(Calendar.MINUTE, 0)
+                      }
+                      .time
+                })
 
     val endTimestamp =
-        endTime
-            ?.let {
+        Timestamp(
+            endTime?.let {
               Calendar.getInstance()
                   .apply {
                     time = dateNormalized
@@ -121,7 +134,15 @@ fun AddActivityScreen(tripsViewModel: TripsViewModel, navigationActions: Navigat
                   }
                   .time
             }
-            ?.let { Timestamp(it) } ?: Timestamp(0, 0)
+                ?: Calendar.getInstance()
+                    .apply {
+                      time = dateNormalized
+                      set(Calendar.HOUR_OF_DAY, 23)
+                      set(Calendar.MINUTE, 59)
+                      set(Calendar.SECOND, 59)
+                      set(Calendar.MILLISECOND, 999)
+                    }
+                    .time)
 
     if (startTime != null &&
         endTime != null &&
@@ -129,6 +150,17 @@ fun AddActivityScreen(tripsViewModel: TripsViewModel, navigationActions: Navigat
       Toast.makeText(context, "End time must be after start time", Toast.LENGTH_SHORT).show()
       return
     }
+
+    if (activityDate != null && startTime == null && endTime == null)
+        Toast.makeText(context, "No times selected, defaults to 00:00 - 23:59", Toast.LENGTH_SHORT)
+            .show()
+
+    if (activityDate == null)
+        Toast.makeText(context, "No date assigned, created as draft", Toast.LENGTH_SHORT).show()
+
+    if (startTime != null && endTime == null)
+        Toast.makeText(context, "No end time selected, defaults to 23:59", Toast.LENGTH_SHORT)
+            .show()
 
     val activity =
         Activity(

--- a/app/src/main/java/com/android/voyageur/ui/trip/Tabs.kt
+++ b/app/src/main/java/com/android/voyageur/ui/trip/Tabs.kt
@@ -6,15 +6,16 @@ import androidx.compose.material3.Tab
 import androidx.compose.material3.TabRow
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.testTag
 import com.android.voyageur.model.trip.TripsViewModel
 import com.android.voyageur.ui.navigation.NavigationActions
+import com.android.voyageur.ui.navigation.Route
 import com.android.voyageur.ui.trip.activities.ActivitiesScreen
 import com.android.voyageur.ui.trip.schedule.ScheduleScreen
 import com.android.voyageur.ui.trip.schedule.TopBarWithImage
@@ -28,13 +29,21 @@ fun TopTabs(tripsViewModel: TripsViewModel, navigationActions: NavigationActions
   // Remember the currently selected tab index
   var selectedTabIndex by remember { mutableIntStateOf(0) }
 
-  val trip =
-      tripsViewModel.selectedTrip.value
-          ?: return Text(text = "No trip selected. Should not happen", color = Color.Red)
+  // Collect selectedTrip as state to avoid calling .value directly in composition
+  val trip by tripsViewModel.selectedTrip.collectAsState()
+
+  // Check if the selected trip is null and navigate to "Overview" if true
+  if (trip == null) {
+    navigationActions.navigateTo(Route.OVERVIEW)
+    return
+  }
+  // Define selectedTrip variable with trip value (trip!!)
+  val selectedTrip = trip!!
 
   // Column for top tabs and content
   Column(modifier = Modifier.testTag("topTabs")) {
-    TopBarWithImage(trip, navigationActions)
+    TopBarWithImage(selectedTrip, navigationActions)
+
     // TabRow composable for creating top tabs
     TabRow(
         selectedTabIndex = selectedTabIndex,
@@ -51,13 +60,11 @@ fun TopTabs(tripsViewModel: TripsViewModel, navigationActions: NavigationActions
 
     // Display content based on selected tab
     when (selectedTabIndex) {
-      0 -> ScheduleScreen(trip, navigationActions)
-      1 -> {
-        ActivitiesScreen(trip, navigationActions)
-      }
+      0 -> ScheduleScreen(selectedTrip, navigationActions)
+      1 -> ActivitiesScreen(selectedTrip, navigationActions)
       2 ->
           SettingsScreen(
-              trip,
+              selectedTrip,
               navigationActions,
               tripsViewModel = tripsViewModel,
               onUpdate = {

--- a/app/src/main/java/com/android/voyageur/ui/trip/Tabs.kt
+++ b/app/src/main/java/com/android/voyageur/ui/trip/Tabs.kt
@@ -50,22 +50,24 @@ fun TopTabs(tripsViewModel: TripsViewModel, navigationActions: NavigationActions
 
     // TabRow composable for creating top tabs
     TabRow(
-        selectedTabIndex = selectedTabIndex,
+        selectedTabIndex = navigationActions.getNavigationState().currentTabIndexForTrip,
         modifier = Modifier.fillMaxWidth().testTag("tabRow"),
     ) {
       // Create each tab with a Tab composable
       tabs.forEachIndexed { index, title ->
         Tab(
-            selected = selectedTabIndex == index,
-            onClick = { updateTabIndex(index) },
+            selected = navigationActions.getNavigationState().currentTabIndexForTrip == index,
+            onClick = { navigationActions.getNavigationState().currentTabIndexForTrip = index },
             text = { Text(title) })
       }
     }
 
     // Display content based on selected tab
-    when (selectedTabIndex) {
+    when (navigationActions.getNavigationState().currentTabIndexForTrip) {
       0 -> ScheduleScreen(selectedTrip, navigationActions)
-      1 -> ActivitiesScreen(selectedTrip, navigationActions)
+      1 -> {
+        ActivitiesScreen(selectedTrip, navigationActions)
+      }
       2 ->
           SettingsScreen(
               selectedTrip,

--- a/app/src/main/java/com/android/voyageur/ui/trip/Tabs.kt
+++ b/app/src/main/java/com/android/voyageur/ui/trip/Tabs.kt
@@ -27,7 +27,11 @@ fun TopTabs(tripsViewModel: TripsViewModel, navigationActions: NavigationActions
   val tabs = listOf("Schedule", "Activities", "Settings")
 
   // Remember the currently selected tab index
-  var selectedTabIndex by remember { mutableIntStateOf(0) }
+  var selectedTabIndex by remember { mutableIntStateOf(navigationActions.getNavigationState("currentTabIndexForTrip", 0)) }
+    fun updateTabIndex(newIndex: Int) {
+        selectedTabIndex = newIndex
+        navigationActions.setNavigationState("currentTabIndexForTrip", newIndex)
+    }
 
   // Collect selectedTrip as state to avoid calling .value directly in composition
   val trip by tripsViewModel.selectedTrip.collectAsState()
@@ -53,7 +57,7 @@ fun TopTabs(tripsViewModel: TripsViewModel, navigationActions: NavigationActions
       tabs.forEachIndexed { index, title ->
         Tab(
             selected = selectedTabIndex == index,
-            onClick = { selectedTabIndex = index },
+            onClick = { updateTabIndex(index) },
             text = { Text(title) })
       }
     }
@@ -68,8 +72,8 @@ fun TopTabs(tripsViewModel: TripsViewModel, navigationActions: NavigationActions
               navigationActions,
               tripsViewModel = tripsViewModel,
               onUpdate = {
-                selectedTabIndex = 0
-                selectedTabIndex = 2
+                updateTabIndex(0)
+                updateTabIndex(2)
               })
     }
   }

--- a/app/src/main/java/com/android/voyageur/ui/trip/Tabs.kt
+++ b/app/src/main/java/com/android/voyageur/ui/trip/Tabs.kt
@@ -8,9 +8,6 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableIntStateOf
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.testTag
 import com.android.voyageur.model.trip.TripsViewModel
@@ -25,13 +22,6 @@ import com.android.voyageur.ui.trip.settings.SettingsScreen
 fun TopTabs(tripsViewModel: TripsViewModel, navigationActions: NavigationActions) {
   // Define tab items
   val tabs = listOf("Schedule", "Activities", "Settings")
-
-  // Remember the currently selected tab index
-  var selectedTabIndex by remember { mutableIntStateOf(navigationActions.getNavigationState("currentTabIndexForTrip", 0)) }
-    fun updateTabIndex(newIndex: Int) {
-        selectedTabIndex = newIndex
-        navigationActions.setNavigationState("currentTabIndexForTrip", newIndex)
-    }
 
   // Collect selectedTrip as state to avoid calling .value directly in composition
   val trip by tripsViewModel.selectedTrip.collectAsState()
@@ -74,8 +64,8 @@ fun TopTabs(tripsViewModel: TripsViewModel, navigationActions: NavigationActions
               navigationActions,
               tripsViewModel = tripsViewModel,
               onUpdate = {
-                updateTabIndex(0)
-                updateTabIndex(2)
+                navigationActions.getNavigationState().currentTabIndexForTrip = 0
+                navigationActions.getNavigationState().currentTabIndexForTrip = 2
               })
     }
   }

--- a/app/src/main/java/com/android/voyageur/ui/trip/schedule/ByDay.kt
+++ b/app/src/main/java/com/android/voyageur/ui/trip/schedule/ByDay.kt
@@ -47,7 +47,6 @@ fun ByDayScreen(
     navigationActions: NavigationActions,
 ) {
   Scaffold(
-      // TODO: Final implementation of ByDayScreen
       floatingActionButton = {
         FloatingActionButton(
             onClick = { navigationActions.navigateTo(Screen.ADD_ACTIVITY) },
@@ -66,7 +65,6 @@ fun ByDayScreen(
             selectedItem = navigationActions.currentRoute())
       },
       content = { pd ->
-        // TODO: sort activities by their hour
         val tripActivities = trip.activities
         val groupedActivities =
             groupActivitiesByDate(tripActivities)
@@ -78,8 +76,8 @@ fun ByDayScreen(
                   // Filter out groups that become empty after removing draft activities
                   activities.isNotEmpty()
                 }
-        //        val groupedActivities = groupActivitiesByDate(tripActivities)
         if (groupedActivities.isEmpty()) {
+          // Display empty prompt if there are no activities
           Text(
               modifier = Modifier.padding(pd).testTag("emptyByDayPrompt"),
               text = "You have no activities yet. Schedule one.")
@@ -104,7 +102,10 @@ fun ByDayScreen(
       })
 }
 
-// TODO: Test this works
+/**
+ * Function to sort Activities. It sorts by startTime, and if startTime is equal sorts by endTime.
+ * It groups the activities in a map with the day as key.
+ */
 fun groupActivitiesByDate(activities: List<Activity>): Map<LocalDate, List<Activity>> {
   val sortedActivities =
       activities.sortedWith(
@@ -112,14 +113,15 @@ fun groupActivitiesByDate(activities: List<Activity>): Map<LocalDate, List<Activ
               { it.startTime }, // First, sort by startTime
               { it.endTime } // If startTime is equal, sort by endTime
               ))
-
+  // Group into a map with the day as key
   return sortedActivities.groupBy { activity ->
     activity.startTime.toDate().toInstant().atZone(ZoneId.systemDefault()).toLocalDate()
   }
 }
 
 @Composable
-fun DayActivityCard(day: LocalDate, activitiesForDay: List<Activity>) {
+/** Day Card which displays the date and a column with activities for the corresponding days. */
+private fun DayActivityCard(day: LocalDate, activitiesForDay: List<Activity>) {
   Card(
       onClick = {},
       modifier =
@@ -151,8 +153,9 @@ fun DayActivityCard(day: LocalDate, activitiesForDay: List<Activity>) {
               .take(4)
               .forEach { activity -> ActivityBox(activity) }
           if (numberOfActivities > 4) {
+            // Displays additional text in case of too many activities
             Text(
-                text = "and ${numberOfActivities - 3} more",
+                text = "and ${numberOfActivities - 4} more",
                 style =
                     TextStyle(fontSize = 10.sp, color = Color.Gray, fontWeight = FontWeight.Bold),
                 modifier = Modifier.padding(top = 4.dp))
@@ -162,11 +165,14 @@ fun DayActivityCard(day: LocalDate, activitiesForDay: List<Activity>) {
 }
 
 @Composable
-fun ActivityBox(activity: Activity) {
+/** Activity box which displays activity title. */
+private fun ActivityBox(activity: Activity) {
+  // Appropriate background for both Light and Dark Themes
   val backgroundColor = if (isSystemInDarkTheme()) Color.Black else Color.White
   Box(
       modifier =
           Modifier.width(119.dp)
+              .testTag("activityBox")
               .height(19.dp)
               .background(color = backgroundColor, shape = RoundedCornerShape(size = 25.dp)),
       contentAlignment = Alignment.CenterStart) {
@@ -185,8 +191,11 @@ fun ActivityBox(activity: Activity) {
       }
 }
 
-// Function to format LocalDate to a "Day, d Month" format
-fun formatDailyDate(date: LocalDate): String {
-  val formatter = DateTimeFormatter.ofPattern("EEEE, d MMMM", Locale.ENGLISH)
-  return date.format(formatter)
+fun formatDailyDate(date: LocalDate?): String {
+  // Wrap in a try-catch to avoid an exception crashing the app
+  return try {
+    date?.format(DateTimeFormatter.ofPattern("EEEE, d MMMM", Locale.ENGLISH)) ?: "Invalid date"
+  } catch (e: Exception) {
+    "Invalid date"
+  }
 }

--- a/app/src/main/java/com/android/voyageur/ui/trip/schedule/ScheduleScreen.kt
+++ b/app/src/main/java/com/android/voyageur/ui/trip/schedule/ScheduleScreen.kt
@@ -23,15 +23,19 @@ import com.android.voyageur.ui.navigation.NavigationActions
 
 @Composable
 fun ScheduleScreen(trip: Trip, navigationActions: NavigationActions) {
-  var isDailySelected by remember { mutableStateOf(true) }
+  var isDailySelected by remember { mutableStateOf(navigationActions.getNavigationState("isDailyViewSelected", true)) }
 
+fun updateIsDailySelected(newIsDailySelected: Boolean) {
+    isDailySelected = newIsDailySelected
+    navigationActions.setNavigationState("isDailyViewSelected", newIsDailySelected)
+}
   Column(modifier = Modifier.fillMaxSize().padding(top = 8.dp)) {
     // Row for the "Daily" and "Weekly" buttons
     Row(
         modifier = Modifier.fillMaxWidth().padding(bottom = 8.dp, end = 16.dp),
         horizontalArrangement = Arrangement.End,
         verticalAlignment = Alignment.CenterVertically) {
-          TextButton(onClick = { isDailySelected = true }) {
+          TextButton(onClick = { updateIsDailySelected(true) }) {
             Text(
                 text = "Daily",
                 style = MaterialTheme.typography.bodyMedium,
@@ -44,7 +48,7 @@ fun ScheduleScreen(trip: Trip, navigationActions: NavigationActions) {
               text = " / ",
               style = MaterialTheme.typography.bodyMedium,
               color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.6f))
-          TextButton(onClick = { isDailySelected = false }) {
+          TextButton(onClick = { updateIsDailySelected(false)}) {
             Text(
                 text = "Weekly",
                 style = MaterialTheme.typography.bodyMedium,
@@ -62,7 +66,7 @@ fun ScheduleScreen(trip: Trip, navigationActions: NavigationActions) {
       WeeklyViewScreen(
           trip = trip,
           navigationActions = navigationActions,
-          onDaySelected = { isDailySelected = true })
+          onDaySelected = { updateIsDailySelected(false) })
     }
   }
 }

--- a/app/src/main/java/com/android/voyageur/ui/trip/schedule/ScheduleScreen.kt
+++ b/app/src/main/java/com/android/voyageur/ui/trip/schedule/ScheduleScreen.kt
@@ -11,8 +11,6 @@ import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -23,50 +21,55 @@ import com.android.voyageur.ui.navigation.NavigationActions
 
 @Composable
 fun ScheduleScreen(trip: Trip, navigationActions: NavigationActions) {
-  var isDailySelected by remember { mutableStateOf(navigationActions.getNavigationState("isDailyViewSelected", true)) }
 
-fun updateIsDailySelected(newIsDailySelected: Boolean) {
-    isDailySelected = newIsDailySelected
-    navigationActions.setNavigationState("isDailyViewSelected", newIsDailySelected)
-}
   Column(modifier = Modifier.fillMaxSize().padding(top = 8.dp)) {
     // Row for the "Daily" and "Weekly" buttons
     Row(
         modifier = Modifier.fillMaxWidth().padding(bottom = 8.dp, end = 16.dp),
         horizontalArrangement = Arrangement.End,
         verticalAlignment = Alignment.CenterVertically) {
-          TextButton(onClick = { updateIsDailySelected(true) }) {
-            Text(
-                text = "Daily",
-                style = MaterialTheme.typography.bodyMedium,
-                color =
-                    if (isDailySelected) MaterialTheme.colorScheme.primary
-                    else MaterialTheme.colorScheme.onSurface.copy(alpha = 0.6f),
-                fontWeight = if (isDailySelected) FontWeight.Bold else FontWeight.Normal)
-          }
+          TextButton(
+              onClick = { navigationActions.getNavigationState().isDailyViewSelected = true }) {
+                Text(
+                    text = "Daily",
+                    style = MaterialTheme.typography.bodyMedium,
+                    color =
+                        if (navigationActions.getNavigationState().isDailyViewSelected)
+                            MaterialTheme.colorScheme.primary
+                        else MaterialTheme.colorScheme.onSurface.copy(alpha = 0.6f),
+                    fontWeight =
+                        if (navigationActions.getNavigationState().isDailyViewSelected)
+                            FontWeight.Bold
+                        else FontWeight.Normal)
+              }
           Text(
               text = " / ",
               style = MaterialTheme.typography.bodyMedium,
               color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.6f))
-          TextButton(onClick = { updateIsDailySelected(false)}) {
-            Text(
-                text = "Weekly",
-                style = MaterialTheme.typography.bodyMedium,
-                color =
-                    if (!isDailySelected) MaterialTheme.colorScheme.primary
-                    else MaterialTheme.colorScheme.onSurface.copy(alpha = 0.6f),
-                fontWeight = if (!isDailySelected) FontWeight.Bold else FontWeight.Normal)
-          }
+          TextButton(
+              onClick = { navigationActions.getNavigationState().isDailyViewSelected = false }) {
+                Text(
+                    text = "Weekly",
+                    style = MaterialTheme.typography.bodyMedium,
+                    color =
+                        if (!navigationActions.getNavigationState().isDailyViewSelected)
+                            MaterialTheme.colorScheme.primary
+                        else MaterialTheme.colorScheme.onSurface.copy(alpha = 0.6f),
+                    fontWeight =
+                        if (!navigationActions.getNavigationState().isDailyViewSelected)
+                            FontWeight.Bold
+                        else FontWeight.Normal)
+              }
         }
 
     // Conditionally show content based on isDailySelected
-    if (isDailySelected) {
+    if (navigationActions.getNavigationState().isDailyViewSelected) {
       ByDayScreen(trip, navigationActions)
     } else {
       WeeklyViewScreen(
           trip = trip,
           navigationActions = navigationActions,
-          onDaySelected = { updateIsDailySelected(false) })
+          onDaySelected = { navigationActions.getNavigationState().isDailyViewSelected = false })
     }
   }
 }

--- a/app/src/test/java/com/android/voyageur/model/place/GooglePlacesRepositoryTest.kt
+++ b/app/src/test/java/com/android/voyageur/model/place/GooglePlacesRepositoryTest.kt
@@ -1,0 +1,153 @@
+package com.android.voyageur.model.place
+
+import android.graphics.Bitmap
+import com.google.android.gms.maps.model.LatLng
+import com.google.android.gms.tasks.OnFailureListener
+import com.google.android.gms.tasks.OnSuccessListener
+import com.google.android.gms.tasks.Task
+import com.google.android.libraries.places.api.model.AutocompletePrediction
+import com.google.android.libraries.places.api.model.PhotoMetadata
+import com.google.android.libraries.places.api.model.Place
+import com.google.android.libraries.places.api.net.FetchPhotoResponse
+import com.google.android.libraries.places.api.net.FetchPlaceResponse
+import com.google.android.libraries.places.api.net.FindAutocompletePredictionsResponse
+import com.google.android.libraries.places.api.net.PlacesClient
+import junit.framework.TestCase.assertEquals
+import junit.framework.TestCase.assertTrue
+import junit.framework.TestCase.fail
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.Mock
+import org.mockito.Mockito.any
+import org.mockito.Mockito.mock
+import org.mockito.Mockito.verify
+import org.mockito.Mockito.`when`
+import org.mockito.MockitoAnnotations
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class GooglePlacesRepositoryTest {
+
+  @Mock private lateinit var mockPlacesClient: PlacesClient
+  @Mock private lateinit var mockFetchPlaceResponse: FetchPlaceResponse
+  @Mock
+  private lateinit var mockFindAutocompletePredictionsResponse: FindAutocompletePredictionsResponse
+  @Mock private lateinit var mockFetchPhotoResponse: FetchPhotoResponse
+  @Mock private lateinit var mockAutocompletePrediction: AutocompletePrediction
+  @Mock private lateinit var mockPlace: Place
+  @Mock private lateinit var mockPhotoMetadata: PhotoMetadata
+
+  private lateinit var googlePlacesRepository: GooglePlacesRepository
+
+  @Before
+  fun setUp() {
+    MockitoAnnotations.openMocks(this)
+    googlePlacesRepository = GooglePlacesRepository(mockPlacesClient)
+
+    // Mock the fetchPlace method to return a valid Task
+    val mockFetchPlaceTask = mock(Task::class.java) as Task<FetchPlaceResponse>
+    `when`(mockPlacesClient.fetchPlace(any())).thenReturn(mockFetchPlaceTask)
+    `when`(mockFetchPlaceTask.addOnSuccessListener(any())).thenAnswer { invocation ->
+      val listener = invocation.arguments[0] as OnSuccessListener<FetchPlaceResponse>
+      `when`(mockFetchPlaceResponse.place).thenReturn(mockPlace)
+      listener.onSuccess(mockFetchPlaceResponse)
+      mockFetchPlaceTask
+    }
+    `when`(mockFetchPlaceTask.addOnFailureListener(any())).thenAnswer { invocation ->
+      val listener = invocation.arguments[0] as OnFailureListener
+      listener.onFailure(Exception("Places API error"))
+      mockFetchPlaceTask
+    }
+  }
+
+  @Test
+  fun testSearchPlaces_success() {
+    val query = "test"
+    val location = LatLng(37.7749, -122.4194)
+    val placeId = "testPlaceId"
+    val placeIds = listOf(placeId)
+    val mockTask = mock(Task::class.java) as Task<FindAutocompletePredictionsResponse>
+
+    `when`(mockPlacesClient.findAutocompletePredictions(any())).thenReturn(mockTask)
+    `when`(mockTask.addOnSuccessListener(any())).thenAnswer { invocation ->
+      val listener =
+          invocation.arguments[0] as OnSuccessListener<FindAutocompletePredictionsResponse>
+      `when`(mockFindAutocompletePredictionsResponse.autocompletePredictions)
+          .thenReturn(listOf(mockAutocompletePrediction))
+      `when`(mockAutocompletePrediction.placeId).thenReturn(placeId)
+      listener.onSuccess(mockFindAutocompletePredictionsResponse)
+      mockTask
+    }
+
+    val onSuccess: (List<CustomPlace>) -> Unit = { places -> assertEquals(1, places.size) }
+    val onFailure: (Exception) -> Unit = { fail("Failure callback should not be called") }
+
+    googlePlacesRepository.searchPlaces(query, location, onSuccess, onFailure)
+
+    verify(mockPlacesClient).findAutocompletePredictions(any())
+    verify(mockTask).addOnSuccessListener(any())
+  }
+
+  @Test
+  fun testSearchPlaces_failure() {
+    val query = "test"
+    val exception = Exception("Places API error")
+    val mockTask = mock(Task::class.java) as Task<FindAutocompletePredictionsResponse>
+
+    `when`(mockPlacesClient.findAutocompletePredictions(any())).thenReturn(mockTask)
+    `when`(mockTask.addOnSuccessListener(any())).thenAnswer { invocation ->
+      val listener =
+          invocation.arguments[0] as OnSuccessListener<FindAutocompletePredictionsResponse>
+      listener.onSuccess(mockFindAutocompletePredictionsResponse)
+      mockTask
+    }
+    `when`(mockTask.addOnFailureListener(any())).thenAnswer { invocation ->
+      val listener = invocation.arguments[0] as OnFailureListener
+      listener.onFailure(exception)
+      mockTask
+    }
+
+    val onSuccess: (List<CustomPlace>) -> Unit = { fail("Success callback should not be called") }
+    val onFailure: (Exception) -> Unit = { e -> assertEquals("Places API error", e.message) }
+
+    googlePlacesRepository.searchPlaces(query, null, onSuccess, onFailure)
+
+    verify(mockPlacesClient).findAutocompletePredictions(any())
+    verify(mockTask).addOnFailureListener(any())
+  }
+
+  @Test
+  fun testFetchPhotoMetadataAndRequest() {
+    val placeId = "testPlaceId"
+    val mockFetchPhotoTask = mock(Task::class.java) as Task<FetchPhotoResponse>
+
+    `when`(mockPlace.photoMetadatas).thenReturn(listOf(mockPhotoMetadata))
+
+    `when`(mockPlacesClient.fetchPhoto(any())).thenReturn(mockFetchPhotoTask)
+    `when`(mockFetchPhotoTask.addOnSuccessListener(any())).thenAnswer { invocation ->
+      val listener = invocation.arguments[0] as OnSuccessListener<FetchPhotoResponse>
+      listener.onSuccess(mockFetchPhotoResponse) // Simulate successful photo fetch
+      mockFetchPhotoTask
+    }
+    `when`(mockFetchPhotoTask.addOnFailureListener(any())).thenAnswer { invocation ->
+      val listener = invocation.arguments[0] as OnFailureListener
+      listener.onFailure(Exception("Photo API error")) // Simulate failure in photo fetch
+      mockFetchPhotoTask
+    }
+
+    val mockBitmap = mock(Bitmap::class.java)
+    `when`(mockFetchPhotoResponse.bitmap).thenReturn(mockBitmap)
+
+    val onSuccess: (List<CustomPlace>) -> Unit = { customPlaces ->
+      // Check if the bitmap list is not empty
+      assertTrue(customPlaces[0].photos.isNotEmpty())
+    }
+    val onFailure: (Exception) -> Unit = { fail("Failure callback should not be called") }
+
+    googlePlacesRepository.fetchPlaceDetails(listOf(placeId), onSuccess, onFailure)
+
+    verify(mockPlacesClient).fetchPhoto(any())
+    verify(mockFetchPhotoTask).addOnSuccessListener(any())
+  }
+}

--- a/app/src/test/java/com/android/voyageur/model/place/PlacesViewModelTest.kt
+++ b/app/src/test/java/com/android/voyageur/model/place/PlacesViewModelTest.kt
@@ -1,0 +1,59 @@
+package com.android.voyageur.model.place
+
+import com.google.android.gms.maps.model.LatLng
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.Mockito.*
+import org.mockito.MockitoAnnotations
+import org.mockito.kotlin.any
+import org.mockito.kotlin.eq
+import org.robolectric.RobolectricTestRunner
+
+@OptIn(ExperimentalCoroutinesApi::class)
+@RunWith(RobolectricTestRunner::class)
+class PlacesViewModelTest {
+  private lateinit var placesRepository: PlacesRepository
+  private lateinit var placesViewModel: PlacesViewModel
+  private val testDispatcher = UnconfinedTestDispatcher()
+
+  @Before
+  fun setUp() {
+    MockitoAnnotations.openMocks(this)
+    Dispatchers.setMain(testDispatcher)
+    placesRepository = mock(PlacesRepository::class.java)
+    placesViewModel = PlacesViewModel(placesRepository)
+  }
+
+  @After
+  fun tearDown() {
+    Dispatchers.resetMain()
+  }
+
+  @Test
+  fun setQueryUpdatesQuery() {
+    val query = "test"
+    placesViewModel.setQuery(query, LatLng(0.0, 0.0))
+    assert(placesViewModel.query.value == query)
+  }
+
+  @Test
+  fun setQueryTriggersSearchAfterDelay() = runTest {
+    val query1 = "test1"
+    val query2 = "test2"
+    placesViewModel.setQuery(query1, LatLng(0.0, 0.0))
+    assert(placesViewModel.query.value == query1)
+    verify(placesRepository, never()).searchPlaces(eq(query1), any(), any(), any())
+    placesViewModel.setQuery(query2, LatLng(0.0, 0.0))
+    delay(200) // Wait for debounce delay
+    verify(placesRepository).searchPlaces(eq(query2), any(), any(), any())
+  }
+}

--- a/app/src/test/java/com/android/voyageur/ui/gallery/CheckOlderVersionTest.kt
+++ b/app/src/test/java/com/android/voyageur/ui/gallery/CheckOlderVersionTest.kt
@@ -1,0 +1,34 @@
+package com.android.voyageur.ui.gallery
+
+import android.Manifest
+import android.content.Context
+import android.os.Build
+import androidx.test.core.app.ApplicationProvider
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [Build.VERSION_CODES.P]) // This simulates an older version sdk >=28
+class CheckOlderVersionTest {
+
+  @Test
+  fun checkFullPermission_onOlderVersion_withPermissionGranted() {
+    val context = ApplicationProvider.getApplicationContext<Context>()
+    org.robolectric.shadows.ShadowApplication.getInstance()
+        .grantPermissions(Manifest.permission.READ_EXTERNAL_STORAGE)
+    val result = checkFullPermission(context)
+    assertEquals(true, result)
+  }
+
+  @Test
+  fun checkFullPermission_onOlderVersion_withPermissionDenied() {
+    val context = ApplicationProvider.getApplicationContext<Context>()
+    org.robolectric.shadows.ShadowApplication.getInstance()
+        .denyPermissions(Manifest.permission.READ_EXTERNAL_STORAGE)
+    val result = checkFullPermission(context)
+    assertEquals(false, result)
+  }
+}

--- a/app/src/test/java/com/android/voyageur/ui/gallery/FindActivityTest.kt
+++ b/app/src/test/java/com/android/voyageur/ui/gallery/FindActivityTest.kt
@@ -1,4 +1,4 @@
-package com.android.voyageur.ui.profile
+package com.android.voyageur.ui.gallery
 
 import android.content.ContextWrapper
 import androidx.activity.ComponentActivity

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -80,6 +80,7 @@ firebaseStorageKtx = "21.0.1"
 testng = "6.9.6"
 foundationAndroid = "1.7.5"
 core = "1.46.0"
+junitKtx = "1.2.1"
 
 [libraries]
 accompanist-permissions = { module = "com.google.accompanist:accompanist-permissions", version.ref = "accompanistPermissions" }
@@ -145,6 +146,7 @@ firebase-storage-ktx = { group = "com.google.firebase", name = "firebase-storage
 testng = { group = "org.testng", name = "testng", version.ref = "testng" }
 androidx-foundation-android = { group = "androidx.compose.foundation", name = "foundation-android", version.ref = "foundationAndroid" }
 core = { group = "com.google.ar", name = "core", version.ref = "core" }
+androidx-junit-ktx = { group = "androidx.test.ext", name = "junit-ktx", version.ref = "junitKtx" }
 
 
 [plugins]


### PR DESCRIPTION
## Summary

Previously, when navigation changed from Tob Tabs to another screen (e.g. Add Activity Screen) and the user wanted to go back, the Schedule tab with Daily view was always displayed, even if the users invoked the screen from the Activities tab, or the Weekly view.
This bugfix solves this issue. Now the navigation actions remember which tab and view is selected. This resets once we exit the trip.
## Changes
- **Logic/Controllers:** NavigationActions now remembers the currentTripTab and if the daily view is selected or not.
- **Bug Fixes/Improvements:** same as summary, navigation is improved

## Checklist

Ensure all / most of these are checked before the pull request is submitted.
- [x] This PR resolves #135 
- [x] Tests have been added for new functionality.
- [x] Screenshots or UI changes have been attached (if applicable).
- [x] Documentation has been updated (if applicable).

##  Testing

- **Manual Testing:**
    - [x] Tested on emulator / physical device.
- **Unit Tests**
    - [x] Added units tests for this


## Screenshots (if applicable)

[Screen_recording_20241111_151327.webm](https://github.com/user-attachments/assets/3d09887d-efe4-46e0-8ecf-2570fbd816be)