### PR TITLE
Feat/Permission button for gallery

### DIFF
--- a/app/src/androidTest/java/com/android/voyageur/ui/gallery/PermissionButtonGalleryTest.kt
+++ b/app/src/androidTest/java/com/android/voyageur/ui/gallery/PermissionButtonGalleryTest.kt
@@ -1,0 +1,110 @@
+package com.android.voyageur.ui.gallery
+
+import android.content.Context
+import android.content.pm.PackageManager.PERMISSION_DENIED
+import android.content.pm.PackageManager.PERMISSION_GRANTED
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithText
+import androidx.core.content.ContextCompat
+import junit.framework.TestCase.assertFalse
+import junit.framework.TestCase.assertTrue
+import org.junit.Rule
+import org.junit.Test
+import org.mockito.Mockito.mock
+import org.mockito.Mockito.`when`
+
+class PermissionButtonForGalleryTest {
+
+    @get:Rule
+    val composeTestRule = createComposeRule()
+
+    @Test
+    fun buttonIsDisplayedWithCorrectText() {
+        val message = "Open Gallery"
+        composeTestRule.setContent {
+            PermissionButtonForGallery(
+                onUriSelected = {},
+                messageToShow = message,
+                dialogMessage = "Permission is required to access the gallery."
+            )
+        }
+        // Check that the button with the correct text is displayed
+        composeTestRule.onNodeWithText(message).assertExists().assertIsDisplayed()
+    }
+    @Test
+    fun checkPermissionReturnsTrue() {
+      // Mock context
+      val context = mock(Context::class.java)
+
+      // Mock the permission check to return PERMISSION_GRANTED
+      `when`(ContextCompat.checkSelfPermission(context, "android.permission.READ_MEDIA_IMAGES"))
+          .thenReturn(PERMISSION_GRANTED)
+
+      val result = checkFullPermission(context)
+      assertTrue(result) // Expecting true because permission is granted
+    }
+
+    @Test
+    fun checkPermissionReturnsTrueLimitedPermission() {
+      // Mock context
+      val context = mock(Context::class.java)
+
+      // Mock the permission check to return PERMISSION_GRANTED
+      `when`(
+              ContextCompat.checkSelfPermission(
+                  context, "android.permission.READ_MEDIA_VISUAL_USER_SELECTED"))
+          .thenReturn(PERMISSION_GRANTED)
+
+      val result = checkLimitedPermission(context)
+      assertTrue(result) // Expecting true because permission is granted
+    }
+
+    @Test
+    fun checkPermissionReturnsFalse() {
+      // Mock context
+      val context = mock(Context::class.java)
+
+      // Mock the permission check to return PERMISSION_DENIED
+      `when`(ContextCompat.checkSelfPermission(context, "android.permission.READ_MEDIA_IMAGES"))
+          .thenReturn(PERMISSION_DENIED)
+      `when`(
+              ContextCompat.checkSelfPermission(
+                  context, "android.permission.READ_MEDIA_VISUAL_USER_SELECTED"))
+          .thenReturn(PERMISSION_DENIED)
+      `when`(ContextCompat.checkSelfPermission(context, "android.permission.READ_EXTERNAL_STORAGE"))
+          .thenReturn(PERMISSION_DENIED)
+
+      val result = checkFullPermission(context)
+      assertFalse(result) // Expecting false because permission is not granted
+    }
+    @Test
+    fun checkLimitedPermissionReturnsTrue() {
+      // Mock the context
+      val context = mock(Context::class.java)
+
+      // Mock the permission check to return PERMISSION_GRANTED for limited access
+      `when`(
+              ContextCompat.checkSelfPermission(
+                  context, "android.permission.READ_MEDIA_VISUAL_USER_SELECTED"))
+          .thenReturn(PERMISSION_GRANTED)
+
+      val result = checkLimitedPermission(context)
+      assertTrue(result) // Expecting true because limited permission is granted
+    }
+
+    @Test
+    fun checkLimitedPermissionReturnsFalse() {
+      // Mock the context
+      val context = mock(Context::class.java)
+
+      // Mock the permission check to return PERMISSION_DENIED for limited access
+      `when`(
+              ContextCompat.checkSelfPermission(
+                  context, "android.permission.READ_MEDIA_VISUAL_USER_SELECTED"))
+          .thenReturn(PERMISSION_DENIED)
+
+      val result = checkLimitedPermission(context)
+      assertFalse(result) // Expecting false because limited permission is not granted
+    }
+}

--- a/app/src/androidTest/java/com/android/voyageur/ui/gallery/PermissionButtonGalleryTest.kt
+++ b/app/src/androidTest/java/com/android/voyageur/ui/gallery/PermissionButtonGalleryTest.kt
@@ -16,95 +16,76 @@ import org.mockito.Mockito.`when`
 
 class PermissionButtonForGalleryTest {
 
-    @get:Rule
-    val composeTestRule = createComposeRule()
+  @get:Rule val composeTestRule = createComposeRule()
 
-    @Test
-    fun buttonIsDisplayedWithCorrectText() {
-        val message = "Open Gallery"
-        composeTestRule.setContent {
-            PermissionButtonForGallery(
-                onUriSelected = {},
-                messageToShow = message,
-                dialogMessage = "Permission is required to access the gallery."
-            )
-        }
-        // Check that the button with the correct text is displayed
-        composeTestRule.onNodeWithText(message).assertExists().assertIsDisplayed()
+  @Test
+  fun buttonIsDisplayedWithCorrectText() {
+    val message = "Open Gallery"
+    composeTestRule.setContent {
+      PermissionButtonForGallery(
+          onUriSelected = {},
+          messageToShow = message,
+          dialogMessage = "Permission is required to access the gallery.")
     }
-    @Test
-    fun checkPermissionReturnsTrue() {
-      // Mock context
-      val context = mock(Context::class.java)
+    composeTestRule.onNodeWithText(message).assertExists().assertIsDisplayed()
+  }
 
-      // Mock the permission check to return PERMISSION_GRANTED
-      `when`(ContextCompat.checkSelfPermission(context, "android.permission.READ_MEDIA_IMAGES"))
-          .thenReturn(PERMISSION_GRANTED)
+  @Test
+  fun checkPermissionReturnsTrue() {
+    // Mock context
+    val context = mock(Context::class.java)
+    // Mock full permission granted to return PERMISSION_GRANTED
+    `when`(ContextCompat.checkSelfPermission(context, "android.permission.READ_MEDIA_IMAGES"))
+        .thenReturn(PERMISSION_GRANTED)
 
-      val result = checkFullPermission(context)
-      assertTrue(result) // Expecting true because permission is granted
-    }
+    val result = checkFullPermission(context)
+    assertTrue(result)
+  }
 
-    @Test
-    fun checkPermissionReturnsTrueLimitedPermission() {
-      // Mock context
-      val context = mock(Context::class.java)
+  @Test
+  fun checkPermissionReturnsFalse() {
+    // Mock context
+    val context = mock(Context::class.java)
 
-      // Mock the permission check to return PERMISSION_GRANTED
-      `when`(
-              ContextCompat.checkSelfPermission(
-                  context, "android.permission.READ_MEDIA_VISUAL_USER_SELECTED"))
-          .thenReturn(PERMISSION_GRANTED)
+    // Mock the permission check to return PERMISSION_DENIED
+    `when`(ContextCompat.checkSelfPermission(context, "android.permission.READ_MEDIA_IMAGES"))
+        .thenReturn(PERMISSION_DENIED)
+    `when`(
+            ContextCompat.checkSelfPermission(
+                context, "android.permission.READ_MEDIA_VISUAL_USER_SELECTED"))
+        .thenReturn(PERMISSION_DENIED)
+    `when`(ContextCompat.checkSelfPermission(context, "android.permission.READ_EXTERNAL_STORAGE"))
+        .thenReturn(PERMISSION_DENIED)
 
-      val result = checkLimitedPermission(context)
-      assertTrue(result) // Expecting true because permission is granted
-    }
+    val result = checkFullPermission(context)
+    assertFalse(result)
+  }
 
-    @Test
-    fun checkPermissionReturnsFalse() {
-      // Mock context
-      val context = mock(Context::class.java)
+  @Test
+  fun checkLimitedPermissionReturnsTrue() {
+    // Mock the context
+    val context = mock(Context::class.java)
 
-      // Mock the permission check to return PERMISSION_DENIED
-      `when`(ContextCompat.checkSelfPermission(context, "android.permission.READ_MEDIA_IMAGES"))
-          .thenReturn(PERMISSION_DENIED)
-      `when`(
-              ContextCompat.checkSelfPermission(
-                  context, "android.permission.READ_MEDIA_VISUAL_USER_SELECTED"))
-          .thenReturn(PERMISSION_DENIED)
-      `when`(ContextCompat.checkSelfPermission(context, "android.permission.READ_EXTERNAL_STORAGE"))
-          .thenReturn(PERMISSION_DENIED)
+    // Mock the permission check to return PERMISSION_GRANTED for limited access
+    `when`(
+            ContextCompat.checkSelfPermission(
+                context, "android.permission.READ_MEDIA_VISUAL_USER_SELECTED"))
+        .thenReturn(PERMISSION_GRANTED)
 
-      val result = checkFullPermission(context)
-      assertFalse(result) // Expecting false because permission is not granted
-    }
-    @Test
-    fun checkLimitedPermissionReturnsTrue() {
-      // Mock the context
-      val context = mock(Context::class.java)
+    val result = checkLimitedPermission(context)
+    assertTrue(result)
+  }
 
-      // Mock the permission check to return PERMISSION_GRANTED for limited access
-      `when`(
-              ContextCompat.checkSelfPermission(
-                  context, "android.permission.READ_MEDIA_VISUAL_USER_SELECTED"))
-          .thenReturn(PERMISSION_GRANTED)
+  @Test
+  fun checkLimitedPermissionReturnsFalse() {
+    val context = mock(Context::class.java)
 
-      val result = checkLimitedPermission(context)
-      assertTrue(result) // Expecting true because limited permission is granted
-    }
+    `when`(
+            ContextCompat.checkSelfPermission(
+                context, "android.permission.READ_MEDIA_VISUAL_USER_SELECTED"))
+        .thenReturn(PERMISSION_DENIED)
 
-    @Test
-    fun checkLimitedPermissionReturnsFalse() {
-      // Mock the context
-      val context = mock(Context::class.java)
-
-      // Mock the permission check to return PERMISSION_DENIED for limited access
-      `when`(
-              ContextCompat.checkSelfPermission(
-                  context, "android.permission.READ_MEDIA_VISUAL_USER_SELECTED"))
-          .thenReturn(PERMISSION_DENIED)
-
-      val result = checkLimitedPermission(context)
-      assertFalse(result) // Expecting false because limited permission is not granted
-    }
+    val result = checkLimitedPermission(context)
+    assertFalse(result)
+  }
 }

--- a/app/src/androidTest/java/com/android/voyageur/ui/overview/AddTripTest.kt
+++ b/app/src/androidTest/java/com/android/voyageur/ui/overview/AddTripTest.kt
@@ -331,7 +331,7 @@ class AddTripScreenTest {
     assert(result == null)
   }
 
-  @Test
+  /*@Test
   fun checkPermissionReturnsTrue() {
     // Mock context
     val context = mock(Context::class.java)
@@ -342,9 +342,9 @@ class AddTripScreenTest {
 
     val result = checkFullPermission(context)
     assertTrue(result) // Expecting true because permission is granted
-  }
+  }*/
 
-  @Test
+  /*@Test
   fun checkPermissionReturnsTrueLimitedPermission() {
     // Mock context
     val context = mock(Context::class.java)
@@ -357,9 +357,9 @@ class AddTripScreenTest {
 
     val result = checkLimitedPermission(context)
     assertTrue(result) // Expecting true because permission is granted
-  }
+  }*/
 
-  @Test
+  /*@Test
   fun checkPermissionReturnsFalse() {
     // Mock context
     val context = mock(Context::class.java)
@@ -377,8 +377,8 @@ class AddTripScreenTest {
     val result = checkFullPermission(context)
     assertFalse(result) // Expecting false because permission is not granted
   }
-
-  @Test
+*/
+  /*@Test
   fun checkLimitedPermissionReturnsTrue() {
     // Mock the context
     val context = mock(Context::class.java)
@@ -391,9 +391,9 @@ class AddTripScreenTest {
 
     val result = checkLimitedPermission(context)
     assertTrue(result) // Expecting true because limited permission is granted
-  }
+  }*/
 
-  @Test
+  /*@Test
   fun checkLimitedPermissionReturnsFalse() {
     // Mock the context
     val context = mock(Context::class.java)
@@ -406,5 +406,5 @@ class AddTripScreenTest {
 
     val result = checkLimitedPermission(context)
     assertFalse(result) // Expecting false because limited permission is not granted
-  }
+  }*/
 }

--- a/app/src/androidTest/java/com/android/voyageur/ui/overview/AddTripTest.kt
+++ b/app/src/androidTest/java/com/android/voyageur/ui/overview/AddTripTest.kt
@@ -1,7 +1,5 @@
 package com.android.voyageur.ui.overview
 
-import android.content.Context
-import android.content.pm.PackageManager
 import android.icu.util.GregorianCalendar
 import android.icu.util.TimeZone
 import androidx.compose.ui.test.assertHasClickAction
@@ -16,7 +14,6 @@ import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.performTextInput
-import androidx.core.content.ContextCompat
 import com.android.voyageur.model.location.Location
 import com.android.voyageur.model.trip.Trip
 import com.android.voyageur.model.trip.TripRepository
@@ -27,8 +24,6 @@ import com.android.voyageur.ui.navigation.Screen
 import com.google.firebase.Timestamp
 import com.google.firebase.auth.FirebaseAuth
 import java.util.Date
-import junit.framework.TestCase.assertFalse
-import junit.framework.TestCase.assertTrue
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
@@ -360,24 +355,24 @@ class AddTripScreenTest {
   }*/
 
   /*@Test
-  fun checkPermissionReturnsFalse() {
-    // Mock context
-    val context = mock(Context::class.java)
+    fun checkPermissionReturnsFalse() {
+      // Mock context
+      val context = mock(Context::class.java)
 
-    // Mock the permission check to return PERMISSION_DENIED
-    `when`(ContextCompat.checkSelfPermission(context, "android.permission.READ_MEDIA_IMAGES"))
-        .thenReturn(PackageManager.PERMISSION_DENIED)
-    `when`(
-            ContextCompat.checkSelfPermission(
-                context, "android.permission.READ_MEDIA_VISUAL_USER_SELECTED"))
-        .thenReturn(PackageManager.PERMISSION_DENIED)
-    `when`(ContextCompat.checkSelfPermission(context, "android.permission.READ_EXTERNAL_STORAGE"))
-        .thenReturn(PackageManager.PERMISSION_DENIED)
+      // Mock the permission check to return PERMISSION_DENIED
+      `when`(ContextCompat.checkSelfPermission(context, "android.permission.READ_MEDIA_IMAGES"))
+          .thenReturn(PackageManager.PERMISSION_DENIED)
+      `when`(
+              ContextCompat.checkSelfPermission(
+                  context, "android.permission.READ_MEDIA_VISUAL_USER_SELECTED"))
+          .thenReturn(PackageManager.PERMISSION_DENIED)
+      `when`(ContextCompat.checkSelfPermission(context, "android.permission.READ_EXTERNAL_STORAGE"))
+          .thenReturn(PackageManager.PERMISSION_DENIED)
 
-    val result = checkFullPermission(context)
-    assertFalse(result) // Expecting false because permission is not granted
-  }
-*/
+      val result = checkFullPermission(context)
+      assertFalse(result) // Expecting false because permission is not granted
+    }
+  */
   /*@Test
   fun checkLimitedPermissionReturnsTrue() {
     // Mock the context

--- a/app/src/main/java/com/android/voyageur/ui/gallery/PermissionButtonForGallery.kt
+++ b/app/src/main/java/com/android/voyageur/ui/gallery/PermissionButtonForGallery.kt
@@ -27,15 +27,16 @@ import androidx.core.app.ActivityCompat
 import androidx.core.content.ContextCompat
 
 @Composable
-        /**
-         * A Composable function that displays a button for selecting a photo from the gallery,
-         * handling permission requests and rationale dialogs if needed.
-         *
-         * @param onUriSelected Callback invoked with the selected image URI or `null` if no image is selected.
-         * @param messageToShow The text displayed on the button.
-         * @param dialogMessage The message shown in the rationale dialog when permission is denied.
-         * @param modifier Modifier to style the button layout and add test tags.
-         */
+/**
+ * A Composable function that displays a button for selecting a photo from the gallery, handling
+ * permission requests and rationale dialogs if needed.
+ *
+ * @param onUriSelected Callback invoked with the selected image URI or `null` if no image is
+ *   selected.
+ * @param messageToShow The text displayed on the button.
+ * @param dialogMessage The message shown in the rationale dialog when permission is denied.
+ * @param modifier Modifier to style the button layout and add test tags.
+ */
 fun PermissionButtonForGallery(
     onUriSelected: (Uri?) -> Unit,
     messageToShow: String,
@@ -43,7 +44,7 @@ fun PermissionButtonForGallery(
     modifier: Modifier = Modifier
 ) {
   val context = LocalContext.current
-    val compActivity = context.findActivity()
+  val compActivity = context.findActivity()
   var showRationaleDialog by remember { mutableStateOf(false) }
   val permissionVersion =
       if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
@@ -79,8 +80,9 @@ fun PermissionButtonForGallery(
             // If permission is granted, launch the gallery
             galleryLauncher.launch("image/*")
           }
-            compActivity != null && ActivityCompat.shouldShowRequestPermissionRationale(
-              compActivity, permissionVersion) -> {
+          compActivity != null &&
+              ActivityCompat.shouldShowRequestPermissionRationale(
+                  compActivity, permissionVersion) -> {
             // Show rationale
             showRationaleDialog = true
           }
@@ -125,8 +127,8 @@ fun PermissionButtonForGallery(
 }
 
 /**
- * Checks if the app has full permission to read media images or external storage,
- * depending on the Android version.
+ * Checks if the app has full permission to read media images or external storage, depending on the
+ * Android version.
  */
 fun checkFullPermission(context: Context): Boolean {
   return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
@@ -136,8 +138,8 @@ fun checkFullPermission(context: Context): Boolean {
   }
 }
 /**
- * Checks if the app has limited permission to read user-selected media on Android
- * versions that support it.
+ * Checks if the app has limited permission to read user-selected media on Android versions that
+ * support it.
  */
 fun checkLimitedPermission(context: Context): Boolean {
   return (Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE &&

--- a/app/src/main/java/com/android/voyageur/ui/gallery/PermissionButtonForGallery.kt
+++ b/app/src/main/java/com/android/voyageur/ui/gallery/PermissionButtonForGallery.kt
@@ -27,111 +27,118 @@ import androidx.core.app.ActivityCompat
 import androidx.core.content.ContextCompat
 
 @Composable
-fun PermissionButtonForGallery(onUriSelected: (Uri?) -> Unit, messageToShow: String, dialogMessage: String, modifier: Modifier = Modifier)
-
-{   val context = LocalContext.current
-    var showRationaleDialog by remember { mutableStateOf(false) }
-    val permissionVersion =
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
-            READ_MEDIA_IMAGES
-        } else {
-            READ_EXTERNAL_STORAGE
-        }
-    val galleryLauncher = rememberLauncherForActivityResult(ActivityResultContracts.GetContent()) { uri: Uri? ->
+fun PermissionButtonForGallery(
+    onUriSelected: (Uri?) -> Unit,
+    messageToShow: String,
+    dialogMessage: String,
+    modifier: Modifier = Modifier
+) {
+  val context = LocalContext.current
+  var showRationaleDialog by remember { mutableStateOf(false) }
+  val permissionVersion =
+      if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+        READ_MEDIA_IMAGES
+      } else {
+        READ_EXTERNAL_STORAGE
+      }
+  val galleryLauncher =
+      rememberLauncherForActivityResult(ActivityResultContracts.GetContent()) { uri: Uri? ->
         if (uri != null) {
-            onUriSelected(uri)
+          onUriSelected(uri)
         } else {
-            Toast.makeText(context, "No image selected", Toast.LENGTH_SHORT).show()
+          Toast.makeText(context, "No image selected", Toast.LENGTH_SHORT).show()
         }
-    }
-    val permissionLauncher =
-        rememberLauncherForActivityResult(ActivityResultContracts.RequestPermission()) { isGranted ->
-            when {
-                isGranted -> galleryLauncher.launch("image/*")
-                checkLimitedPermission(context) -> galleryLauncher.launch("image/*")
-                else -> {
-                    // Permission is denied, show a message to the user
-                    Toast.makeText(
-                        context,
-                        "Permission denied. Unable to select photo.",
-                        Toast.LENGTH_SHORT)
-                        .show()
-                }
-            }
+      }
+  val permissionLauncher =
+      rememberLauncherForActivityResult(ActivityResultContracts.RequestPermission()) { isGranted ->
+        when {
+          isGranted -> galleryLauncher.launch("image/*")
+          checkLimitedPermission(context) -> galleryLauncher.launch("image/*")
+          else -> {
+            // Permission is denied, show a toast to the user
+            Toast.makeText(
+                    context, "Permission denied. Unable to select photo.", Toast.LENGTH_SHORT)
+                .show()
+          }
         }
-    Button(
-        onClick = {
-            when {
-                checkFullPermission(context) || checkLimitedPermission(context) -> {
-                    // If permission is granted, launch the gallery
-                    galleryLauncher.launch("image/*")
-                }
-                ActivityCompat.shouldShowRequestPermissionRationale(
-                    context.findActivity(), permissionVersion) -> {
-                    // Show rationale
-                    showRationaleDialog = true
-                }
-                else -> {
-                    permissionLauncher.launch(permissionVersion)
-                }
-            }
-        },
-        modifier = modifier) {
+      }
+  Button(
+      onClick = {
+        when {
+          checkFullPermission(context) || checkLimitedPermission(context) -> {
+            // If permission is granted, launch the gallery
+            galleryLauncher.launch("image/*")
+          }
+          ActivityCompat.shouldShowRequestPermissionRationale(
+              context.findActivity(), permissionVersion) -> {
+            // Show rationale
+            showRationaleDialog = true
+          }
+          else -> {
+            permissionLauncher.launch(permissionVersion)
+          }
+        }
+      },
+      modifier = modifier) {
         // Shows message corresponding to the screen
         Text(messageToShow)
         // Show rationale dialog if needed
         if (showRationaleDialog) {
-            AlertDialog(
-                onDismissRequest = { showRationaleDialog = false },
-                title = { Text("Permission Required") },
-                text = {
-                    Text(
-                        dialogMessage)
-                },
-                confirmButton = {
-                    TextButton(
-                        onClick = {
-                            showRationaleDialog = false
-                            permissionLauncher.launch(permissionVersion)
-                        }) {
-                        Text("Allow")
+          AlertDialog(
+              onDismissRequest = { showRationaleDialog = false },
+              title = { Text("Permission Required") },
+              text = { Text(dialogMessage) },
+              confirmButton = {
+                TextButton(
+                    onClick = {
+                      showRationaleDialog = false
+                      permissionLauncher.launch(permissionVersion)
+                    }) {
+                      Text("Allow")
                     }
-                },
-                dismissButton = {
-                    TextButton(onClick = { showRationaleDialog = false
-                        Toast.makeText(
-                            context,
-                            "Permission denied. Unable to select photo.",
-                            Toast.LENGTH_SHORT)
-                            .show()}) { Text("Cancel")}
-                })
+              },
+              dismissButton = {
+                TextButton(
+                    onClick = {
+                      showRationaleDialog = false
+                      Toast.makeText(
+                              context,
+                              "Permission denied. Unable to select photo.",
+                              Toast.LENGTH_SHORT)
+                          .show()
+                    }) {
+                      Text("Cancel")
+                    }
+              })
         }
-    }
+      }
 }
-// Function to check if full permission is granted
- fun checkFullPermission(context: Context): Boolean {
-    return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
-        ContextCompat.checkSelfPermission(context, READ_MEDIA_IMAGES) == PERMISSION_GRANTED
-    } else {
-        ContextCompat.checkSelfPermission(context, READ_EXTERNAL_STORAGE) == PERMISSION_GRANTED
-    }
+
+fun checkFullPermission(context: Context): Boolean {
+  return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+    ContextCompat.checkSelfPermission(context, READ_MEDIA_IMAGES) == PERMISSION_GRANTED
+  } else {
+    ContextCompat.checkSelfPermission(context, READ_EXTERNAL_STORAGE) == PERMISSION_GRANTED
+  }
 }
-// Function to check if limited access permission is granted
+
 fun checkLimitedPermission(context: Context): Boolean {
-    return (Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE &&
-            ContextCompat.checkSelfPermission(context, READ_MEDIA_VISUAL_USER_SELECTED) ==
-            PERMISSION_GRANTED)
+  return (Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE &&
+      ContextCompat.checkSelfPermission(context, READ_MEDIA_VISUAL_USER_SELECTED) ==
+          PERMISSION_GRANTED)
 }
-/** Return Component Activity associated with Context to show dialog
- * Unwraps context on which it is called upon
- * **/
+/**
+ * Return Component Activity associated with Context to show dialog. Unwraps context on which it is
+ * called upon.
+ * *
+ */
 fun Context.findActivity(): ComponentActivity {
-    var context = this
-    while (context is ContextWrapper) {
-        if (context is ComponentActivity) {
-            return context
-        }
-        context = context.baseContext
+  var context = this
+  while (context is ContextWrapper) {
+    if (context is ComponentActivity) {
+      return context
     }
-    throw IllegalStateException("No Activity found")
+    context = context.baseContext
+  }
+  throw IllegalStateException("No Activity found")
 }

--- a/app/src/main/java/com/android/voyageur/ui/gallery/PermissionButtonForGallery.kt
+++ b/app/src/main/java/com/android/voyageur/ui/gallery/PermissionButtonForGallery.kt
@@ -1,0 +1,137 @@
+package com.android.voyageur.ui.gallery
+
+import android.Manifest.permission.READ_EXTERNAL_STORAGE
+import android.Manifest.permission.READ_MEDIA_IMAGES
+import android.Manifest.permission.READ_MEDIA_VISUAL_USER_SELECTED
+import android.content.Context
+import android.content.ContextWrapper
+import android.content.pm.PackageManager.PERMISSION_GRANTED
+import android.net.Uri
+import android.os.Build
+import android.widget.Toast
+import androidx.activity.ComponentActivity
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.Button
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.core.app.ActivityCompat
+import androidx.core.content.ContextCompat
+
+@Composable
+fun PermissionButtonForGallery(onUriSelected: (Uri?) -> Unit, messageToShow: String, dialogMessage: String, modifier: Modifier = Modifier)
+
+{   val context = LocalContext.current
+    var showRationaleDialog by remember { mutableStateOf(false) }
+    val permissionVersion =
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            READ_MEDIA_IMAGES
+        } else {
+            READ_EXTERNAL_STORAGE
+        }
+    val galleryLauncher = rememberLauncherForActivityResult(ActivityResultContracts.GetContent()) { uri: Uri? ->
+        if (uri != null) {
+            onUriSelected(uri)
+        } else {
+            Toast.makeText(context, "No image selected", Toast.LENGTH_SHORT).show()
+        }
+    }
+    val permissionLauncher =
+        rememberLauncherForActivityResult(ActivityResultContracts.RequestPermission()) { isGranted ->
+            when {
+                isGranted -> galleryLauncher.launch("image/*")
+                checkLimitedPermission(context) -> galleryLauncher.launch("image/*")
+                else -> {
+                    // Permission is denied, show a message to the user
+                    Toast.makeText(
+                        context,
+                        "Permission denied. Unable to select photo.",
+                        Toast.LENGTH_SHORT)
+                        .show()
+                }
+            }
+        }
+    Button(
+        onClick = {
+            when {
+                checkFullPermission(context) || checkLimitedPermission(context) -> {
+                    // If permission is granted, launch the gallery
+                    galleryLauncher.launch("image/*")
+                }
+                ActivityCompat.shouldShowRequestPermissionRationale(
+                    context.findActivity(), permissionVersion) -> {
+                    // Show rationale
+                    showRationaleDialog = true
+                }
+                else -> {
+                    permissionLauncher.launch(permissionVersion)
+                }
+            }
+        },
+        modifier = modifier) {
+        // Shows message corresponding to the screen
+        Text(messageToShow)
+        // Show rationale dialog if needed
+        if (showRationaleDialog) {
+            AlertDialog(
+                onDismissRequest = { showRationaleDialog = false },
+                title = { Text("Permission Required") },
+                text = {
+                    Text(
+                        dialogMessage)
+                },
+                confirmButton = {
+                    TextButton(
+                        onClick = {
+                            showRationaleDialog = false
+                            permissionLauncher.launch(permissionVersion)
+                        }) {
+                        Text("Allow")
+                    }
+                },
+                dismissButton = {
+                    TextButton(onClick = { showRationaleDialog = false
+                        Toast.makeText(
+                            context,
+                            "Permission denied. Unable to select photo.",
+                            Toast.LENGTH_SHORT)
+                            .show()}) { Text("Cancel")}
+                })
+        }
+    }
+}
+// Function to check if full permission is granted
+ fun checkFullPermission(context: Context): Boolean {
+    return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+        ContextCompat.checkSelfPermission(context, READ_MEDIA_IMAGES) == PERMISSION_GRANTED
+    } else {
+        ContextCompat.checkSelfPermission(context, READ_EXTERNAL_STORAGE) == PERMISSION_GRANTED
+    }
+}
+// Function to check if limited access permission is granted
+fun checkLimitedPermission(context: Context): Boolean {
+    return (Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE &&
+            ContextCompat.checkSelfPermission(context, READ_MEDIA_VISUAL_USER_SELECTED) ==
+            PERMISSION_GRANTED)
+}
+/** Return Component Activity associated with Context to show dialog
+ * Unwraps context on which it is called upon
+ * **/
+fun Context.findActivity(): ComponentActivity {
+    var context = this
+    while (context is ContextWrapper) {
+        if (context is ComponentActivity) {
+            return context
+        }
+        context = context.baseContext
+    }
+    throw IllegalStateException("No Activity found")
+}

--- a/app/src/main/java/com/android/voyageur/ui/gallery/PermissionButtonForGallery.kt
+++ b/app/src/main/java/com/android/voyageur/ui/gallery/PermissionButtonForGallery.kt
@@ -27,6 +27,15 @@ import androidx.core.app.ActivityCompat
 import androidx.core.content.ContextCompat
 
 @Composable
+        /**
+         * A Composable function that displays a button for selecting a photo from the gallery,
+         * handling permission requests and rationale dialogs if needed.
+         *
+         * @param onUriSelected Callback invoked with the selected image URI or `null` if no image is selected.
+         * @param messageToShow The text displayed on the button.
+         * @param dialogMessage The message shown in the rationale dialog when permission is denied.
+         * @param modifier Modifier to style the button layout and add test tags.
+         */
 fun PermissionButtonForGallery(
     onUriSelected: (Uri?) -> Unit,
     messageToShow: String,
@@ -34,6 +43,7 @@ fun PermissionButtonForGallery(
     modifier: Modifier = Modifier
 ) {
   val context = LocalContext.current
+    val compActivity = context.findActivity()
   var showRationaleDialog by remember { mutableStateOf(false) }
   val permissionVersion =
       if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
@@ -69,8 +79,8 @@ fun PermissionButtonForGallery(
             // If permission is granted, launch the gallery
             galleryLauncher.launch("image/*")
           }
-          ActivityCompat.shouldShowRequestPermissionRationale(
-              context.findActivity(), permissionVersion) -> {
+            compActivity != null && ActivityCompat.shouldShowRequestPermissionRationale(
+              compActivity, permissionVersion) -> {
             // Show rationale
             showRationaleDialog = true
           }
@@ -114,6 +124,10 @@ fun PermissionButtonForGallery(
       }
 }
 
+/**
+ * Checks if the app has full permission to read media images or external storage,
+ * depending on the Android version.
+ */
 fun checkFullPermission(context: Context): Boolean {
   return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
     ContextCompat.checkSelfPermission(context, READ_MEDIA_IMAGES) == PERMISSION_GRANTED
@@ -121,18 +135,21 @@ fun checkFullPermission(context: Context): Boolean {
     ContextCompat.checkSelfPermission(context, READ_EXTERNAL_STORAGE) == PERMISSION_GRANTED
   }
 }
-
+/**
+ * Checks if the app has limited permission to read user-selected media on Android
+ * versions that support it.
+ */
 fun checkLimitedPermission(context: Context): Boolean {
   return (Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE &&
       ContextCompat.checkSelfPermission(context, READ_MEDIA_VISUAL_USER_SELECTED) ==
           PERMISSION_GRANTED)
 }
 /**
- * Return Component Activity associated with Context to show dialog. Unwraps context on which it is
+ * Returns Component Activity associated with Context to show dialog. Unwraps context on which it is
  * called upon.
  * *
  */
-fun Context.findActivity(): ComponentActivity {
+fun Context.findActivity(): ComponentActivity? {
   var context = this
   while (context is ContextWrapper) {
     if (context is ComponentActivity) {
@@ -140,5 +157,5 @@ fun Context.findActivity(): ComponentActivity {
     }
     context = context.baseContext
   }
-  throw IllegalStateException("No Activity found")
+  return null
 }

--- a/app/src/main/java/com/android/voyageur/ui/overview/AddTrip.kt
+++ b/app/src/main/java/com/android/voyageur/ui/overview/AddTrip.kt
@@ -2,15 +2,10 @@ package com.android.voyageur.ui.overview
 
 import android.Manifest.permission.READ_EXTERNAL_STORAGE
 import android.Manifest.permission.READ_MEDIA_IMAGES
-import android.Manifest.permission.READ_MEDIA_VISUAL_USER_SELECTED
 import android.annotation.SuppressLint
-import android.content.Context
-import android.content.pm.PackageManager.PERMISSION_GRANTED
 import android.net.Uri
 import android.os.Build
 import android.widget.Toast
-import androidx.activity.compose.rememberLauncherForActivityResult
-import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
@@ -28,7 +23,6 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.outlined.ArrowBack
-import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Button
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
@@ -37,7 +31,6 @@ import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.RadioButton
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
-import androidx.compose.material3.TextButton
 import androidx.compose.material3.TextFieldDefaults
 import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
@@ -54,8 +47,6 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.unit.dp
-import androidx.core.app.ActivityCompat
-import androidx.core.content.ContextCompat
 import androidx.lifecycle.viewmodel.compose.viewModel
 import coil.compose.rememberAsyncImagePainter
 import com.android.voyageur.R
@@ -241,10 +232,11 @@ fun AddTripScreen(
                 }
 
                 Spacer(modifier = Modifier.height(16.dp))
-                 PermissionButtonForGallery(onUriSelected = { uri ->
-                     imageUri = uri.toString()
-                 }, "Select Image from Gallery","This app needs access to your photos to allow you to select an image for your trip.",
-                      Modifier.fillMaxWidth())
+                PermissionButtonForGallery(
+                    onUriSelected = { uri -> imageUri = uri.toString() },
+                    "Select Image from Gallery",
+                    "This app needs access to your photos to allow you to select an image for your trip.",
+                    Modifier.fillMaxWidth())
 
                 OutlinedTextField(
                     value = name,
@@ -380,4 +372,3 @@ enum class DateField {
   START,
   END
 }
-

--- a/app/src/main/java/com/android/voyageur/ui/profile/EditProfileScreen.kt
+++ b/app/src/main/java/com/android/voyageur/ui/profile/EditProfileScreen.kt
@@ -1,9 +1,6 @@
 package com.android.voyageur.ui.profile
 
 import android.net.Uri
-import android.widget.Toast
-import androidx.activity.compose.rememberLauncherForActivityResult
-import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -41,7 +38,6 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
-import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.unit.dp
@@ -57,226 +53,182 @@ import com.android.voyageur.ui.profile.interests.InterestChipEditable
 @OptIn(ExperimentalMaterial3Api::class, ExperimentalLayoutApi::class)
 @Composable
 fun EditProfileScreen(userViewModel: UserViewModel, navigationActions: NavigationActions) {
-    val user by userViewModel.user.collectAsState()
-    val isLoading by userViewModel.isLoading.collectAsState()
+  val user by userViewModel.user.collectAsState()
+  val isLoading by userViewModel.isLoading.collectAsState()
 
-    var name by remember { mutableStateOf(user?.name ?: "") }
-    var email by remember { mutableStateOf(user?.email ?: "") }
-    var profilePictureUri by remember { mutableStateOf<Uri?>(null) }
-    var profilePictureUrl by remember { mutableStateOf(user?.profilePicture ?: "") }
-    var isSaving by remember { mutableStateOf(false) }
+  var name by remember { mutableStateOf(user?.name ?: "") }
+  var email by remember { mutableStateOf(user?.email ?: "") }
+  var profilePictureUri by remember { mutableStateOf<Uri?>(null) }
+  var profilePictureUrl by remember { mutableStateOf(user?.profilePicture ?: "") }
+  var isSaving by remember { mutableStateOf(false) }
 
-    // State variables for interests
-    var interests by remember {
-        mutableStateOf(
-            user?.interests?.toMutableList() ?: mutableListOf()
-        )
-    }
-    var newInterest by remember { mutableStateOf("") }
+  // State variables for interests
+  var interests by remember { mutableStateOf(user?.interests?.toMutableList() ?: mutableListOf()) }
+  var newInterest by remember { mutableStateOf("") }
 
-    if (isSaving) {
-        LaunchedEffect(isSaving) {
-            if (profilePictureUri != null) {
-                userViewModel.updateUserProfilePicture(profilePictureUri!!) { downloadUrl ->
-                    val updatedUser =
-                        user!!.copy(
-                            name = name,
-                            profilePicture = downloadUrl,
-                            interests = interests
-                        )
-                    userViewModel.updateUser(updatedUser)
-                    isSaving = false
-                    navigationActions.navigateTo(Route.PROFILE)
-                }
-            } else {
-                val updatedUser = user!!.copy(name = name, interests = interests)
-                userViewModel.updateUser(updatedUser)
-                isSaving = false
-                navigationActions.navigateTo(Route.PROFILE)
-            }
+  if (isSaving) {
+    LaunchedEffect(isSaving) {
+      if (profilePictureUri != null) {
+        userViewModel.updateUserProfilePicture(profilePictureUri!!) { downloadUrl ->
+          val updatedUser =
+              user!!.copy(name = name, profilePicture = downloadUrl, interests = interests)
+          userViewModel.updateUser(updatedUser)
+          isSaving = false
+          navigationActions.navigateTo(Route.PROFILE)
         }
+      } else {
+        val updatedUser = user!!.copy(name = name, interests = interests)
+        userViewModel.updateUser(updatedUser)
+        isSaving = false
+        navigationActions.navigateTo(Route.PROFILE)
+      }
     }
+  }
 
-    Scaffold(
-        bottomBar = {
-            BottomNavigationMenu(
-                onTabSelect = { route -> navigationActions.navigateTo(route) },
-                tabList = LIST_TOP_LEVEL_DESTINATION,
-                selectedItem = navigationActions.currentRoute(),
-            )
-        },
-        content = { paddingValues ->
-            Box(
-                modifier = Modifier
-                    .fillMaxSize()
-                    .padding(paddingValues),
-                contentAlignment = Alignment.Center
-            ) {
-                if (isLoading) {
-                    CircularProgressIndicator(modifier = Modifier.testTag("loadingIndicator"))
-                } else {
-                    user?.let { userData ->
-                        Column(
-                            modifier = Modifier
-                                .fillMaxSize()
-                                .padding(16.dp),
-                            verticalArrangement = Arrangement.Center,
-                            horizontalAlignment = Alignment.CenterHorizontally
-                        ) {
-                            // Display the selected image or the existing profile picture
-                            if (profilePictureUri != null) {
-                                Image(
-                                    painter = rememberAsyncImagePainter(model = profilePictureUri),
-                                    contentDescription = "Profile Picture",
-                                    modifier =
-                                    Modifier
-                                        .size(128.dp)
-                                        .clip(CircleShape)
-                                        .testTag("profilePicture")
-                                )
-                            } else if (profilePictureUrl.isNotEmpty()) {
-                                Image(
-                                    painter = rememberAsyncImagePainter(model = profilePictureUrl),
-                                    contentDescription = "Profile Picture",
-                                    modifier =
-                                    Modifier
-                                        .size(128.dp)
-                                        .clip(CircleShape)
-                                        .testTag("profilePicture")
-                                )
-                            } else {
-                                Icon(
-                                    imageVector = Icons.Default.AccountCircle,
-                                    contentDescription = "Default Profile Picture",
-                                    modifier = Modifier
-                                        .size(128.dp)
-                                        .testTag("defaultProfilePicture")
-                                )
+  Scaffold(
+      bottomBar = {
+        BottomNavigationMenu(
+            onTabSelect = { route -> navigationActions.navigateTo(route) },
+            tabList = LIST_TOP_LEVEL_DESTINATION,
+            selectedItem = navigationActions.currentRoute(),
+        )
+      },
+      content = { paddingValues ->
+        Box(
+            modifier = Modifier.fillMaxSize().padding(paddingValues),
+            contentAlignment = Alignment.Center) {
+              if (isLoading) {
+                CircularProgressIndicator(modifier = Modifier.testTag("loadingIndicator"))
+              } else {
+                user?.let { userData ->
+                  Column(
+                      modifier = Modifier.fillMaxSize().padding(16.dp),
+                      verticalArrangement = Arrangement.Center,
+                      horizontalAlignment = Alignment.CenterHorizontally) {
+                        // Display the selected image or the existing profile picture
+                        if (profilePictureUri != null) {
+                          Image(
+                              painter = rememberAsyncImagePainter(model = profilePictureUri),
+                              contentDescription = "Profile Picture",
+                              modifier =
+                                  Modifier.size(128.dp).clip(CircleShape).testTag("profilePicture"))
+                        } else if (profilePictureUrl.isNotEmpty()) {
+                          Image(
+                              painter = rememberAsyncImagePainter(model = profilePictureUrl),
+                              contentDescription = "Profile Picture",
+                              modifier =
+                                  Modifier.size(128.dp).clip(CircleShape).testTag("profilePicture"))
+                        } else {
+                          Icon(
+                              imageVector = Icons.Default.AccountCircle,
+                              contentDescription = "Default Profile Picture",
+                              modifier = Modifier.size(128.dp).testTag("defaultProfilePicture"))
+                        }
+                        PermissionButtonForGallery(
+                            onUriSelected = { profilePictureUri = it },
+                            "Edit Profile Picture",
+                            "This app needs access to your photos to allow you to select a profile picture.",
+                            Modifier.testTag("editImageButton"))
+
+                        Spacer(modifier = Modifier.height(16.dp))
+
+                        OutlinedTextField(
+                            value = name,
+                            onValueChange = { name = it },
+                            label = { Text("Name") },
+                            modifier = Modifier.testTag("nameField"),
+                        )
+
+                        Spacer(modifier = Modifier.height(16.dp))
+
+                        OutlinedTextField(
+                            value = email,
+                            onValueChange = {},
+                            label = { Text("Email") },
+                            readOnly = true,
+                            enabled = false,
+                            modifier = Modifier.testTag("emailField"))
+
+                        Spacer(modifier = Modifier.height(16.dp))
+
+                        // Display interests
+                        Text(
+                            text = "Interests:",
+                            style = MaterialTheme.typography.titleMedium,
+                            modifier = Modifier.padding(vertical = 8.dp))
+
+                        if (interests.isNotEmpty()) {
+                          // Display interests using FlowRow for better layout
+                          FlowRow(modifier = Modifier.fillMaxWidth().padding(horizontal = 16.dp)) {
+                            interests.forEach { interest ->
+                              InterestChipEditable(
+                                  interest = interest,
+                                  onRemove = {
+                                    interests = interests.filter { it != interest }.toMutableList()
+                                  })
                             }
-                            PermissionButtonForGallery(
-                                onUriSelected = { profilePictureUri = it },
-                                "Edit Profile Picture",
-                                "This app needs access to your photos to allow you to select a profile picture.",
-                                Modifier.testTag("editImageButton")
+                          }
+                        } else {
+                          // Display message when no interests are added
+                          Text(
+                              text = "No interests added yet",
+                              style = MaterialTheme.typography.bodyMedium,
+                              modifier = Modifier.testTag("noInterests"))
+                        }
 
-                            )
+                        Spacer(modifier = Modifier.height(16.dp))
 
-                            Spacer(modifier = Modifier.height(16.dp))
-
-                            OutlinedTextField(
-                                value = name,
-                                onValueChange = { name = it },
-                                label = { Text("Name") },
-                                modifier = Modifier.testTag("nameField"),
-                            )
-
-                            Spacer(modifier = Modifier.height(16.dp))
-
-                            OutlinedTextField(
-                                value = email,
-                                onValueChange = {},
-                                label = { Text("Email") },
-                                readOnly = true,
-                                enabled = false,
-                                modifier = Modifier.testTag("emailField")
-                            )
-
-                            Spacer(modifier = Modifier.height(16.dp))
-
-                            // Display interests
-                            Text(
-                                text = "Interests:",
-                                style = MaterialTheme.typography.titleMedium,
-                                modifier = Modifier.padding(vertical = 8.dp)
-                            )
-
-                            if (interests.isNotEmpty()) {
-                                // Display interests using FlowRow for better layout
-                                FlowRow(
-                                    modifier = Modifier
-                                        .fillMaxWidth()
-                                        .padding(horizontal = 16.dp)
-                                ) {
-                                    interests.forEach { interest ->
-                                        InterestChipEditable(
-                                            interest = interest,
-                                            onRemove = {
-                                                interests = interests.filter { it != interest }
-                                                    .toMutableList()
-                                            })
-                                    }
-                                }
-                            } else {
-                                // Display message when no interests are added
-                                Text(
-                                    text = "No interests added yet",
-                                    style = MaterialTheme.typography.bodyMedium,
-                                    modifier = Modifier.testTag("noInterests")
-                                )
-                            }
-
-                            Spacer(modifier = Modifier.height(16.dp))
-
-                            // Input field to add new interest
-                            Row(verticalAlignment = Alignment.CenterVertically) {
-                                OutlinedTextField(
-                                    value = newInterest,
-                                    onValueChange = { newInterest = it },
-                                    label = { Text("Add Interest") },
-                                    modifier = Modifier
-                                        .weight(1f)
-                                        .testTag("newInterestField"),
-                                    keyboardOptions = KeyboardOptions(imeAction = ImeAction.Done),
-                                    keyboardActions =
-                                    KeyboardActions(
-                                        onDone = {
-                                            if (newInterest.isNotBlank()) {
-                                                if (!interests.contains(newInterest.trim())) {
-                                                    interests.add(newInterest.trim())
-                                                }
-                                                newInterest = ""
-                                            }
-                                        })
-                                )
-                                Spacer(modifier = Modifier.width(8.dp))
-
-                                Button(
-                                    onClick = {
+                        // Input field to add new interest
+                        Row(verticalAlignment = Alignment.CenterVertically) {
+                          OutlinedTextField(
+                              value = newInterest,
+                              onValueChange = { newInterest = it },
+                              label = { Text("Add Interest") },
+                              modifier = Modifier.weight(1f).testTag("newInterestField"),
+                              keyboardOptions = KeyboardOptions(imeAction = ImeAction.Done),
+                              keyboardActions =
+                                  KeyboardActions(
+                                      onDone = {
                                         if (newInterest.isNotBlank()) {
-                                            if (!interests.contains(newInterest.trim())) {
-                                                interests.add(newInterest.trim())
-                                            }
-                                            newInterest = ""
+                                          if (!interests.contains(newInterest.trim())) {
+                                            interests.add(newInterest.trim())
+                                          }
+                                          newInterest = ""
                                         }
-                                    },
-                                    modifier = Modifier.testTag("addInterestButton")
-                                ) {
-                                    Text("Add")
+                                      }))
+                          Spacer(modifier = Modifier.width(8.dp))
+
+                          Button(
+                              onClick = {
+                                if (newInterest.isNotBlank()) {
+                                  if (!interests.contains(newInterest.trim())) {
+                                    interests.add(newInterest.trim())
+                                  }
+                                  newInterest = ""
                                 }
-                            }
-
-                            Spacer(modifier = Modifier.height(16.dp))
-
-                            Button(
-                                onClick = { isSaving = true },
-                                modifier = Modifier.testTag("saveButton")
-                            ) {
-                                Text("Save")
-                            }
+                              },
+                              modifier = Modifier.testTag("addInterestButton")) {
+                                Text("Add")
+                              }
                         }
-                    }
-                        ?: run {
-                            Column(horizontalAlignment = Alignment.CenterHorizontally) {
-                                Text(
-                                    "No user data available",
-                                    modifier = Modifier
-                                        .testTag("noUserData")
-                                        .padding(16.dp)
-                                )
+
+                        Spacer(modifier = Modifier.height(16.dp))
+
+                        Button(
+                            onClick = { isSaving = true },
+                            modifier = Modifier.testTag("saveButton")) {
+                              Text("Save")
                             }
-                        }
+                      }
                 }
+                    ?: run {
+                      Column(horizontalAlignment = Alignment.CenterHorizontally) {
+                        Text(
+                            "No user data available",
+                            modifier = Modifier.testTag("noUserData").padding(16.dp))
+                      }
+                    }
+              }
             }
-        })
+      })
 }
-

--- a/app/src/main/java/com/android/voyageur/ui/profile/EditProfileScreen.kt
+++ b/app/src/main/java/com/android/voyageur/ui/profile/EditProfileScreen.kt
@@ -1,13 +1,7 @@
 package com.android.voyageur.ui.profile
 
-import android.Manifest
-import android.content.Context
-import android.content.ContextWrapper
-import android.content.pm.PackageManager
 import android.net.Uri
-import android.os.Build
 import android.widget.Toast
-import androidx.activity.ComponentActivity
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.Image
@@ -29,7 +23,6 @@ import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.AccountCircle
-import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Button
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3Api
@@ -38,7 +31,6 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
-import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
@@ -53,10 +45,9 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.unit.dp
-import androidx.core.app.ActivityCompat
-import androidx.core.content.ContextCompat
 import coil.compose.rememberAsyncImagePainter
 import com.android.voyageur.model.user.UserViewModel
+import com.android.voyageur.ui.gallery.PermissionButtonForGallery
 import com.android.voyageur.ui.navigation.BottomNavigationMenu
 import com.android.voyageur.ui.navigation.LIST_TOP_LEVEL_DESTINATION
 import com.android.voyageur.ui.navigation.NavigationActions
@@ -66,265 +57,226 @@ import com.android.voyageur.ui.profile.interests.InterestChipEditable
 @OptIn(ExperimentalMaterial3Api::class, ExperimentalLayoutApi::class)
 @Composable
 fun EditProfileScreen(userViewModel: UserViewModel, navigationActions: NavigationActions) {
-  val user by userViewModel.user.collectAsState()
-  val isLoading by userViewModel.isLoading.collectAsState()
+    val user by userViewModel.user.collectAsState()
+    val isLoading by userViewModel.isLoading.collectAsState()
 
-  var name by remember { mutableStateOf(user?.name ?: "") }
-  var email by remember { mutableStateOf(user?.email ?: "") }
-  var profilePictureUri by remember { mutableStateOf<Uri?>(null) }
-  var profilePictureUrl by remember { mutableStateOf(user?.profilePicture ?: "") }
-  var isSaving by remember { mutableStateOf(false) }
+    var name by remember { mutableStateOf(user?.name ?: "") }
+    var email by remember { mutableStateOf(user?.email ?: "") }
+    var profilePictureUri by remember { mutableStateOf<Uri?>(null) }
+    var profilePictureUrl by remember { mutableStateOf(user?.profilePicture ?: "") }
+    var isSaving by remember { mutableStateOf(false) }
 
-  // State variables for interests
-  var interests by remember { mutableStateOf(user?.interests?.toMutableList() ?: mutableListOf()) }
-  var newInterest by remember { mutableStateOf("") }
-
-  // Context and permission state variables
-  val context = LocalContext.current
-  var showPermissionRationale by remember { mutableStateOf(false) }
-  var permissionToRequest by remember { mutableStateOf("") }
-  // Photo picker launcher
-  val pickPhotoLauncher =
-      rememberLauncherForActivityResult(ActivityResultContracts.GetContent()) { uri: Uri? ->
-        uri?.let { profilePictureUri = it }
-      }
-
-  // Permission launcher
-  val permissionLauncher =
-      rememberLauncherForActivityResult(ActivityResultContracts.RequestPermission()) { isGranted ->
-        if (isGranted) {
-          pickPhotoLauncher.launch("image/*")
-        } else {
-          Toast.makeText(context, "Permission denied. Unable to select photo.", Toast.LENGTH_SHORT)
-              .show()
-        }
-      }
-
-  if (isSaving) {
-    LaunchedEffect(isSaving) {
-      if (profilePictureUri != null) {
-        userViewModel.updateUserProfilePicture(profilePictureUri!!) { downloadUrl ->
-          val updatedUser =
-              user!!.copy(name = name, profilePicture = downloadUrl, interests = interests)
-          userViewModel.updateUser(updatedUser)
-          isSaving = false
-          navigationActions.navigateTo(Route.PROFILE)
-        }
-      } else {
-        val updatedUser = user!!.copy(name = name, interests = interests)
-        userViewModel.updateUser(updatedUser)
-        isSaving = false
-        navigationActions.navigateTo(Route.PROFILE)
-      }
-    }
-  }
-
-  Scaffold(
-      bottomBar = {
-        BottomNavigationMenu(
-            onTabSelect = { route -> navigationActions.navigateTo(route) },
-            tabList = LIST_TOP_LEVEL_DESTINATION,
-            selectedItem = navigationActions.currentRoute(),
+    // State variables for interests
+    var interests by remember {
+        mutableStateOf(
+            user?.interests?.toMutableList() ?: mutableListOf()
         )
-      },
-      content = { paddingValues ->
-        Box(
-            modifier = Modifier.fillMaxSize().padding(paddingValues),
-            contentAlignment = Alignment.Center) {
-              if (isLoading) {
-                CircularProgressIndicator(modifier = Modifier.testTag("loadingIndicator"))
-              } else {
-                user?.let { userData ->
-                  Column(
-                      modifier = Modifier.fillMaxSize().padding(16.dp),
-                      verticalArrangement = Arrangement.Center,
-                      horizontalAlignment = Alignment.CenterHorizontally) {
-                        // Display the selected image or the existing profile picture
-                        if (profilePictureUri != null) {
-                          Image(
-                              painter = rememberAsyncImagePainter(model = profilePictureUri),
-                              contentDescription = "Profile Picture",
-                              modifier =
-                                  Modifier.size(128.dp).clip(CircleShape).testTag("profilePicture"))
-                        } else if (profilePictureUrl.isNotEmpty()) {
-                          Image(
-                              painter = rememberAsyncImagePainter(model = profilePictureUrl),
-                              contentDescription = "Profile Picture",
-                              modifier =
-                                  Modifier.size(128.dp).clip(CircleShape).testTag("profilePicture"))
-                        } else {
-                          Icon(
-                              imageVector = Icons.Default.AccountCircle,
-                              contentDescription = "Default Profile Picture",
-                              modifier = Modifier.size(128.dp).testTag("defaultProfilePicture"))
-                        }
-
-                        Button(
-                            onClick = {
-                              val permission =
-                                  if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
-                                    Manifest.permission.READ_MEDIA_IMAGES
-                                  } else {
-                                    Manifest.permission.READ_EXTERNAL_STORAGE
-                                  }
-
-                              permissionToRequest = permission
-
-                              when {
-                                ContextCompat.checkSelfPermission(context, permission) ==
-                                    PackageManager.PERMISSION_GRANTED -> {
-                                  // Permission is granted
-                                  pickPhotoLauncher.launch("image/*")
-                                }
-                                ActivityCompat.shouldShowRequestPermissionRationale(
-                                    context.findActivity(), permission) -> {
-                                  // Show rationale
-                                  showPermissionRationale = true
-                                }
-                                else -> {
-                                  // Request permission
-                                  permissionLauncher.launch(permission)
-                                }
-                              }
-                            },
-                            modifier = Modifier.testTag("editImageButton")) {
-                              Text("Edit Profile Picture")
-                            }
-
-                        Spacer(modifier = Modifier.height(16.dp))
-
-                        OutlinedTextField(
-                            value = name,
-                            onValueChange = { name = it },
-                            label = { Text("Name") },
-                            modifier = Modifier.testTag("nameField"),
-                        )
-
-                        Spacer(modifier = Modifier.height(16.dp))
-
-                        OutlinedTextField(
-                            value = email,
-                            onValueChange = {},
-                            label = { Text("Email") },
-                            readOnly = true,
-                            enabled = false,
-                            modifier = Modifier.testTag("emailField"))
-
-                        Spacer(modifier = Modifier.height(16.dp))
-
-                        // Display interests
-                        Text(
-                            text = "Interests:",
-                            style = MaterialTheme.typography.titleMedium,
-                            modifier = Modifier.padding(vertical = 8.dp))
-
-                        if (interests.isNotEmpty()) {
-                          // Display interests using FlowRow for better layout
-                          FlowRow(modifier = Modifier.fillMaxWidth().padding(horizontal = 16.dp)) {
-                            interests.forEach { interest ->
-                              InterestChipEditable(
-                                  interest = interest,
-                                  onRemove = {
-                                    interests = interests.filter { it != interest }.toMutableList()
-                                  })
-                            }
-                          }
-                        } else {
-                          // Display message when no interests are added
-                          Text(
-                              text = "No interests added yet",
-                              style = MaterialTheme.typography.bodyMedium,
-                              modifier = Modifier.testTag("noInterests"))
-                        }
-
-                        Spacer(modifier = Modifier.height(16.dp))
-
-                        // Input field to add new interest
-                        Row(verticalAlignment = Alignment.CenterVertically) {
-                          OutlinedTextField(
-                              value = newInterest,
-                              onValueChange = { newInterest = it },
-                              label = { Text("Add Interest") },
-                              modifier = Modifier.weight(1f).testTag("newInterestField"),
-                              keyboardOptions = KeyboardOptions(imeAction = ImeAction.Done),
-                              keyboardActions =
-                                  KeyboardActions(
-                                      onDone = {
-                                        if (newInterest.isNotBlank()) {
-                                          if (!interests.contains(newInterest.trim())) {
-                                            interests.add(newInterest.trim())
-                                          }
-                                          newInterest = ""
-                                        }
-                                      }))
-                          Spacer(modifier = Modifier.width(8.dp))
-
-                          Button(
-                              onClick = {
-                                if (newInterest.isNotBlank()) {
-                                  if (!interests.contains(newInterest.trim())) {
-                                    interests.add(newInterest.trim())
-                                  }
-                                  newInterest = ""
-                                }
-                              },
-                              modifier = Modifier.testTag("addInterestButton")) {
-                                Text("Add")
-                              }
-                        }
-
-                        Spacer(modifier = Modifier.height(16.dp))
-
-                        Button(
-                            onClick = { isSaving = true },
-                            modifier = Modifier.testTag("saveButton")) {
-                              Text("Save")
-                            }
-                        // Show rationale dialog if needed
-                        if (showPermissionRationale) {
-                          AlertDialog(
-                              onDismissRequest = { showPermissionRationale = false },
-                              title = { Text("Permission Required") },
-                              text = {
-                                Text(
-                                    "This app needs access to your photos to allow you to select a profile picture.")
-                              },
-                              confirmButton = {
-                                TextButton(
-                                    onClick = {
-                                      showPermissionRationale = false
-                                      permissionLauncher.launch(permissionToRequest)
-                                    }) {
-                                      Text("Allow")
-                                    }
-                              },
-                              dismissButton = {
-                                TextButton(onClick = { showPermissionRationale = false }) {
-                                  Text("Cancel")
-                                }
-                              })
-                        }
-                      }
-                }
-                    ?: run {
-                      Column(horizontalAlignment = Alignment.CenterHorizontally) {
-                        Text(
-                            "No user data available",
-                            modifier = Modifier.testTag("noUserData").padding(16.dp))
-                      }
-                    }
-              }
-            }
-      })
-}
-
-fun Context.findActivity(): ComponentActivity {
-  var context = this
-  while (context is ContextWrapper) {
-    if (context is ComponentActivity) {
-      return context
     }
-    context = context.baseContext
-  }
-  throw IllegalStateException("No Activity found")
+    var newInterest by remember { mutableStateOf("") }
+
+    if (isSaving) {
+        LaunchedEffect(isSaving) {
+            if (profilePictureUri != null) {
+                userViewModel.updateUserProfilePicture(profilePictureUri!!) { downloadUrl ->
+                    val updatedUser =
+                        user!!.copy(
+                            name = name,
+                            profilePicture = downloadUrl,
+                            interests = interests
+                        )
+                    userViewModel.updateUser(updatedUser)
+                    isSaving = false
+                    navigationActions.navigateTo(Route.PROFILE)
+                }
+            } else {
+                val updatedUser = user!!.copy(name = name, interests = interests)
+                userViewModel.updateUser(updatedUser)
+                isSaving = false
+                navigationActions.navigateTo(Route.PROFILE)
+            }
+        }
+    }
+
+    Scaffold(
+        bottomBar = {
+            BottomNavigationMenu(
+                onTabSelect = { route -> navigationActions.navigateTo(route) },
+                tabList = LIST_TOP_LEVEL_DESTINATION,
+                selectedItem = navigationActions.currentRoute(),
+            )
+        },
+        content = { paddingValues ->
+            Box(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .padding(paddingValues),
+                contentAlignment = Alignment.Center
+            ) {
+                if (isLoading) {
+                    CircularProgressIndicator(modifier = Modifier.testTag("loadingIndicator"))
+                } else {
+                    user?.let { userData ->
+                        Column(
+                            modifier = Modifier
+                                .fillMaxSize()
+                                .padding(16.dp),
+                            verticalArrangement = Arrangement.Center,
+                            horizontalAlignment = Alignment.CenterHorizontally
+                        ) {
+                            // Display the selected image or the existing profile picture
+                            if (profilePictureUri != null) {
+                                Image(
+                                    painter = rememberAsyncImagePainter(model = profilePictureUri),
+                                    contentDescription = "Profile Picture",
+                                    modifier =
+                                    Modifier
+                                        .size(128.dp)
+                                        .clip(CircleShape)
+                                        .testTag("profilePicture")
+                                )
+                            } else if (profilePictureUrl.isNotEmpty()) {
+                                Image(
+                                    painter = rememberAsyncImagePainter(model = profilePictureUrl),
+                                    contentDescription = "Profile Picture",
+                                    modifier =
+                                    Modifier
+                                        .size(128.dp)
+                                        .clip(CircleShape)
+                                        .testTag("profilePicture")
+                                )
+                            } else {
+                                Icon(
+                                    imageVector = Icons.Default.AccountCircle,
+                                    contentDescription = "Default Profile Picture",
+                                    modifier = Modifier
+                                        .size(128.dp)
+                                        .testTag("defaultProfilePicture")
+                                )
+                            }
+                            PermissionButtonForGallery(
+                                onUriSelected = { profilePictureUri = it },
+                                "Edit Profile Picture",
+                                "This app needs access to your photos to allow you to select a profile picture.",
+                                Modifier.testTag("editImageButton")
+
+                            )
+
+                            Spacer(modifier = Modifier.height(16.dp))
+
+                            OutlinedTextField(
+                                value = name,
+                                onValueChange = { name = it },
+                                label = { Text("Name") },
+                                modifier = Modifier.testTag("nameField"),
+                            )
+
+                            Spacer(modifier = Modifier.height(16.dp))
+
+                            OutlinedTextField(
+                                value = email,
+                                onValueChange = {},
+                                label = { Text("Email") },
+                                readOnly = true,
+                                enabled = false,
+                                modifier = Modifier.testTag("emailField")
+                            )
+
+                            Spacer(modifier = Modifier.height(16.dp))
+
+                            // Display interests
+                            Text(
+                                text = "Interests:",
+                                style = MaterialTheme.typography.titleMedium,
+                                modifier = Modifier.padding(vertical = 8.dp)
+                            )
+
+                            if (interests.isNotEmpty()) {
+                                // Display interests using FlowRow for better layout
+                                FlowRow(
+                                    modifier = Modifier
+                                        .fillMaxWidth()
+                                        .padding(horizontal = 16.dp)
+                                ) {
+                                    interests.forEach { interest ->
+                                        InterestChipEditable(
+                                            interest = interest,
+                                            onRemove = {
+                                                interests = interests.filter { it != interest }
+                                                    .toMutableList()
+                                            })
+                                    }
+                                }
+                            } else {
+                                // Display message when no interests are added
+                                Text(
+                                    text = "No interests added yet",
+                                    style = MaterialTheme.typography.bodyMedium,
+                                    modifier = Modifier.testTag("noInterests")
+                                )
+                            }
+
+                            Spacer(modifier = Modifier.height(16.dp))
+
+                            // Input field to add new interest
+                            Row(verticalAlignment = Alignment.CenterVertically) {
+                                OutlinedTextField(
+                                    value = newInterest,
+                                    onValueChange = { newInterest = it },
+                                    label = { Text("Add Interest") },
+                                    modifier = Modifier
+                                        .weight(1f)
+                                        .testTag("newInterestField"),
+                                    keyboardOptions = KeyboardOptions(imeAction = ImeAction.Done),
+                                    keyboardActions =
+                                    KeyboardActions(
+                                        onDone = {
+                                            if (newInterest.isNotBlank()) {
+                                                if (!interests.contains(newInterest.trim())) {
+                                                    interests.add(newInterest.trim())
+                                                }
+                                                newInterest = ""
+                                            }
+                                        })
+                                )
+                                Spacer(modifier = Modifier.width(8.dp))
+
+                                Button(
+                                    onClick = {
+                                        if (newInterest.isNotBlank()) {
+                                            if (!interests.contains(newInterest.trim())) {
+                                                interests.add(newInterest.trim())
+                                            }
+                                            newInterest = ""
+                                        }
+                                    },
+                                    modifier = Modifier.testTag("addInterestButton")
+                                ) {
+                                    Text("Add")
+                                }
+                            }
+
+                            Spacer(modifier = Modifier.height(16.dp))
+
+                            Button(
+                                onClick = { isSaving = true },
+                                modifier = Modifier.testTag("saveButton")
+                            ) {
+                                Text("Save")
+                            }
+                        }
+                    }
+                        ?: run {
+                            Column(horizontalAlignment = Alignment.CenterHorizontally) {
+                                Text(
+                                    "No user data available",
+                                    modifier = Modifier
+                                        .testTag("noUserData")
+                                        .padding(16.dp)
+                                )
+                            }
+                        }
+                }
+            }
+        })
 }
+

--- a/app/src/test/java/com/android/voyageur/ui/gallery/CheckOlderVersionTest.kt
+++ b/app/src/test/java/com/android/voyageur/ui/gallery/CheckOlderVersionTest.kt
@@ -1,0 +1,34 @@
+package com.android.voyageur.ui.gallery
+
+import android.Manifest
+import android.content.Context
+import android.os.Build
+import androidx.test.core.app.ApplicationProvider
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [Build.VERSION_CODES.P]) // This simulates an older version sdk >=28
+class CheckOlderVersionTest {
+
+  @Test
+  fun checkFullPermission_onOlderVersion_withPermissionGranted() {
+    val context = ApplicationProvider.getApplicationContext<Context>()
+    org.robolectric.shadows.ShadowApplication.getInstance()
+        .grantPermissions(Manifest.permission.READ_EXTERNAL_STORAGE)
+    val result = checkFullPermission(context)
+    assertEquals(true, result)
+  }
+
+  @Test
+  fun checkFullPermission_onOlderVersion_withPermissionDenied() {
+    val context = ApplicationProvider.getApplicationContext<Context>()
+    org.robolectric.shadows.ShadowApplication.getInstance()
+        .denyPermissions(Manifest.permission.READ_EXTERNAL_STORAGE)
+    val result = checkFullPermission(context)
+    assertEquals(false, result)
+  }
+}

--- a/app/src/test/java/com/android/voyageur/ui/gallery/FindActivityTest.kt
+++ b/app/src/test/java/com/android/voyageur/ui/gallery/FindActivityTest.kt
@@ -1,10 +1,13 @@
-package com.android.voyageur.ui.profile
+package com.android.voyageur.ui.gallery
 
+import android.content.Context
 import android.content.ContextWrapper
 import androidx.activity.ComponentActivity
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertThrows
 import org.junit.Test
 import org.junit.runner.RunWith
+import org.mockito.Mockito.mock
 import org.robolectric.Robolectric
 import org.robolectric.RobolectricTestRunner
 
@@ -53,5 +56,14 @@ class FindActivityTest {
 
     // Assert: The result should be the original activity
     assertEquals(activity, result)
+  }
+
+  @Test
+  fun contextIsNotAnActivity_throwsIllegalStateException() {
+    // Create a mock context that doesn't contain a Component Activity
+    val nonActivityContext = mock(Context::class.java)
+
+    // Ensure that calling findActivity throws an IllegalStateException
+    assertThrows(IllegalStateException::class.java) { nonActivityContext.findActivity() }
   }
 }

--- a/app/src/test/java/com/android/voyageur/ui/gallery/FindActivityTest.kt
+++ b/app/src/test/java/com/android/voyageur/ui/gallery/FindActivityTest.kt
@@ -1,13 +1,10 @@
 package com.android.voyageur.ui.gallery
 
-import android.content.Context
 import android.content.ContextWrapper
 import androidx.activity.ComponentActivity
 import org.junit.Assert.assertEquals
-import org.junit.Assert.assertThrows
 import org.junit.Test
 import org.junit.runner.RunWith
-import org.mockito.Mockito.mock
 import org.robolectric.Robolectric
 import org.robolectric.RobolectricTestRunner
 
@@ -56,14 +53,5 @@ class FindActivityTest {
 
     // Assert: The result should be the original activity
     assertEquals(activity, result)
-  }
-
-  @Test
-  fun contextIsNotAnActivity_throwsIllegalStateException() {
-    // Create a mock context that doesn't contain a Component Activity
-    val nonActivityContext = mock(Context::class.java)
-
-    // Ensure that calling findActivity throws an IllegalStateException
-    assertThrows(IllegalStateException::class.java) { nonActivityContext.findActivity() }
   }
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -80,6 +80,7 @@ firebaseStorageKtx = "21.0.1"
 testng = "6.9.6"
 foundationAndroid = "1.7.5"
 core = "1.46.0"
+junitKtx = "1.2.1"
 
 [libraries]
 accompanist-permissions = { module = "com.google.accompanist:accompanist-permissions", version.ref = "accompanistPermissions" }
@@ -145,6 +146,7 @@ firebase-storage-ktx = { group = "com.google.firebase", name = "firebase-storage
 testng = { group = "org.testng", name = "testng", version.ref = "testng" }
 androidx-foundation-android = { group = "androidx.compose.foundation", name = "foundation-android", version.ref = "foundationAndroid" }
 core = { group = "com.google.ar", name = "core", version.ref = "core" }
+androidx-junit-ktx = { group = "androidx.test.ext", name = "junit-ktx", version.ref = "junitKtx" }
 
 
 [plugins]


### PR DESCRIPTION
## Summary

This PR finalizes the permission button for opening the gallery when the user wants to upload a photo either for their new profile picture or for a new/current trip . It aims to reduce code duplication as mentioned in issue #137 , since both the EditProfileScreen and AddTripScreen had similar code for the same functionality.  Tests have also been added for the new button.


## Changes

- **Screens/UI:**  No particular changes, buttons display as before, but now they are using the same Composable with different parameters.
- **Bug Fixes/Improvements:**  This is an improvement to reduce code duplication.

## Checklist

Ensure all / most of these are checked before the pull request is submitted.
- [X] This PR resolves #137 .
- [X] Tests have been added for new functionality.
- [X] Screenshots or UI changes have been attached .
- [X] Documentation has been updated.

##  Testing

- **Manual Testing:**
    - [X] Tested on emulator / physical device.
- **Unit Tests**
    - [X] Added units tests for this

##  Related Issues/Tickets

Closes #137.

## Screenshots (if applicable)

- Screenshots have been attached just to show that the new button displays as the previous ones, matching the Figma design.
<img width="250" alt="Screenshot 2024-11-13 at 14 30 40" src="https://github.com/user-attachments/assets/0b4b0252-18cc-466d-a182-d5fe799ef9e9">
<img width="251" alt="Screenshot 2024-11-13 at 14 31 05" src="https://github.com/user-attachments/assets/fcbdea19-2255-4e18-a2c7-4d437fc8bd35">
<img width="250" alt="Screenshot 2024-11-13 at 14 31 27" src="https://github.com/user-attachments/assets/5b265bcf-0dec-4728-bbd8-ee4ab44d3878">


## 💡 Additional Context

As mentioned in my previous PR #125 and in the Wiki, the app does not have special Limited Access support, as it is using the Android default photo picker, not a custom one.  The current behaviour implemented has been discussed in a meeting on 10.11 (noted in Wiki).  
