### PR TITLE
Fix: correctly add API key to build pipelines

### DIFF
--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -79,7 +79,7 @@ jobs:
         env:
           MAPS_API_KEY: $ {{ secrets.PLACES_API_KEY }}
           PLACES_API_KEY: ${{ secrets.PLACES_API_KEY }}
-        run: echo PLACES_API_KEY=\$PLACES_API_KEY\ > ./local.properties
+        run: echo "PLACES_API_KEY=\${{ secrets.PLACES_API_KEY }}" > ./local.properties
 
       - name: Grant execute permission for gradlew
         run: |

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -57,7 +57,7 @@ jobs:
         env:
           PLACES_API_KEY: ${{ secrets.PLACES_API_KEY }}
           MAPS_API_KEY: $ {{ secrets.PLACES_API_KEY }}
-        run: echo PLACES_API_KEY=\$PLACES_API_KEY\ > ./local.properties
+        run: echo "PLACES_API_KEY=\${{ secrets.PLACES_API_KEY }}" > ./local.properties
 
       - name: Build APK
         run: |


### PR DESCRIPTION
## Summary

Fix the CI and build apk pipelines that didn't set the places api key correctly due to a formatting error