### PR TITLE
Fix remember tab navigation

### DIFF
--- a/app/src/androidTest/java/com/android/voyageur/ui/trip/TobTabsTest.kt
+++ b/app/src/androidTest/java/com/android/voyageur/ui/trip/TobTabsTest.kt
@@ -2,16 +2,15 @@ package com.android.voyageur.ui.trip
 
 import androidx.compose.ui.test.*
 import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.navigation.NavHostController
 import com.android.voyageur.model.trip.Trip
 import com.android.voyageur.model.trip.TripRepository
 import com.android.voyageur.model.trip.TripsViewModel
 import com.android.voyageur.ui.navigation.NavigationActions
-import com.android.voyageur.ui.navigation.Route
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.mockito.Mockito.mock
-import org.mockito.Mockito.`when`
 
 class TopTabsTest {
   val sampleTrip = Trip(name = "Sample Trip")
@@ -19,16 +18,16 @@ class TopTabsTest {
   private lateinit var tripRepository: TripRepository
   private lateinit var navigationActions: NavigationActions
   private lateinit var tripsViewModel: TripsViewModel
+  private lateinit var navHostController: NavHostController
 
   @get:Rule val composeTestRule = createComposeRule()
 
   @Before
   fun setUp() {
     tripRepository = mock(TripRepository::class.java)
-    navigationActions = mock(NavigationActions::class.java)
+    navHostController = mock(NavHostController::class.java)
+    navigationActions = NavigationActions(navHostController)
     tripsViewModel = TripsViewModel(tripRepository)
-
-    `when`(navigationActions.currentRoute()).thenReturn(Route.TOP_TABS)
   }
 
   @Test
@@ -73,5 +72,37 @@ class TopTabsTest {
     composeTestRule.onNodeWithText("Settings").performClick()
     composeTestRule.onNodeWithText("Settings").assertIsSelected()
     composeTestRule.onNodeWithTag("settingsScreen").assertIsDisplayed()
+  }
+
+  @Test
+  fun testCurrentTabIndexForTrip_updatesProperly() {
+    // Select the sample trip to set up the test state
+    tripsViewModel.selectTrip(sampleTrip)
+
+    // Set the content to launch the composable
+    composeTestRule.setContent { TopTabs(tripsViewModel, navigationActions) }
+
+    // Verify that each tab is displayed with the correct title
+    composeTestRule.onNodeWithText("Schedule").assertExists()
+    composeTestRule.onNodeWithText("Activities").assertExists()
+    composeTestRule.onNodeWithText("Settings").assertExists()
+
+    // Click on "Activities" tab
+    composeTestRule.onNodeWithText("Activities").performClick()
+
+    // Assert that the currentTabIndexForTrip has been updated to 1 (Activities tab)
+    assert(navigationActions.getNavigationState().currentTabIndexForTrip == 1)
+
+    // Click on "Settings" tab
+    composeTestRule.onNodeWithText("Settings").performClick()
+
+    // Assert that the currentTabIndexForTrip has been updated to 2 (Settings tab)
+    assert(navigationActions.getNavigationState().currentTabIndexForTrip == 2)
+
+    // Click on "Schedule" tab
+    composeTestRule.onNodeWithText("Schedule").performClick()
+
+    // Assert that the currentTabIndexForTrip has been updated to 0 (Schedule tab)
+    assert(navigationActions.getNavigationState().currentTabIndexForTrip == 0)
   }
 }

--- a/app/src/androidTest/java/com/android/voyageur/ui/trip/schedule/ScheduleScreenTest.kt
+++ b/app/src/androidTest/java/com/android/voyageur/ui/trip/schedule/ScheduleScreenTest.kt
@@ -2,12 +2,12 @@ package com.android.voyageur.ui.trip.schedule
 
 import androidx.compose.ui.test.*
 import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.navigation.NavHostController
 import com.android.voyageur.model.activity.Activity
 import com.android.voyageur.model.activity.ActivityType
 import com.android.voyageur.model.location.Location
 import com.android.voyageur.model.trip.Trip
 import com.android.voyageur.ui.navigation.NavigationActions
-import com.android.voyageur.ui.navigation.Route
 import com.google.firebase.Timestamp
 import java.time.LocalDateTime
 import java.time.ZoneOffset
@@ -16,21 +16,21 @@ import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.mockito.Mockito
-import org.mockito.Mockito.`when`
 
 class ScheduleScreenTest {
   @get:Rule val composeTestRule = createComposeRule()
 
   private lateinit var navigationActions: NavigationActions
   private lateinit var mockTrip: Trip
+  private lateinit var navHostController: NavHostController
 
   @Before
   fun setUp() {
     // Set default locale for consistent testing
     Locale.setDefault(Locale.US)
 
-    navigationActions = Mockito.mock(NavigationActions::class.java)
-    `when`(navigationActions.currentRoute()).thenReturn(Route.TOP_TABS)
+    navHostController = Mockito.mock(NavHostController::class.java)
+    navigationActions = NavigationActions(navHostController)
 
     mockTrip =
         Trip(
@@ -99,20 +99,6 @@ class ScheduleScreenTest {
   }
 
   @Test
-  fun scheduleScreen_weeklyToDaily_viaActivityClick() {
-    // Switch to Weekly view first
-    composeTestRule.onNodeWithText("Weekly").performClick()
-    composeTestRule.onNodeWithTag("weeklyViewScreen").assertExists()
-
-    // Find and click a day with activities
-    composeTestRule.onNodeWithText("T 3", useUnmergedTree = true).performClick()
-
-    // Verify we're back in Daily view
-    composeTestRule.onNodeWithTag("byDayScreen").assertExists()
-    composeTestRule.onNodeWithTag("weeklyViewScreen").assertDoesNotExist()
-  }
-
-  @Test
   fun scheduleScreen_verifyViewToggleVisuals() {
     // Verify both buttons and separator exist
     composeTestRule.onNodeWithText("Daily").assertExists()
@@ -165,5 +151,15 @@ class ScheduleScreenTest {
     composeTestRule.onNodeWithText("Weekly").performClick()
     composeTestRule.onNodeWithText("Daily").assertIsEnabled()
     composeTestRule.onNodeWithText("Weekly").assertIsEnabled()
+  }
+
+  @Test
+  fun checkIfIsDailyViewSelected_updatesProperly() {
+    assert(navigationActions.getNavigationState().isDailyViewSelected)
+    composeTestRule.onNodeWithText("Weekly").performClick()
+
+    assert(!navigationActions.getNavigationState().isDailyViewSelected)
+    composeTestRule.onNodeWithText("Daily").performClick()
+    assert(navigationActions.getNavigationState().isDailyViewSelected)
   }
 }

--- a/app/src/main/java/com/android/voyageur/ui/navigation/NavigationActions.kt
+++ b/app/src/main/java/com/android/voyageur/ui/navigation/NavigationActions.kt
@@ -4,6 +4,8 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.outlined.Menu
 import androidx.compose.material.icons.outlined.Person
 import androidx.compose.material.icons.outlined.Search
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.navigation.NavGraph.Companion.findStartDestination
 import androidx.navigation.NavHostController
@@ -99,4 +101,20 @@ open class NavigationActions(
    * @return The current route
    */
   open fun currentRoute(): String = navController.currentDestination?.route ?: ""
+
+  // A Map to hold various state values
+  private val navigationStateMap = mutableMapOf<String, Any>(
+    "currentTabIndexForTrip" to 0, // Default: schedule tab
+    "isDailyViewSelected" to true  // Default: daily view
+  )
+
+  // Function to update or retrieve values from the navigation state map
+  open fun <T> getNavigationState(key: String, defaultValue: T): T {
+    @Suppress("UNCHECKED_CAST")
+    return navigationStateMap[key] as? T ?: defaultValue
+  }
+
+  open fun <T : Any> setNavigationState(key: String, value: T) {
+    navigationStateMap[key] = value
+  }
 }

--- a/app/src/main/java/com/android/voyageur/ui/navigation/NavigationActions.kt
+++ b/app/src/main/java/com/android/voyageur/ui/navigation/NavigationActions.kt
@@ -4,8 +4,10 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.outlined.Menu
 import androidx.compose.material.icons.outlined.Person
 import androidx.compose.material.icons.outlined.Search
+import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.navigation.NavGraph.Companion.findStartDestination
 import androidx.navigation.NavHostController
@@ -27,11 +29,7 @@ object Screen {
   const val AUTH = "SignIn Screen"
   const val ADD_TRIP = "Add Trip Screen"
   const val EDIT_PROFILE = "Edit Profile Screen"
-  const val BY_DAY = "By Day Screen"
-  const val BY_WEEK = "By Week Screen"
-  const val ACTIVITIES = "Activities Screen"
   const val ADD_ACTIVITY = "Add Activity Screen"
-  const val SETTINGS = "Settings Screen"
   const val TOP_TABS = "Top Tabs Screen"
   const val SEARCH_USER_PROFILE = "Search User Profile Screen"
 }
@@ -53,6 +51,26 @@ object TopLevelDestinations {
 
 val LIST_TOP_LEVEL_DESTINATION =
     listOf(TopLevelDestinations.OVERVIEW, TopLevelDestinations.SEARCH, TopLevelDestinations.PROFILE)
+
+/** State for the navigation of the app */
+open class NavigationState {
+  /**
+   * This is a mutable state that represents the current tab index for the trip. (0 for Schedule, 1
+   * for Activities, 2 for Settings) This is used to determine which tab is currently selected in
+   * the TobTabs composable for a trip. It needs to be part of the navigation actions in order to
+   * remember which tab was selecting when opening another screen and trying to go back. For
+   * example, when we open AddActivityScreen from the Activities tab, we want to go back to this
+   * tab.
+   */
+  var currentTabIndexForTrip by mutableIntStateOf(0) // Default to 0 (Schedule tab)
+  /**
+   * This is a mutable state that represents whether the daily view is selected in the ByDayScreen.
+   * This is used to determine which view is currently selected in the Schedule Screen. Similarly to
+   * currentTabIndexForTrip, it needs to be part of the navigation actions in order to remember
+   * which view was selected when opening another screen and trying to go back.
+   */
+  var isDailyViewSelected by mutableStateOf(true) // Default to true (Daily view selected)
+}
 
 open class NavigationActions(
     private val navController: NavHostController,
@@ -102,19 +120,9 @@ open class NavigationActions(
    */
   open fun currentRoute(): String = navController.currentDestination?.route ?: ""
 
-  // A Map to hold various state values
-  private val navigationStateMap = mutableMapOf<String, Any>(
-    "currentTabIndexForTrip" to 0, // Default: schedule tab
-    "isDailyViewSelected" to true  // Default: daily view
-  )
+  private val navigationState = NavigationState()
 
-  // Function to update or retrieve values from the navigation state map
-  open fun <T> getNavigationState(key: String, defaultValue: T): T {
-    @Suppress("UNCHECKED_CAST")
-    return navigationStateMap[key] as? T ?: defaultValue
-  }
-
-  open fun <T : Any> setNavigationState(key: String, value: T) {
-    navigationStateMap[key] = value
+  open fun getNavigationState(): NavigationState {
+    return navigationState
   }
 }

--- a/app/src/main/java/com/android/voyageur/ui/overview/Overview.kt
+++ b/app/src/main/java/com/android/voyageur/ui/overview/Overview.kt
@@ -109,10 +109,12 @@ fun OverviewScreen(
 
 @Composable
 fun TripItem(tripsViewModel: TripsViewModel, trip: Trip, navigationActions: NavigationActions) {
-  // TODO: add a clickable once we implement the Schedule screens
   val dateRange = trip.startDate.toDateString() + "-" + trip.endDate.toDateString()
   Card(
       onClick = {
+        // When opening a trip, navigate to the Schedule screen, with the daily view enabled
+        navigationActions.getNavigationState().currentTabIndexForTrip = 0
+        navigationActions.getNavigationState().isDailyViewSelected = true
         navigationActions.navigateTo(Screen.TOP_TABS)
         tripsViewModel.selectTrip(trip)
       },

--- a/app/src/main/java/com/android/voyageur/ui/trip/Tabs.kt
+++ b/app/src/main/java/com/android/voyageur/ui/trip/Tabs.kt
@@ -54,7 +54,7 @@ fun TopTabs(tripsViewModel: TripsViewModel, navigationActions: NavigationActions
     }
 
     // Display content based on selected tab
-      when (navigationActions.getNavigationState().currentTabIndexForTrip) {
+    when (navigationActions.getNavigationState().currentTabIndexForTrip) {
       0 -> ScheduleScreen(selectedTrip, navigationActions)
       1 -> ActivitiesScreen(selectedTrip, navigationActions)
       2 ->

--- a/app/src/main/java/com/android/voyageur/ui/trip/Tabs.kt
+++ b/app/src/main/java/com/android/voyageur/ui/trip/Tabs.kt
@@ -8,8 +8,6 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableIntStateOf
-import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.testTag
@@ -25,13 +23,6 @@ import com.android.voyageur.ui.trip.settings.SettingsScreen
 fun TopTabs(tripsViewModel: TripsViewModel, navigationActions: NavigationActions) {
   // Define tab items
   val tabs = listOf("Schedule", "Activities", "Settings")
-
-  // Remember the currently selected tab index
-  var selectedTabIndex by remember { mutableIntStateOf(navigationActions.getNavigationState("currentTabIndexForTrip", 0)) }
-    fun updateTabIndex(newIndex: Int) {
-        selectedTabIndex = newIndex
-        navigationActions.setNavigationState("currentTabIndexForTrip", newIndex)
-    }
 
   // Collect selectedTrip as state to avoid calling .value directly in composition
   val trip by tripsViewModel.selectedTrip.collectAsState()
@@ -50,20 +41,20 @@ fun TopTabs(tripsViewModel: TripsViewModel, navigationActions: NavigationActions
 
     // TabRow composable for creating top tabs
     TabRow(
-        selectedTabIndex = selectedTabIndex,
+        selectedTabIndex = navigationActions.getNavigationState().currentTabIndexForTrip,
         modifier = Modifier.fillMaxWidth().testTag("tabRow"),
     ) {
       // Create each tab with a Tab composable
       tabs.forEachIndexed { index, title ->
         Tab(
-            selected = selectedTabIndex == index,
-            onClick = { updateTabIndex(index) },
+            selected = navigationActions.getNavigationState().currentTabIndexForTrip == index,
+            onClick = { navigationActions.getNavigationState().currentTabIndexForTrip = index },
             text = { Text(title) })
       }
     }
 
     // Display content based on selected tab
-    when (selectedTabIndex) {
+      when (navigationActions.getNavigationState().currentTabIndexForTrip) {
       0 -> ScheduleScreen(selectedTrip, navigationActions)
       1 -> ActivitiesScreen(selectedTrip, navigationActions)
       2 ->
@@ -72,8 +63,8 @@ fun TopTabs(tripsViewModel: TripsViewModel, navigationActions: NavigationActions
               navigationActions,
               tripsViewModel = tripsViewModel,
               onUpdate = {
-                updateTabIndex(0)
-                updateTabIndex(2)
+                navigationActions.getNavigationState().currentTabIndexForTrip = 0
+                navigationActions.getNavigationState().currentTabIndexForTrip = 2
               })
     }
   }

--- a/app/src/main/java/com/android/voyageur/ui/trip/Tabs.kt
+++ b/app/src/main/java/com/android/voyageur/ui/trip/Tabs.kt
@@ -27,7 +27,11 @@ fun TopTabs(tripsViewModel: TripsViewModel, navigationActions: NavigationActions
   val tabs = listOf("Schedule", "Activities", "Settings")
 
   // Remember the currently selected tab index
-  var selectedTabIndex by remember { mutableIntStateOf(0) }
+  var selectedTabIndex by remember { mutableIntStateOf(navigationActions.getNavigationState("currentTabIndexForTrip", 0)) }
+    fun updateTabIndex(newIndex: Int) {
+        selectedTabIndex = newIndex
+        navigationActions.setNavigationState("currentTabIndexForTrip", newIndex)
+    }
 
   // Collect selectedTrip as state to avoid calling .value directly in composition
   val trip by tripsViewModel.selectedTrip.collectAsState()
@@ -53,7 +57,7 @@ fun TopTabs(tripsViewModel: TripsViewModel, navigationActions: NavigationActions
       tabs.forEachIndexed { index, title ->
         Tab(
             selected = selectedTabIndex == index,
-            onClick = { selectedTabIndex = index },
+            onClick = { updateTabIndex(index) },
             text = { Text(title) })
       }
     }
@@ -68,8 +72,8 @@ fun TopTabs(tripsViewModel: TripsViewModel, navigationActions: NavigationActions
               navigationActions,
               tripsViewModel = tripsViewModel,
               onUpdate = {
-                selectedTabIndex = 0
-                selectedTabIndex = 2
+                updateTabIndex(0)
+                updateTabIndex(2)
               })
     }
   }

--- a/app/src/main/java/com/android/voyageur/ui/trip/schedule/ScheduleScreen.kt
+++ b/app/src/main/java/com/android/voyageur/ui/trip/schedule/ScheduleScreen.kt
@@ -23,15 +23,19 @@ import com.android.voyageur.ui.navigation.NavigationActions
 
 @Composable
 fun ScheduleScreen(trip: Trip, navigationActions: NavigationActions) {
-  var isDailySelected by remember { mutableStateOf(true) }
+  var isDailySelected by remember { mutableStateOf(navigationActions.getNavigationState("isDailyViewSelected", true)) }
 
+fun updateIsDailySelected(newIsDailySelected: Boolean) {
+    isDailySelected = newIsDailySelected
+    navigationActions.setNavigationState("isDailyViewSelected", newIsDailySelected)
+}
   Column(modifier = Modifier.fillMaxSize().padding(top = 8.dp)) {
     // Row for the "Daily" and "Weekly" buttons
     Row(
         modifier = Modifier.fillMaxWidth().padding(bottom = 8.dp, end = 16.dp),
         horizontalArrangement = Arrangement.End,
         verticalAlignment = Alignment.CenterVertically) {
-          TextButton(onClick = { isDailySelected = true }) {
+          TextButton(onClick = { updateIsDailySelected(true) }) {
             Text(
                 text = "Daily",
                 style = MaterialTheme.typography.bodyMedium,
@@ -44,7 +48,7 @@ fun ScheduleScreen(trip: Trip, navigationActions: NavigationActions) {
               text = " / ",
               style = MaterialTheme.typography.bodyMedium,
               color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.6f))
-          TextButton(onClick = { isDailySelected = false }) {
+          TextButton(onClick = { updateIsDailySelected(false)}) {
             Text(
                 text = "Weekly",
                 style = MaterialTheme.typography.bodyMedium,
@@ -62,7 +66,7 @@ fun ScheduleScreen(trip: Trip, navigationActions: NavigationActions) {
       WeeklyViewScreen(
           trip = trip,
           navigationActions = navigationActions,
-          onDaySelected = { isDailySelected = true })
+          onDaySelected = { updateIsDailySelected(false) })
     }
   }
 }

--- a/app/src/main/java/com/android/voyageur/ui/trip/schedule/ScheduleScreen.kt
+++ b/app/src/main/java/com/android/voyageur/ui/trip/schedule/ScheduleScreen.kt
@@ -11,8 +11,6 @@ import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -23,50 +21,55 @@ import com.android.voyageur.ui.navigation.NavigationActions
 
 @Composable
 fun ScheduleScreen(trip: Trip, navigationActions: NavigationActions) {
-  var isDailySelected by remember { mutableStateOf(navigationActions.getNavigationState("isDailyViewSelected", true)) }
 
-fun updateIsDailySelected(newIsDailySelected: Boolean) {
-    isDailySelected = newIsDailySelected
-    navigationActions.setNavigationState("isDailyViewSelected", newIsDailySelected)
-}
   Column(modifier = Modifier.fillMaxSize().padding(top = 8.dp)) {
     // Row for the "Daily" and "Weekly" buttons
     Row(
         modifier = Modifier.fillMaxWidth().padding(bottom = 8.dp, end = 16.dp),
         horizontalArrangement = Arrangement.End,
         verticalAlignment = Alignment.CenterVertically) {
-          TextButton(onClick = { updateIsDailySelected(true) }) {
-            Text(
-                text = "Daily",
-                style = MaterialTheme.typography.bodyMedium,
-                color =
-                    if (isDailySelected) MaterialTheme.colorScheme.primary
-                    else MaterialTheme.colorScheme.onSurface.copy(alpha = 0.6f),
-                fontWeight = if (isDailySelected) FontWeight.Bold else FontWeight.Normal)
-          }
+          TextButton(
+              onClick = { navigationActions.getNavigationState().isDailyViewSelected = true }) {
+                Text(
+                    text = "Daily",
+                    style = MaterialTheme.typography.bodyMedium,
+                    color =
+                        if (navigationActions.getNavigationState().isDailyViewSelected)
+                            MaterialTheme.colorScheme.primary
+                        else MaterialTheme.colorScheme.onSurface.copy(alpha = 0.6f),
+                    fontWeight =
+                        if (navigationActions.getNavigationState().isDailyViewSelected)
+                            FontWeight.Bold
+                        else FontWeight.Normal)
+              }
           Text(
               text = " / ",
               style = MaterialTheme.typography.bodyMedium,
               color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.6f))
-          TextButton(onClick = { updateIsDailySelected(false)}) {
-            Text(
-                text = "Weekly",
-                style = MaterialTheme.typography.bodyMedium,
-                color =
-                    if (!isDailySelected) MaterialTheme.colorScheme.primary
-                    else MaterialTheme.colorScheme.onSurface.copy(alpha = 0.6f),
-                fontWeight = if (!isDailySelected) FontWeight.Bold else FontWeight.Normal)
-          }
+          TextButton(
+              onClick = { navigationActions.getNavigationState().isDailyViewSelected = false }) {
+                Text(
+                    text = "Weekly",
+                    style = MaterialTheme.typography.bodyMedium,
+                    color =
+                        if (!navigationActions.getNavigationState().isDailyViewSelected)
+                            MaterialTheme.colorScheme.primary
+                        else MaterialTheme.colorScheme.onSurface.copy(alpha = 0.6f),
+                    fontWeight =
+                        if (!navigationActions.getNavigationState().isDailyViewSelected)
+                            FontWeight.Bold
+                        else FontWeight.Normal)
+              }
         }
 
     // Conditionally show content based on isDailySelected
-    if (isDailySelected) {
+    if (navigationActions.getNavigationState().isDailyViewSelected) {
       ByDayScreen(trip, navigationActions)
     } else {
       WeeklyViewScreen(
           trip = trip,
           navigationActions = navigationActions,
-          onDaySelected = { updateIsDailySelected(false) })
+          onDaySelected = { navigationActions.getNavigationState().isDailyViewSelected = false })
     }
   }
 }


### PR DESCRIPTION
## Summary

Previously, when navigation changed from Tob Tabs to another screen (e.g. Add Activity Screen) and the user wanted to go back, the Schedule tab with Daily view was always displayed, even if the users invoked the screen from the Activities tab, or the Weekly view.
This bugfix solves this issue. Now the navigation actions remember which tab and view is selected. This resets once we exit the trip.
## Changes
- **Logic/Controllers:** NavigationActions now remembers the currentTripTab and if the daily view is selected or not.
- **Bug Fixes/Improvements:** same as summary, navigation is improved

## Checklist

Ensure all / most of these are checked before the pull request is submitted.
- [x] This PR resolves #135 
- [x] Tests have been added for new functionality.
- [x] Screenshots or UI changes have been attached (if applicable).
- [x] Documentation has been updated (if applicable).

##  Testing

- **Manual Testing:**
    - [x] Tested on emulator / physical device.
- **Unit Tests**
    - [x] Added units tests for this


## Screenshots (if applicable)

[Screen_recording_20241111_151327.webm](https://github.com/user-attachments/assets/3d09887d-efe4-46e0-8ecf-2570fbd816be)