### PR TITLE
Fix: the logged-in user's profile page in search does not allow to ad…

### DIFF
--- a/app/src/main/java/com/android/voyageur/ui/components/UserProfileContent.kt
+++ b/app/src/main/java/com/android/voyageur/ui/components/UserProfileContent.kt
@@ -57,24 +57,21 @@ fun UserProfileContent(
     onEdit: (() -> Unit)? = null,
     onAddOrRemoveContact: (() -> Unit)? = null
 ) {
-    Column(
-        modifier = Modifier.fillMaxSize().padding(16.dp).testTag("userProfileContent"),
-        verticalArrangement = Arrangement.Center,
-        horizontalAlignment = Alignment.CenterHorizontally
-    ) {
+  Column(
+      modifier = Modifier.fillMaxSize().padding(16.dp).testTag("userProfileContent"),
+      verticalArrangement = Arrangement.Center,
+      horizontalAlignment = Alignment.CenterHorizontally) {
         // Display profile picture
         if (userData.profilePicture.isNotEmpty()) {
-            Image(
-                painter = rememberAsyncImagePainter(model = userData.profilePicture),
-                contentDescription = "Profile Picture",
-                modifier = Modifier.size(128.dp).clip(CircleShape).testTag("userProfilePicture")
-            )
+          Image(
+              painter = rememberAsyncImagePainter(model = userData.profilePicture),
+              contentDescription = "Profile Picture",
+              modifier = Modifier.size(128.dp).clip(CircleShape).testTag("userProfilePicture"))
         } else {
-            Icon(
-                imageVector = Icons.Default.AccountCircle,
-                contentDescription = "Default Profile Picture",
-                modifier = Modifier.size(128.dp).testTag("defaultProfilePicture")
-            )
+          Icon(
+              imageVector = Icons.Default.AccountCircle,
+              contentDescription = "Default Profile Picture",
+              modifier = Modifier.size(128.dp).testTag("defaultProfilePicture"))
         }
 
         Spacer(modifier = Modifier.height(16.dp))
@@ -83,13 +80,11 @@ fun UserProfileContent(
         Text(
             text = userData.name.takeIf { it.isNotEmpty() } ?: "No name available",
             style = MaterialTheme.typography.titleLarge,
-            modifier = Modifier.testTag("userName")
-        )
+            modifier = Modifier.testTag("userName"))
         Text(
             text = userData.email.takeIf { it.isNotEmpty() } ?: "No email available",
             style = MaterialTheme.typography.bodyMedium,
-            modifier = Modifier.testTag("userEmail")
-        )
+            modifier = Modifier.testTag("userEmail"))
 
         Spacer(modifier = Modifier.height(16.dp))
 
@@ -97,49 +92,48 @@ fun UserProfileContent(
         Text(
             text = "Interests:",
             style = MaterialTheme.typography.titleMedium,
-            modifier = Modifier.padding(vertical = 8.dp)
-        )
+            modifier = Modifier.padding(vertical = 8.dp))
 
         if (userData.interests.isNotEmpty()) {
-            FlowRow(
-                modifier = Modifier.fillMaxWidth().padding(horizontal = 16.dp).testTag("interestsFlowRow"),
-                horizontalArrangement = Arrangement.Center
-            ) {
+          FlowRow(
+              modifier =
+                  Modifier.fillMaxWidth().padding(horizontal = 16.dp).testTag("interestsFlowRow"),
+              horizontalArrangement = Arrangement.Center) {
                 userData.interests.forEach { interest ->
-                    InterestChip(interest = interest, modifier = Modifier.padding(4.dp))
+                  InterestChip(interest = interest, modifier = Modifier.padding(4.dp))
                 }
-            }
+              }
         } else {
-            Text(
-                text = "No interests added yet",
-                style = MaterialTheme.typography.bodyMedium,
-                modifier = Modifier.testTag("noInterests")
-            )
+          Text(
+              text = "No interests added yet",
+              style = MaterialTheme.typography.bodyMedium,
+              modifier = Modifier.testTag("noInterests"))
         }
 
         Spacer(modifier = Modifier.height(16.dp))
 
         // Display buttons conditionally
         Row {
-            if (showEditAndSignOutButtons && onEdit != null && onSignOut != null) {
-                Button(onClick = onEdit, modifier = Modifier.testTag("editButton")) {
-                    Text(text = "Edit")
-                }
-                Spacer(modifier = Modifier.width(16.dp))
-                Button(onClick = onSignOut, modifier = Modifier.testTag("signOutButton")) {
-                    Text(text = "Sign Out")
-                }
-            } else if (userData.id != signedInUserId && onAddOrRemoveContact != null) {
-                Button(
-                    onClick = onAddOrRemoveContact,
-                    colors = ButtonDefaults.buttonColors(
-                        containerColor = if (isContactAdded) MaterialTheme.colorScheme.error else MaterialTheme.colorScheme.primary
-                    ),
-                    modifier = Modifier.testTag("userProfileAddRemoveContactButton")
-                ) {
-                    Text(text = if (isContactAdded) "Remove from contacts" else "Add to contacts")
-                }
+          if (showEditAndSignOutButtons && onEdit != null && onSignOut != null) {
+            Button(onClick = onEdit, modifier = Modifier.testTag("editButton")) {
+              Text(text = "Edit")
             }
+            Spacer(modifier = Modifier.width(16.dp))
+            Button(onClick = onSignOut, modifier = Modifier.testTag("signOutButton")) {
+              Text(text = "Sign Out")
+            }
+          } else if (userData.id != signedInUserId && onAddOrRemoveContact != null) {
+            Button(
+                onClick = onAddOrRemoveContact,
+                colors =
+                    ButtonDefaults.buttonColors(
+                        containerColor =
+                            if (isContactAdded) MaterialTheme.colorScheme.error
+                            else MaterialTheme.colorScheme.primary),
+                modifier = Modifier.testTag("userProfileAddRemoveContactButton")) {
+                  Text(text = if (isContactAdded) "Remove from contacts" else "Add to contacts")
+                }
+          }
         }
-    }
+      }
 }

--- a/app/src/main/java/com/android/voyageur/ui/components/UserProfileContent.kt
+++ b/app/src/main/java/com/android/voyageur/ui/components/UserProfileContent.kt
@@ -50,89 +50,96 @@ import com.android.voyageur.ui.profile.interests.InterestChip
 @Composable
 fun UserProfileContent(
     userData: User,
+    signedInUserId: String,
     showEditAndSignOutButtons: Boolean = false,
     isContactAdded: Boolean = false,
     onSignOut: (() -> Unit)? = null,
     onEdit: (() -> Unit)? = null,
     onAddOrRemoveContact: (() -> Unit)? = null
 ) {
-  Column(
-      modifier = Modifier.fillMaxSize().padding(16.dp).testTag("userProfileContent"),
-      verticalArrangement = Arrangement.Center,
-      horizontalAlignment = Alignment.CenterHorizontally) {
-        // Display user's profile picture or a default icon if no picture is available
+    Column(
+        modifier = Modifier.fillMaxSize().padding(16.dp).testTag("userProfileContent"),
+        verticalArrangement = Arrangement.Center,
+        horizontalAlignment = Alignment.CenterHorizontally
+    ) {
+        // Display profile picture
         if (userData.profilePicture.isNotEmpty()) {
-          Image(
-              painter = rememberAsyncImagePainter(model = userData.profilePicture),
-              contentDescription = "Profile Picture",
-              modifier = Modifier.size(128.dp).clip(CircleShape).testTag("userProfilePicture"))
+            Image(
+                painter = rememberAsyncImagePainter(model = userData.profilePicture),
+                contentDescription = "Profile Picture",
+                modifier = Modifier.size(128.dp).clip(CircleShape).testTag("userProfilePicture")
+            )
         } else {
-          Icon(
-              imageVector = Icons.Default.AccountCircle,
-              contentDescription = "Default Profile Picture",
-              modifier = Modifier.size(128.dp).testTag("defaultProfilePicture"))
+            Icon(
+                imageVector = Icons.Default.AccountCircle,
+                contentDescription = "Default Profile Picture",
+                modifier = Modifier.size(128.dp).testTag("defaultProfilePicture")
+            )
         }
 
         Spacer(modifier = Modifier.height(16.dp))
 
-        // Display user's name and email, with fallback text if unavailable
+        // Display name and email
         Text(
             text = userData.name.takeIf { it.isNotEmpty() } ?: "No name available",
             style = MaterialTheme.typography.titleLarge,
-            modifier = Modifier.testTag("userName"))
+            modifier = Modifier.testTag("userName")
+        )
         Text(
             text = userData.email.takeIf { it.isNotEmpty() } ?: "No email available",
             style = MaterialTheme.typography.bodyMedium,
-            modifier = Modifier.testTag("userEmail"))
+            modifier = Modifier.testTag("userEmail")
+        )
 
         Spacer(modifier = Modifier.height(16.dp))
 
-        // Display the user's interests or a message if no interests are added
+        // Display interests
         Text(
             text = "Interests:",
             style = MaterialTheme.typography.titleMedium,
-            modifier = Modifier.padding(vertical = 8.dp))
+            modifier = Modifier.padding(vertical = 8.dp)
+        )
 
         if (userData.interests.isNotEmpty()) {
-          FlowRow(
-              modifier =
-                  Modifier.fillMaxWidth().padding(horizontal = 16.dp).testTag("interestsFlowRow"),
-              horizontalArrangement = Arrangement.Center) {
+            FlowRow(
+                modifier = Modifier.fillMaxWidth().padding(horizontal = 16.dp).testTag("interestsFlowRow"),
+                horizontalArrangement = Arrangement.Center
+            ) {
                 userData.interests.forEach { interest ->
-                  InterestChip(interest = interest, modifier = Modifier.padding(4.dp))
+                    InterestChip(interest = interest, modifier = Modifier.padding(4.dp))
                 }
-              }
+            }
         } else {
-          Text(
-              text = "No interests added yet",
-              style = MaterialTheme.typography.bodyMedium,
-              modifier = Modifier.testTag("noInterests"))
+            Text(
+                text = "No interests added yet",
+                style = MaterialTheme.typography.bodyMedium,
+                modifier = Modifier.testTag("noInterests")
+            )
         }
 
         Spacer(modifier = Modifier.height(16.dp))
 
-        // Conditional buttons for editing, signing out, or adding/removing as contact
+        // Display buttons conditionally
         Row {
-          if (showEditAndSignOutButtons && onEdit != null && onSignOut != null) {
-            Button(onClick = onEdit, modifier = Modifier.testTag("editButton")) {
-              Text(text = "Edit")
-            }
-            Spacer(modifier = Modifier.width(16.dp))
-            Button(onClick = onSignOut, modifier = Modifier.testTag("signOutButton")) {
-              Text(text = "Sign Out")
-            }
-          } else if (onAddOrRemoveContact != null) {
-            Button(
-                onClick = onAddOrRemoveContact,
-                colors =
-                    ButtonDefaults.buttonColors(
-                        containerColor =
-                            if (isContactAdded) MaterialTheme.colorScheme.error
-                            else MaterialTheme.colorScheme.primary),
-                modifier = Modifier.testTag("userProfileAddRemoveContactButton")) {
-                  Text(text = if (isContactAdded) "Remove from contacts" else "Add to contacts")
+            if (showEditAndSignOutButtons && onEdit != null && onSignOut != null) {
+                Button(onClick = onEdit, modifier = Modifier.testTag("editButton")) {
+                    Text(text = "Edit")
                 }
-          }
+                Spacer(modifier = Modifier.width(16.dp))
+                Button(onClick = onSignOut, modifier = Modifier.testTag("signOutButton")) {
+                    Text(text = "Sign Out")
+                }
+            } else if (userData.id != signedInUserId && onAddOrRemoveContact != null) {
+                Button(
+                    onClick = onAddOrRemoveContact,
+                    colors = ButtonDefaults.buttonColors(
+                        containerColor = if (isContactAdded) MaterialTheme.colorScheme.error else MaterialTheme.colorScheme.primary
+                    ),
+                    modifier = Modifier.testTag("userProfileAddRemoveContactButton")
+                ) {
+                    Text(text = if (isContactAdded) "Remove from contacts" else "Add to contacts")
+                }
+            }
         }
-      }
+    }
 }

--- a/app/src/main/java/com/android/voyageur/ui/profile/ProfileScreen.kt
+++ b/app/src/main/java/com/android/voyageur/ui/profile/ProfileScreen.kt
@@ -71,6 +71,7 @@ fun ProfileScreen(userViewModel: UserViewModel, navigationActions: NavigationAct
                 user != null -> {
                   ProfileContent(
                       userData = user!!,
+                      signedInUserId = user!!.id,
                       onSignOut = { isSigningOut = true },
                       onEdit = { navigationActions.navigateTo(Route.EDIT_PROFILE) })
                 }
@@ -83,7 +84,17 @@ fun ProfileScreen(userViewModel: UserViewModel, navigationActions: NavigationAct
 }
 
 @Composable
-fun ProfileContent(userData: User, onSignOut: () -> Unit, onEdit: () -> Unit) {
-  UserProfileContent(
-      userData = userData, showEditAndSignOutButtons = true, onSignOut = onSignOut, onEdit = onEdit)
+fun ProfileContent(
+    userData: User,
+    signedInUserId: String,
+    onSignOut: () -> Unit,
+    onEdit: () -> Unit
+) {
+    UserProfileContent(
+        userData = userData,
+        signedInUserId = signedInUserId,
+        showEditAndSignOutButtons = true,
+        onSignOut = onSignOut,
+        onEdit = onEdit
+    )
 }

--- a/app/src/main/java/com/android/voyageur/ui/profile/ProfileScreen.kt
+++ b/app/src/main/java/com/android/voyageur/ui/profile/ProfileScreen.kt
@@ -90,11 +90,10 @@ fun ProfileContent(
     onSignOut: () -> Unit,
     onEdit: () -> Unit
 ) {
-    UserProfileContent(
-        userData = userData,
-        signedInUserId = signedInUserId,
-        showEditAndSignOutButtons = true,
-        onSignOut = onSignOut,
-        onEdit = onEdit
-    )
+  UserProfileContent(
+      userData = userData,
+      signedInUserId = signedInUserId,
+      showEditAndSignOutButtons = true,
+      onSignOut = onSignOut,
+      onEdit = onEdit)
 }

--- a/app/src/main/java/com/android/voyageur/ui/search/SearchUserProfile.kt
+++ b/app/src/main/java/com/android/voyageur/ui/search/SearchUserProfile.kt
@@ -84,25 +84,21 @@ fun SearchUserProfileScreen(userViewModel: UserViewModel, navigationActions: Nav
  * @param userViewModel The UserViewModel used for managing user data and interactions.
  */
 @Composable
-fun SearchUserProfileContent(
-    userData: User,
-    userViewModel: UserViewModel
-) {
-    val isContactAdded by remember {
-        derivedStateOf { userViewModel.user.value?.contacts?.contains(userData.id) ?: false }
-    }
-    val signedInUserId = userViewModel.user.value?.id ?: ""
+fun SearchUserProfileContent(userData: User, userViewModel: UserViewModel) {
+  val isContactAdded by remember {
+    derivedStateOf { userViewModel.user.value?.contacts?.contains(userData.id) ?: false }
+  }
+  val signedInUserId = userViewModel.user.value?.id ?: ""
 
-    UserProfileContent(
-        userData = userData,
-        signedInUserId = signedInUserId,
-        isContactAdded = isContactAdded,
-        onAddOrRemoveContact = {
-            if (isContactAdded) {
-                userViewModel.removeContact(userData.id)
-            } else {
-                userViewModel.addContact(userData.id)
-            }
+  UserProfileContent(
+      userData = userData,
+      signedInUserId = signedInUserId,
+      isContactAdded = isContactAdded,
+      onAddOrRemoveContact = {
+        if (isContactAdded) {
+          userViewModel.removeContact(userData.id)
+        } else {
+          userViewModel.addContact(userData.id)
         }
-    )
+      })
 }

--- a/app/src/main/java/com/android/voyageur/ui/search/SearchUserProfile.kt
+++ b/app/src/main/java/com/android/voyageur/ui/search/SearchUserProfile.kt
@@ -84,18 +84,25 @@ fun SearchUserProfileScreen(userViewModel: UserViewModel, navigationActions: Nav
  * @param userViewModel The UserViewModel used for managing user data and interactions.
  */
 @Composable
-fun SearchUserProfileContent(userData: User, userViewModel: UserViewModel) {
-  val isContactAdded by remember {
-    derivedStateOf { userViewModel.user.value?.contacts?.contains(userData.id) ?: false }
-  }
-  UserProfileContent(
-      userData = userData,
-      isContactAdded = isContactAdded,
-      onAddOrRemoveContact = {
-        if (isContactAdded) {
-          userViewModel.removeContact(userData.id)
-        } else {
-          userViewModel.addContact(userData.id)
+fun SearchUserProfileContent(
+    userData: User,
+    userViewModel: UserViewModel
+) {
+    val isContactAdded by remember {
+        derivedStateOf { userViewModel.user.value?.contacts?.contains(userData.id) ?: false }
+    }
+    val signedInUserId = userViewModel.user.value?.id ?: ""
+
+    UserProfileContent(
+        userData = userData,
+        signedInUserId = signedInUserId,
+        isContactAdded = isContactAdded,
+        onAddOrRemoveContact = {
+            if (isContactAdded) {
+                userViewModel.removeContact(userData.id)
+            } else {
+                userViewModel.addContact(userData.id)
+            }
         }
-      })
+    )
 }


### PR DESCRIPTION
## Summary

This pull request fixes a bug in the user profile screen within the search feature. Previously, users could add themselves as a contact, which was unintended behavior. This fix now prevents users from adding their own profile to their contacts list.

## Changes

- **Models:** Add details of any new or modified data models.
- **Screens/UI:**
  - Updated the UserProfileContent composable to conditionally hide the "Add/Remove Contact" button when viewing one's own profile.
- **Logic/Controllers:** 
  - Adjusted the UserProfileContent function to include a signedInUserId parameter, enabling the logic to check if the selected user profile matches the signed-in user.
- **Repositories:** If any repository classes were added or modified, include details here.
- **Bug Fixes/Improvements:** 
  - This PR addresses an issue where users could add themselves to their contacts list from the profile view in the search screen.

## Checklist

Ensure all / most of these are checked before the pull request is submitted.
- [X] This PR resolves #152.
- 
##  Related Issues/Tickets

Closes #152 

## Screenshots
<img width="366" alt="Screenshot 2024-11-13 at 17 17 15" src="https://github.com/user-attachments/assets/60a1d3bd-d7b5-42cb-a0a9-9108e0fca962">


