### PR TITLE
Fix bug EditProfileScreen

### DIFF
--- a/app/src/androidTest/java/com/android/voyageur/ui/profile/EditProfileScreenTest.kt
+++ b/app/src/androidTest/java/com/android/voyageur/ui/profile/EditProfileScreenTest.kt
@@ -172,16 +172,6 @@ class EditProfileScreenTest {
     composeTestRule.onNodeWithTag("emailField").assertIsNotEnabled()
   }
 
-  @Test
-  fun noUserDataDisplaysMessage() {
-    // Arrange: Set user to null and isLoading to false
-    userViewModel._user.value = null
-    userViewModel._isLoading.value = false
-
-    // Assert: Check that the "No user data available" text is displayed
-    composeTestRule.onNodeWithTag("noUserData").assertIsDisplayed()
-    composeTestRule.onNodeWithText("No user data available").assertIsDisplayed()
-  }
   // New test: Add Interest
   @Test
   fun addInterestSuccessfully() {

--- a/app/src/main/java/com/android/voyageur/ui/profile/EditProfileScreen.kt
+++ b/app/src/main/java/com/android/voyageur/ui/profile/EditProfileScreen.kt
@@ -55,8 +55,14 @@ import com.android.voyageur.ui.profile.interests.InterestChipEditable
 fun EditProfileScreen(userViewModel: UserViewModel, navigationActions: NavigationActions) {
   val user by userViewModel.user.collectAsState()
   val isLoading by userViewModel.isLoading.collectAsState()
+    // Check if user is null and navigate back to the Profile screen if true
+    if (user == null && !isLoading) {
+        navigationActions.navigateTo(Route.PROFILE)
+        return
+    }
 
-  var name by remember { mutableStateOf(user?.name ?: "") }
+
+    var name by remember { mutableStateOf(user?.name ?: "") }
   var email by remember { mutableStateOf(user?.email ?: "") }
   var profilePictureUri by remember { mutableStateOf<Uri?>(null) }
   var profilePictureUrl by remember { mutableStateOf(user?.profilePicture ?: "") }

--- a/app/src/main/java/com/android/voyageur/ui/profile/EditProfileScreen.kt
+++ b/app/src/main/java/com/android/voyageur/ui/profile/EditProfileScreen.kt
@@ -83,6 +83,12 @@ fun EditProfileScreen(userViewModel: UserViewModel, navigationActions: Navigatio
   val context = LocalContext.current
   var showPermissionRationale by remember { mutableStateOf(false) }
   var permissionToRequest by remember { mutableStateOf("") }
+
+  // Check if user is null and navigate back to the Profile screen if true
+  if (user == null && !isLoading) {
+    navigationActions.navigateTo(Route.PROFILE)
+    return
+  }
   // Photo picker launcher
   val pickPhotoLauncher =
       rememberLauncherForActivityResult(ActivityResultContracts.GetContent()) { uri: Uri? ->

--- a/app/src/main/java/com/android/voyageur/ui/profile/EditProfileScreen.kt
+++ b/app/src/main/java/com/android/voyageur/ui/profile/EditProfileScreen.kt
@@ -55,14 +55,13 @@ import com.android.voyageur.ui.profile.interests.InterestChipEditable
 fun EditProfileScreen(userViewModel: UserViewModel, navigationActions: NavigationActions) {
   val user by userViewModel.user.collectAsState()
   val isLoading by userViewModel.isLoading.collectAsState()
-    // Check if user is null and navigate back to the Profile screen if true
-    if (user == null && !isLoading) {
-        navigationActions.navigateTo(Route.PROFILE)
-        return
-    }
+  // Check if user is null and navigate back to the Profile screen if true
+  if (user == null && !isLoading) {
+    navigationActions.navigateTo(Route.PROFILE)
+    return
+  }
 
-
-    var name by remember { mutableStateOf(user?.name ?: "") }
+  var name by remember { mutableStateOf(user?.name ?: "") }
   var email by remember { mutableStateOf(user?.email ?: "") }
   var profilePictureUri by remember { mutableStateOf<Uri?>(null) }
   var profilePictureUrl by remember { mutableStateOf(user?.profilePicture ?: "") }


### PR DESCRIPTION
## Summary

This pull request fixes a bug in the EditProfileScreen composable where an error occurred if the user data was null after modifying photo permissions. The update ensures that the app navigates back to the "Profile" screen if user data is unavailable, improving error handling and the overall user experience. This is a bug fix aimed at gracefully managing cases where user data may be null.

## Changes

- **Screens/UI:** Updated the EditProfileScreen composable to check if the user data is null. If null, it now navigates back to the "Profile" screen using NavigationActions.
- **Bug Fixes/Improvements:** Addresses the issue where modifying photo permissions could cause a null user error in EditProfileScreen. This fix ensures a smooth user experience when permissions are modified or user data is unexpectedly unavailable.

## Checklist

- [X] This PR resolves #154 

##  Related Issues/Tickets

Closes #154 

## Screenshots

https://github.com/user-attachments/assets/b5a6da82-4872-4428-950d-a28eca9639fd


