### PR TITLE
Feat/Display User profile icon in Overview and Participants Form.

### DIFF
--- a/app/src/androidTest/java/com/android/voyageur/ui/e2e/EndToEndTest.kt
+++ b/app/src/androidTest/java/com/android/voyageur/ui/e2e/EndToEndTest.kt
@@ -165,6 +165,7 @@ class E2ETest {
       it.getArgument<(List<Trip>) -> Unit>(1)(mockTrips)
     }
     tripsViewModel.getTrips()
+    userViewModel._isLoading.value = false
 
     composeTestRule.onNodeWithTag("cardItem").assertIsDisplayed() // check view by day of the trip
     composeTestRule.onNodeWithTag("cardItem").performClick()

--- a/app/src/androidTest/java/com/android/voyageur/ui/e2e/EndToEndTest.kt
+++ b/app/src/androidTest/java/com/android/voyageur/ui/e2e/EndToEndTest.kt
@@ -93,6 +93,21 @@ class E2ETest {
         .`when`(userRepository)
         .getUserById(anyString(), anyOrNull(), anyOrNull())
 
+    // Mock userRepository.fetchUsersByIds to call onSuccess with the list of users
+    doAnswer { invocation ->
+          val userIds = invocation.getArgument<List<String>>(0)
+          val onSuccess = invocation.getArgument<(List<User>) -> Unit>(1)
+
+          val mockUsers =
+              userIds.map { userId ->
+                User(id = userId, name = "User $userId", email = "$userId@example.com")
+              }
+          onSuccess(mockUsers)
+          null
+        }
+        .`when`(userRepository)
+        .fetchUsersByIds(any(), any(), anyOrNull())
+
     // Create the UserViewModel with the mocked userRepository and firebaseAuth
     userViewModel = UserViewModel(userRepository, firebaseAuth)
     mockUser = mock(FirebaseUser::class.java)

--- a/app/src/androidTest/java/com/android/voyageur/ui/e2e/EndToEndTestM2.kt
+++ b/app/src/androidTest/java/com/android/voyageur/ui/e2e/EndToEndTestM2.kt
@@ -115,6 +115,20 @@ class E2ETestM2 {
         .`when`(userRepository)
         .getUserById(anyString(), anyOrNull(), anyOrNull())
 
+    doAnswer { invocation ->
+          val userIds = invocation.getArgument<List<String>>(0)
+          val onSuccess = invocation.getArgument<(List<User>) -> Unit>(1)
+
+          val mockUsers =
+              userIds.map { userId ->
+                User(id = userId, name = "User $userId", email = "$userId@example.com")
+              }
+          onSuccess(mockUsers)
+          null
+        }
+        .`when`(userRepository)
+        .fetchUsersByIds(any(), any(), anyOrNull())
+
     whenever(tripsViewModel.getNewTripId()).thenReturn("mockTripId")
 
     `when`(navigationActions.currentRoute()).thenReturn(Route.OVERVIEW)
@@ -219,7 +233,6 @@ class E2ETestM2 {
     composeTestRule
         .onNodeWithText("You have no trips yet.")
         .assertIsNotDisplayed() // We have a trip so no trips text is not displayed
-
     composeTestRule
         .onNodeWithText("Trip with activities")
         .assertIsDisplayed() // check if trip name is displayed

--- a/app/src/androidTest/java/com/android/voyageur/ui/e2e/EndToEndTestM2.kt
+++ b/app/src/androidTest/java/com/android/voyageur/ui/e2e/EndToEndTestM2.kt
@@ -229,6 +229,7 @@ class E2ETestM2 {
       it.getArgument<(List<Trip>) -> Unit>(1)(mockTrips)
     }
     tripsViewModel.getTrips()
+    userViewModel._isLoading.value = false
 
     composeTestRule
         .onNodeWithText("You have no trips yet.")

--- a/app/src/androidTest/java/com/android/voyageur/ui/overview/DropDownTest.kt
+++ b/app/src/androidTest/java/com/android/voyageur/ui/overview/DropDownTest.kt
@@ -11,15 +11,6 @@ class DropDownTest {
 
   @get:Rule val composeTestRule = createComposeRule()
 
-  // Tests for UserIcon
-  @Test
-  fun userIcon_displaysCorrectInitial_NoProfilePic() {
-    composeTestRule.setContent { UserIcon(User(name = "Alice")) }
-    // Assert that the participant avatar exists and shows the correct initial
-    composeTestRule.onNodeWithTag("participantAvatar").assertExists()
-    composeTestRule.onNodeWithText("A").assertExists()
-  }
-
   @Test
   fun userIcon_displaysProfilePic() {
     composeTestRule.setContent {
@@ -33,16 +24,11 @@ class DropDownTest {
   @Test
   fun userDropdown_displaysParticipants() {
     val users =
-        listOf(
-            Pair(User(name = "Alice"), true),
-            Pair(User(name = "Bob"), false),
-            Pair(User(name = "Charlie"), true))
+        listOf(Pair(User(name = "Alice", profilePicture = "https://test.com/profile.jpg"), true))
 
     composeTestRule.setContent { UserDropdown(users = users, onUpdate = { _, _ -> }) }
-
-    // Verify the initially selected participants are displayed
-    composeTestRule.onNodeWithText("A").assertExists()
-    composeTestRule.onNodeWithText("C").assertExists()
+    // Assert that the participant profile picture is displayed
+    composeTestRule.onNodeWithTag("profilePic", useUnmergedTree = true).assertExists()
 
     // Verify the label "Participants" does not exist because participants are selected
     composeTestRule.onNodeWithText("Participants").assertDoesNotExist()

--- a/app/src/androidTest/java/com/android/voyageur/ui/overview/DropDownTest.kt
+++ b/app/src/androidTest/java/com/android/voyageur/ui/overview/DropDownTest.kt
@@ -13,11 +13,20 @@ class DropDownTest {
 
   // Tests for UserIcon
   @Test
-  fun userIcon_displaysCorrectInitial() {
-    composeTestRule.setContent { UserIcon(text = "Alice") }
+  fun userIcon_displaysCorrectInitial_NoProfilePic() {
+    composeTestRule.setContent { UserIcon(User(name = "Alice")) }
     // Assert that the participant avatar exists and shows the correct initial
     composeTestRule.onNodeWithTag("participantAvatar").assertExists()
     composeTestRule.onNodeWithText("A").assertExists()
+  }
+
+  @Test
+  fun userIcon_displaysProfilePic() {
+    composeTestRule.setContent {
+      UserIcon(User(name = "Alice", profilePicture = "https://test.com/profile.jpg"))
+    }
+    // Assert that the participant profile picture is displayed
+    composeTestRule.onNodeWithTag("profilePic").assertExists()
   }
 
   // Tests for UserDropdown

--- a/app/src/androidTest/java/com/android/voyageur/ui/overview/OverviewScreenTest.kt
+++ b/app/src/androidTest/java/com/android/voyageur/ui/overview/OverviewScreenTest.kt
@@ -226,5 +226,4 @@ class OverviewScreenTest {
     composeTestRule.onNodeWithTag("defaultTripImage", useUnmergedTree = true).assertExists()
     composeTestRule.onNodeWithTag("tripImage").assertDoesNotExist()
   }
-
 }

--- a/app/src/androidTest/java/com/android/voyageur/ui/overview/OverviewScreenTest.kt
+++ b/app/src/androidTest/java/com/android/voyageur/ui/overview/OverviewScreenTest.kt
@@ -226,4 +226,5 @@ class OverviewScreenTest {
     composeTestRule.onNodeWithTag("defaultTripImage", useUnmergedTree = true).assertExists()
     composeTestRule.onNodeWithTag("tripImage").assertDoesNotExist()
   }
+
 }

--- a/app/src/main/java/com/android/voyageur/model/user/UserViewModel.kt
+++ b/app/src/main/java/com/android/voyageur/model/user/UserViewModel.kt
@@ -258,8 +258,17 @@ open class UserViewModel(
    * @param onSuccess callback for the response
    */
   fun getUsersByIds(userIds: List<String>, onSuccess: (List<User>) -> Unit) {
+    _isLoading.value = true
     userRepository.fetchUsersByIds(
-        userIds, onSuccess, { Log.e("USER_VIEW_MODEL", it.message.orEmpty()) })
+        userIds,
+        { users ->
+          _isLoading.value = false
+          onSuccess(users)
+        },
+        { error ->
+          _isLoading.value = false
+          Log.e("USER_VIEW_MODEL", error.message.orEmpty())
+        })
   }
   /**
    * Fetches all the contacts of the current user and returns them into a list

--- a/app/src/main/java/com/android/voyageur/ui/formFields/UserDropdown.kt
+++ b/app/src/main/java/com/android/voyageur/ui/formFields/UserDropdown.kt
@@ -1,11 +1,11 @@
 package com.android.voyageur.ui.formFields
 
+import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.ExperimentalLayoutApi
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
@@ -27,24 +27,43 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.unit.dp
+import coil.compose.rememberAsyncImagePainter
 import com.android.voyageur.model.user.User
 
+/**
+ * Composable function that displays the profile picture of a given user.
+ *
+ * This function renders a user's profile picture inside a circular avatar. If the user's profile
+ * picture URI is not available or is empty, it falls back to displaying the first letter of the
+ * user's name in uppercase, centered within the avatar circle.
+ *
+ * @param user An instance of the `User` class containing the user's profile data, including the
+ *   `profilePicture` URI and `name`. *
+ */
 @Composable
-fun UserIcon(text: String) {
+fun UserIcon(user: User) {
+  val profilePictureUri = user.profilePicture
   Box(
       modifier =
           Modifier.size(30.dp) // Set size for the avatar circle
               .testTag("participantAvatar")
               .background(Color.Gray, shape = RoundedCornerShape(50)), // Circular shape
       contentAlignment = Alignment.Center) {
-        Text(text = text.first().uppercaseChar().toString(), color = Color.White)
+        if (profilePictureUri != "") {
+          Image(
+              painter = rememberAsyncImagePainter(profilePictureUri),
+              contentDescription = "Profile Picture",
+              modifier = Modifier.size(30.dp).clip(RoundedCornerShape(50)).testTag("profilePic"))
+        } else {
+          Text(text = user.name.first().uppercaseChar().toString(), color = Color.White)
+        }
       }
 }
 
-@OptIn(ExperimentalLayoutApi::class)
 @Composable()
 fun UserDropdown(
     users: List<Pair<User, Boolean>>,
@@ -66,12 +85,13 @@ fun UserDropdown(
                 .testTag("expander"),
         verticalAlignment = Alignment.CenterVertically) {
           val selectedUsers = users.filter { it.second }
+          val numberOfUsers = selectedUsers.size
           if (selectedUsers.isEmpty()) {
             Text("Participants")
           }
           selectedUsers.forEach {
             Column(modifier = Modifier.padding(4.dp).align(Alignment.CenterVertically)) {
-              UserIcon(it.first.name)
+              UserIcon(it.first)
             }
           }
         }

--- a/app/src/main/java/com/android/voyageur/ui/formFields/UserDropdown.kt
+++ b/app/src/main/java/com/android/voyageur/ui/formFields/UserDropdown.kt
@@ -53,14 +53,10 @@ fun UserIcon(user: User) {
               .testTag("participantAvatar")
               .background(Color.Gray, shape = RoundedCornerShape(50)), // Circular shape
       contentAlignment = Alignment.Center) {
-        if (profilePictureUri != "") {
-          Image(
-              painter = rememberAsyncImagePainter(profilePictureUri),
-              contentDescription = "Profile Picture",
-              modifier = Modifier.size(30.dp).clip(RoundedCornerShape(50)).testTag("profilePic"))
-        } else {
-          Text(text = user.name.first().uppercaseChar().toString(), color = Color.White)
-        }
+        Image(
+            painter = rememberAsyncImagePainter(profilePictureUri),
+            contentDescription = "Profile Picture",
+            modifier = Modifier.size(30.dp).clip(RoundedCornerShape(50)).testTag("profilePic"))
       }
 }
 

--- a/app/src/main/java/com/android/voyageur/ui/overview/AddTrip.kt
+++ b/app/src/main/java/com/android/voyageur/ui/overview/AddTrip.kt
@@ -138,7 +138,6 @@ fun AddTripScreen(
       //      userList.clear()
     }
   }
-
   val _trip = tripsViewModel.selectedTrip.value
 
   fun createTripWithImage(imageUrl: String) {

--- a/app/src/main/java/com/android/voyageur/ui/overview/Overview.kt
+++ b/app/src/main/java/com/android/voyageur/ui/overview/Overview.kt
@@ -1,9 +1,7 @@
 package com.android.voyageur.ui.overview
 
 import android.annotation.SuppressLint
-import android.util.Log
 import androidx.compose.foundation.Image
-import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -21,6 +19,7 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.outlined.Add
 import androidx.compose.material3.Card
+import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.FloatingActionButton
 import androidx.compose.material3.Icon
@@ -32,6 +31,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
@@ -48,6 +48,7 @@ import com.android.voyageur.R
 import com.android.voyageur.model.trip.Trip
 import com.android.voyageur.model.trip.TripsViewModel
 import com.android.voyageur.model.user.UserViewModel
+import com.android.voyageur.ui.formFields.UserIcon
 import com.android.voyageur.ui.navigation.BottomNavigationMenu
 import com.android.voyageur.ui.navigation.LIST_TOP_LEVEL_DESTINATION
 import com.android.voyageur.ui.navigation.NavigationActions
@@ -64,17 +65,18 @@ fun OverviewScreen(
     userViewModel: UserViewModel
 ) {
   val trips by tripsViewModel.trips.collectAsState()
+  val isLoading by userViewModel.isLoading.collectAsState()
   LaunchedEffect(trips) {
-    userViewModel.getUsersByIds(
-        trips
-            .map { it.participants + (userViewModel._user.value?.contacts ?: listOf()) }
-            .flatten()
-            .toSet()
-            .toList(),
-        {
-          userViewModel._contacts.value = it
-          Log.d("USERSSS", userViewModel._contacts.value.size.toString())
-        })
+    if (trips.isNotEmpty()) {
+      userViewModel.getUsersByIds(
+          trips
+              .map { it.participants + (userViewModel._user.value?.contacts ?: listOf()) }
+              .flatten()
+              .toSet()
+              .toList()) {
+            userViewModel._contacts.value = it
+          }
+    }
   }
   Scaffold(
       floatingActionButton = {
@@ -98,35 +100,39 @@ fun OverviewScreen(
             selectedItem = navigationActions.currentRoute())
       },
       content = { pd ->
-        Column(
-            modifier = Modifier.padding(pd).testTag("overviewColumn"),
-        ) {
-          if (trips.isEmpty()) {
-            Box(
-                modifier = Modifier.padding(pd).fillMaxSize(),
-                contentAlignment = Alignment.Center) {
-                  Text(
-                      modifier = Modifier.testTag("emptyTripPrompt"),
-                      text = "You have no trips yet.",
-                  )
-                }
-          } else {
-            val sortedTrips = trips.sortedBy { trip -> trip.startDate }
-            LazyColumn(
-                verticalArrangement = Arrangement.spacedBy(10.dp, Alignment.Top),
-                horizontalAlignment = Alignment.CenterHorizontally, // Center items horizontally
-                modifier = Modifier.fillMaxSize().testTag("lazyColumn")) {
-                  sortedTrips.forEach { trip ->
-                    item {
-                      TripItem(
-                          tripsViewModel = tripsViewModel,
-                          trip = trip,
-                          navigationActions = navigationActions,
-                          userViewModel = userViewModel)
-                      Spacer(modifier = Modifier.height(10.dp))
+        if (isLoading) {
+          CircularProgressIndicator(modifier = Modifier.testTag("loadingIndicator"))
+        } else {
+          Column(
+              modifier = Modifier.padding(pd).testTag("overviewColumn"),
+          ) {
+            if (trips.isEmpty()) {
+              Box(
+                  modifier = Modifier.padding(pd).fillMaxSize(),
+                  contentAlignment = Alignment.Center) {
+                    Text(
+                        modifier = Modifier.testTag("emptyTripPrompt"),
+                        text = "You have no trips yet.",
+                    )
+                  }
+            } else {
+              val sortedTrips = trips.sortedBy { trip -> trip.startDate }
+              LazyColumn(
+                  verticalArrangement = Arrangement.spacedBy(10.dp, Alignment.Top),
+                  horizontalAlignment = Alignment.CenterHorizontally, // Center items horizontally
+                  modifier = Modifier.fillMaxSize().testTag("lazyColumn")) {
+                    sortedTrips.forEach { trip ->
+                      item {
+                        TripItem(
+                            tripsViewModel = tripsViewModel,
+                            trip = trip,
+                            navigationActions = navigationActions,
+                            userViewModel = userViewModel)
+                        Spacer(modifier = Modifier.height(10.dp))
+                      }
                     }
                   }
-                }
+            }
           }
         }
       })
@@ -139,7 +145,6 @@ fun TripItem(
     navigationActions: NavigationActions,
     userViewModel: UserViewModel
 ) {
-  // TODO: add a clickable once we implement the Schedule screens
   val dateRange = trip.startDate.toDateString() + " - " + trip.endDate.toDateString()
   val themeColor = MaterialTheme.colorScheme.onSurface
   Card(
@@ -241,26 +246,15 @@ fun DisplayParticipants(trip: Trip, userViewModel: UserViewModel) {
                 .filter { it != Firebase.auth.uid.orEmpty() }
                 .take(4)
                 .forEach { participant ->
-                  // TODO: Replace Box with user avatars once they are designed
-                  Box(
-                      modifier =
-                          Modifier.size(30.dp) // Set size for the avatar circle
-                              .testTag("participantAvatar")
-                              .background(
-                                  Color.Gray, shape = RoundedCornerShape(50)), // Circular shape
-                      contentAlignment = Alignment.Center) {
-                        userViewModel.contacts.value
-                            .find { it.id == participant }
-                            ?.name
-                            ?.first()
-                            ?.let {
-                              Text(text = it.uppercaseChar().toString(), color = Color.White)
-                            }
-                      }
+                  val user = userViewModel.contacts.value.find { it.id == participant }
+                  if (user != null) {
+                    // uses the same UserIcon function as in the participants form
+                    UserIcon(user)
+                  }
                 }
-            if (trip.participants.size > 4) {
+            if (numberOfParticipants > 4) {
               Text(
-                  text = "and ${trip.participants.size - 4} more",
+                  text = "and ${numberOfParticipants - 4} more",
                   fontSize = 8.sp,
                   color = Color.Gray,
                   modifier =


### PR DESCRIPTION
## Summary

This PR introduces improvements to the Overview Screen and to the AddParticipant screen to show the participant users' profile pictures instead of an icon which displayed their initial. If the user added to the trip has no profile picture, the icon containing their initial will be displayed. Moreover, it uses a loading screen to wait for the profile pictures to be fetched from the database.

## Changes

- **Models:** Modified the `getUsersByIds() `method to update the `_isLoading` state flow value of the userViewModel.
- **Screens/UI:** Overview and Participant form in both AddTrip and Settings screens display the profile picture of the participant users instead of an icon.
- **Bug Fixes/Improvements:** This addresses #179.

## Checklist

- [X] This PR resolves #179.
- [X] Tests have been added for new functionality.
- [X] Screenshots or UI changes have been attached.
- [X] Documentation has been updated.

##  Testing

- **Manual Testing:**
    - [X] Tested on emulator / physical device.
- **Unit Tests**
    - [X] Added units tests for this.

##  Related Issues/Tickets

Closes #179.

## Screenshots (if applicable)

<img width="300" alt="Screenshot 2024-11-19 at 17 05 03" src="https://github.com/user-attachments/assets/4a600323-08d0-45e0-b9ce-102a2bb16c97">
<img width="300" alt="Screenshot 2024-11-19 at 17 05 34" src="https://github.com/user-attachments/assets/9ae9c774-d1d9-4bfd-9bd6-127df7020851">

