### PR TITLE
fix price field

### DIFF
--- a/app/src/main/java/com/android/voyageur/ui/trip/AddActivity.kt
+++ b/app/src/main/java/com/android/voyageur/ui/trip/AddActivity.kt
@@ -31,8 +31,6 @@ import com.android.voyageur.ui.formFields.DatePickerModal
 import com.android.voyageur.ui.formFields.TimePickerInput
 import com.android.voyageur.ui.navigation.NavigationActions
 import com.google.firebase.Timestamp
-import java.text.DecimalFormat
-import java.text.DecimalFormatSymbols
 import java.text.SimpleDateFormat
 import java.util.Calendar
 import java.util.Date
@@ -363,22 +361,8 @@ fun AddActivityScreen(tripsViewModel: TripsViewModel, navigationActions: Navigat
                   }
                 }
 
-                fun formatPrice(price: Double): String {
-                  val symbols =
-                      DecimalFormatSymbols.getInstance(Locale.getDefault()).apply {
-                        groupingSeparator = '\''
-                      }
-                  val decimalFormat =
-                      if (price % 1.0 == 0.0) {
-                        DecimalFormat("#,###", symbols)
-                      } else {
-                        DecimalFormat("#,###.##", symbols)
-                      }
-                  return decimalFormat.format(price)
-                }
-
                 OutlinedTextField(
-                    value = priceInput.ifEmpty { estimatedPrice?.let { formatPrice(it) } ?: "" },
+                    value = priceInput,
                     onValueChange = { input ->
                       val filteredInput = input.filter { it.isDigit() || it == '.' }
                       if (filteredInput.count { it == '.' } <= 1) {
@@ -394,7 +378,7 @@ fun AddActivityScreen(tripsViewModel: TripsViewModel, navigationActions: Navigat
                     keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
                     modifier = Modifier.fillMaxWidth().testTag("inputActivityPrice"))
 
-                Spacer(modifier = Modifier.height(8.dp))
+                Spacer(modifier = Modifier.height(2.dp))
 
                 ExposedDropdownMenuBox(
                     expanded = expanded, onExpandedChange = { expanded = !expanded }) {


### PR DESCRIPTION
## Summary

I fixed the price field of the activity screen. You can input only numbers and with maximum 2 digits. 

## Changes

- **Models:** estimatedPrice field logic in AddActivityScreen has been updated
- **Bug Fixes/Improvements:** #165

## Checklist

Ensure all / most of these are checked before the pull request is submitted.
- [x] This PR resolves #165 .
- [ ] Tests have been added for new functionality.
- [ ] Screenshots or UI changes have been attached (if applicable).
- [x] Documentation has been updated (if applicable).

##  Testing

Explain how this feature was tested and what kind of testing (unit, integration, UI) has been done. Mention platforms or configurations used for testing.
- **Manual Testing:**
    - [x] Tested on emulator / physical device.
- **Unit Tests**
    - [ ] Added units tests for this

If you haven't added tests, please create a new issue and assign it.

##  Related Issues/Tickets

Closes #165 


