### PR TITLE
Fix bug TapsScreen

### DIFF
--- a/app/src/androidTest/java/com/android/voyageur/ui/trip/TobTabsTest.kt
+++ b/app/src/androidTest/java/com/android/voyageur/ui/trip/TobTabsTest.kt
@@ -32,14 +32,6 @@ class TopTabsTest {
   }
 
   @Test
-  fun displayTextWhenNoTripSelected() {
-    composeTestRule.setContent { TopTabs(tripsViewModel, navigationActions) }
-
-    // Verify that the "No trip selected" text is displayed
-    composeTestRule.onNodeWithText("No trip selected. Should not happen").assertIsDisplayed()
-  }
-
-  @Test
   fun topAppBar_DisplaysTripName() {
     tripsViewModel.selectTrip(sampleTrip)
     composeTestRule.setContent { TopTabs(tripsViewModel, navigationActions) }

--- a/app/src/main/java/com/android/voyageur/ui/trip/Tabs.kt
+++ b/app/src/main/java/com/android/voyageur/ui/trip/Tabs.kt
@@ -37,10 +37,12 @@ fun TopTabs(tripsViewModel: TripsViewModel, navigationActions: NavigationActions
     navigationActions.navigateTo(Route.OVERVIEW)
     return
   }
+  // Define selectedTrip variable with trip value (trip!!)
+  val selectedTrip = trip!!
 
   // Column for top tabs and content
   Column(modifier = Modifier.testTag("topTabs")) {
-    TopBarWithImage(trip!!, navigationActions)
+    TopBarWithImage(selectedTrip, navigationActions)
 
     // TabRow composable for creating top tabs
     TabRow(
@@ -58,11 +60,11 @@ fun TopTabs(tripsViewModel: TripsViewModel, navigationActions: NavigationActions
 
     // Display content based on selected tab
     when (selectedTabIndex) {
-      0 -> ScheduleScreen(trip!!, navigationActions)
-      1 -> ActivitiesScreen(trip!!, navigationActions)
+      0 -> ScheduleScreen(selectedTrip, navigationActions)
+      1 -> ActivitiesScreen(selectedTrip, navigationActions)
       2 ->
           SettingsScreen(
-              trip!!,
+              selectedTrip,
               navigationActions,
               tripsViewModel = tripsViewModel,
               onUpdate = {

--- a/app/src/main/java/com/android/voyageur/ui/trip/Tabs.kt
+++ b/app/src/main/java/com/android/voyageur/ui/trip/Tabs.kt
@@ -12,7 +12,6 @@ import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.testTag
 import com.android.voyageur.model.trip.TripsViewModel
 import com.android.voyageur.ui.navigation.NavigationActions
@@ -24,53 +23,52 @@ import com.android.voyageur.ui.trip.settings.SettingsScreen
 
 @Composable
 fun TopTabs(tripsViewModel: TripsViewModel, navigationActions: NavigationActions) {
-    // Define tab items
-    val tabs = listOf("Schedule", "Activities", "Settings")
+  // Define tab items
+  val tabs = listOf("Schedule", "Activities", "Settings")
 
-    // Remember the currently selected tab index
-    var selectedTabIndex by remember { mutableIntStateOf(0) }
+  // Remember the currently selected tab index
+  var selectedTabIndex by remember { mutableIntStateOf(0) }
 
-    // Collect selectedTrip as state to avoid calling .value directly in composition
-    val trip by tripsViewModel.selectedTrip.collectAsState()
+  // Collect selectedTrip as state to avoid calling .value directly in composition
+  val trip by tripsViewModel.selectedTrip.collectAsState()
 
-    // Check if the selected trip is null and navigate to "Overview" if true
-    if (trip == null) {
-        navigationActions.navigateTo(Route.OVERVIEW)
-        return
+  // Check if the selected trip is null and navigate to "Overview" if true
+  if (trip == null) {
+    navigationActions.navigateTo(Route.OVERVIEW)
+    return
+  }
+
+  // Column for top tabs and content
+  Column(modifier = Modifier.testTag("topTabs")) {
+    TopBarWithImage(trip!!, navigationActions)
+
+    // TabRow composable for creating top tabs
+    TabRow(
+        selectedTabIndex = selectedTabIndex,
+        modifier = Modifier.fillMaxWidth().testTag("tabRow"),
+    ) {
+      // Create each tab with a Tab composable
+      tabs.forEachIndexed { index, title ->
+        Tab(
+            selected = selectedTabIndex == index,
+            onClick = { selectedTabIndex = index },
+            text = { Text(title) })
+      }
     }
 
-    // Column for top tabs and content
-    Column(modifier = Modifier.testTag("topTabs")) {
-        TopBarWithImage(trip!!, navigationActions)
-
-        // TabRow composable for creating top tabs
-        TabRow(
-            selectedTabIndex = selectedTabIndex,
-            modifier = Modifier.fillMaxWidth().testTag("tabRow"),
-        ) {
-            // Create each tab with a Tab composable
-            tabs.forEachIndexed { index, title ->
-                Tab(
-                    selected = selectedTabIndex == index,
-                    onClick = { selectedTabIndex = index },
-                    text = { Text(title) }
-                )
-            }
-        }
-
-        // Display content based on selected tab
-        when (selectedTabIndex) {
-            0 -> ScheduleScreen(trip!!, navigationActions)
-            1 -> ActivitiesScreen(trip!!, navigationActions)
-            2 -> SettingsScreen(
-                trip!!,
-                navigationActions,
-                tripsViewModel = tripsViewModel,
-                onUpdate = {
-                    selectedTabIndex = 0
-                    selectedTabIndex = 2
-                }
-            )
-        }
+    // Display content based on selected tab
+    when (selectedTabIndex) {
+      0 -> ScheduleScreen(trip!!, navigationActions)
+      1 -> ActivitiesScreen(trip!!, navigationActions)
+      2 ->
+          SettingsScreen(
+              trip!!,
+              navigationActions,
+              tripsViewModel = tripsViewModel,
+              onUpdate = {
+                selectedTabIndex = 0
+                selectedTabIndex = 2
+              })
     }
+  }
 }


### PR DESCRIPTION
## Summary

This pull request fixes a bug in the TopTabs composable where an error occurred if the selected trip was null after modifying photo permissions. The update ensures that the app navigates back to the "Overview" screen if there is no selected trip, improving error handling and user experience. This is a bug fix aimed at gracefully handling cases where a trip may be null.

## Changes

- **Screens/UI:** Updated the TopTabs composable to check if the selected trip is null. If null, it now navigates back to the "Overview" screen using NavigationActions.
- **Bug Fixes/Improvements:** Addresses the issue where modifying photo permissions could cause a null trip error in TopTabs. This fix ensures a smooth user experience when permissions are modified.
## Checklist

Ensure all / most of these are checked before the pull request is submitted.
- [X] This PR resolves #154 

##  Related Issues/Tickets

Closes #154 

## Screenshots

https://github.com/user-attachments/assets/84029123-eded-4035-9d7b-f747721fa094

