### PR TITLE
feat: edit activity + tests

### DIFF
--- a/app/src/androidTest/java/com/android/voyageur/ui/trip/activities/ActivitiesScreenTest.kt
+++ b/app/src/androidTest/java/com/android/voyageur/ui/trip/activities/ActivitiesScreenTest.kt
@@ -8,6 +8,8 @@ import androidx.compose.ui.test.performClick
 import com.android.voyageur.model.activity.Activity
 import com.android.voyageur.model.activity.ActivityType
 import com.android.voyageur.model.trip.Trip
+import com.android.voyageur.model.trip.TripRepository
+import com.android.voyageur.model.trip.TripsViewModel
 import com.android.voyageur.ui.navigation.LIST_TOP_LEVEL_DESTINATION
 import com.android.voyageur.ui.navigation.NavigationActions
 import com.android.voyageur.ui.navigation.Screen
@@ -51,17 +53,21 @@ class ActivitiesScreenTest {
               ))
 
   private lateinit var navigationActions: NavigationActions
+  private lateinit var tripsViewModel: TripsViewModel
+  private lateinit var tripRepository: TripRepository
 
   @get:Rule val composeTestRule = createComposeRule()
 
   @Before
   fun setUp() {
     navigationActions = mock(NavigationActions::class.java)
+    tripRepository = mock(TripRepository::class.java)
+    tripsViewModel = TripsViewModel(tripRepository)
   }
 
   @Test
   fun hasRequiredComponents() {
-    composeTestRule.setContent { ActivitiesScreen(sampleTrip, navigationActions) }
+    composeTestRule.setContent { ActivitiesScreen(sampleTrip, navigationActions, tripsViewModel) }
     composeTestRule.onNodeWithTag("activitiesScreen").assertIsDisplayed()
     composeTestRule.onNodeWithTag("bottomNavigationMenu").assertIsDisplayed()
     composeTestRule.onNodeWithTag("createActivityButton").assertIsDisplayed()
@@ -70,7 +76,7 @@ class ActivitiesScreenTest {
 
   @Test
   fun displaysBottomNavigationCorrectly() {
-    composeTestRule.setContent { ActivitiesScreen(sampleTrip, navigationActions) }
+    composeTestRule.setContent { ActivitiesScreen(sampleTrip, navigationActions, tripsViewModel) }
 
     composeTestRule.onNodeWithTag("bottomNavigationMenu").assertIsDisplayed()
 
@@ -82,7 +88,7 @@ class ActivitiesScreenTest {
   @Test
   fun activitiesScreen_displaysDraftAndFinalSections() {
     composeTestRule.setContent {
-      ActivitiesScreen(trip = sampleTrip, navigationActions = navigationActions)
+      ActivitiesScreen(trip = sampleTrip, navigationActions = navigationActions, tripsViewModel)
     }
 
     composeTestRule.onNodeWithTag("lazyColumn").assertIsDisplayed()
@@ -92,7 +98,7 @@ class ActivitiesScreenTest {
 
   @Test
   fun clickingCreateActivityButton_navigatesToAddActivityScreen() {
-    composeTestRule.setContent { ActivitiesScreen(sampleTrip, navigationActions) }
+    composeTestRule.setContent { ActivitiesScreen(sampleTrip, navigationActions, tripsViewModel) }
 
     composeTestRule.onNodeWithTag("createActivityButton").performClick()
 
@@ -101,7 +107,7 @@ class ActivitiesScreenTest {
 
   @Test
   fun activitiesScreen_displaysActivityItems() {
-    composeTestRule.setContent { ActivitiesScreen(sampleTrip, navigationActions) }
+    composeTestRule.setContent { ActivitiesScreen(sampleTrip, navigationActions, tripsViewModel) }
 
     composeTestRule.onNodeWithTag("cardItem_${sampleTrip.activities[0].title}").assertIsDisplayed()
     composeTestRule.onNodeWithTag("cardItem_${sampleTrip.activities[1].title}").assertIsDisplayed()

--- a/app/src/androidTest/java/com/android/voyageur/ui/trip/activities/ActivitiesScreenTest.kt
+++ b/app/src/androidTest/java/com/android/voyageur/ui/trip/activities/ActivitiesScreenTest.kt
@@ -76,7 +76,9 @@ class ActivitiesScreenTest {
 
   @Test
   fun hasRequiredComponents() {
-    composeTestRule.setContent { ActivitiesScreen(sampleTrip, navigationActions, userViewModel, tripsViewModel) }
+    composeTestRule.setContent {
+      ActivitiesScreen(sampleTrip, navigationActions, userViewModel, tripsViewModel)
+    }
     composeTestRule.onNodeWithTag("activitiesScreen").assertIsDisplayed()
     composeTestRule.onNodeWithTag("bottomNavigationMenu").assertIsDisplayed()
     composeTestRule.onNodeWithTag("createActivityButton").assertIsDisplayed()
@@ -85,7 +87,9 @@ class ActivitiesScreenTest {
 
   @Test
   fun displaysBottomNavigationCorrectly() {
-    composeTestRule.setContent { ActivitiesScreen(sampleTrip, navigationActions, userViewModel, tripsViewModel) }
+    composeTestRule.setContent {
+      ActivitiesScreen(sampleTrip, navigationActions, userViewModel, tripsViewModel)
+    }
 
     composeTestRule.onNodeWithTag("bottomNavigationMenu").assertIsDisplayed()
 
@@ -97,7 +101,8 @@ class ActivitiesScreenTest {
   @Test
   fun activitiesScreen_displaysDraftAndFinalSections() {
     composeTestRule.setContent {
-      ActivitiesScreen(trip = sampleTrip, navigationActions = navigationActions, userViewModel, tripsViewModel)
+      ActivitiesScreen(
+          trip = sampleTrip, navigationActions = navigationActions, userViewModel, tripsViewModel)
     }
 
     composeTestRule.onNodeWithTag("lazyColumn").assertIsDisplayed()
@@ -107,7 +112,9 @@ class ActivitiesScreenTest {
 
   @Test
   fun clickingCreateActivityButton_navigatesToAddActivityScreen() {
-    composeTestRule.setContent { ActivitiesScreen(sampleTrip, navigationActions, userViewModel, tripsViewModel) }
+    composeTestRule.setContent {
+      ActivitiesScreen(sampleTrip, navigationActions, userViewModel, tripsViewModel)
+    }
 
     composeTestRule.onNodeWithTag("createActivityButton").performClick()
 
@@ -116,7 +123,9 @@ class ActivitiesScreenTest {
 
   @Test
   fun activitiesScreen_displaysActivityItems() {
-    composeTestRule.setContent { ActivitiesScreen(sampleTrip, navigationActions, userViewModel, tripsViewModel) }
+    composeTestRule.setContent {
+      ActivitiesScreen(sampleTrip, navigationActions, userViewModel, tripsViewModel)
+    }
 
     composeTestRule.onNodeWithTag("cardItem_${sampleTrip.activities[0].title}").assertIsDisplayed()
     composeTestRule.onNodeWithTag("cardItem_${sampleTrip.activities[1].title}").assertIsDisplayed()

--- a/app/src/androidTest/java/com/android/voyageur/ui/trip/activities/ActivityItemTest.kt
+++ b/app/src/androidTest/java/com/android/voyageur/ui/trip/activities/ActivityItemTest.kt
@@ -8,8 +8,13 @@ import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
 import com.android.voyageur.model.activity.Activity
 import com.android.voyageur.model.activity.ActivityType
+import com.android.voyageur.model.trip.TripRepository
+import com.android.voyageur.model.trip.TripsViewModel
+import com.android.voyageur.ui.navigation.NavigationActions
+import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
+import org.mockito.Mockito.mock
 
 class ActivityItemTest {
   private val sampleActivityWithoutDescription =
@@ -28,12 +33,25 @@ class ActivityItemTest {
           estimatedPrice = 20.0,
           activityType = ActivityType.RESTAURANT)
 
+  private lateinit var tripRepository: TripRepository
+  private lateinit var navigationActions: NavigationActions
+  private lateinit var tripsViewModel: TripsViewModel
+
   @get:Rule val composeTestRule = createComposeRule()
+
+  @Before
+  fun setUp() {
+    tripRepository = mock(TripRepository::class.java)
+    navigationActions = mock(NavigationActions::class.java)
+    tripsViewModel = TripsViewModel(tripRepository)
+  }
 
   @Test
   fun activityItem_expandAndCollapse() {
 
-    composeTestRule.setContent { ActivityItem(sampleActivityWithDescription) }
+    composeTestRule.setContent {
+      ActivityItem(sampleActivityWithDescription, navigationActions, tripsViewModel)
+    }
 
     composeTestRule.onNodeWithText("Price").assertIsNotDisplayed()
     composeTestRule.onNodeWithText("Type").assertIsNotDisplayed()
@@ -53,7 +71,9 @@ class ActivityItemTest {
 
   @Test
   fun activityCard_displaysCorrectTitle() {
-    composeTestRule.setContent { ActivityItem(sampleActivityWithDescription) }
+    composeTestRule.setContent {
+      ActivityItem(sampleActivityWithDescription, navigationActions, tripsViewModel)
+    }
 
     composeTestRule
         .onNodeWithTag("cardItem_${sampleActivityWithDescription.title}")
@@ -64,7 +84,9 @@ class ActivityItemTest {
   @Test
   fun activityCard_displaysCorrectDescription() {
 
-    composeTestRule.setContent { ActivityItem(sampleActivityWithDescription) }
+    composeTestRule.setContent {
+      ActivityItem(sampleActivityWithDescription, navigationActions, tripsViewModel)
+    }
     composeTestRule
         .onNodeWithTag("expandIcon_${sampleActivityWithDescription.title}")
         .assertIsDisplayed()
@@ -78,7 +100,9 @@ class ActivityItemTest {
   @Test
   fun activityCard_doesNotDisplayDescription() {
 
-    composeTestRule.setContent { ActivityItem(sampleActivityWithoutDescription) }
+    composeTestRule.setContent {
+      ActivityItem(sampleActivityWithoutDescription, navigationActions, tripsViewModel)
+    }
     composeTestRule
         .onNodeWithTag("expandIcon_${sampleActivityWithoutDescription.title}")
         .assertIsDisplayed()
@@ -94,7 +118,9 @@ class ActivityItemTest {
   @Test
   fun activityCard_displaysCorrectDateAndTime() {
 
-    composeTestRule.setContent { ActivityItem(sampleActivityWithDescription) }
+    composeTestRule.setContent {
+      ActivityItem(sampleActivityWithDescription, navigationActions, tripsViewModel)
+    }
 
     composeTestRule
         .onNodeWithTag("cardItem_${sampleActivityWithDescription.title}")

--- a/app/src/main/java/com/android/voyageur/App.kt
+++ b/app/src/main/java/com/android/voyageur/App.kt
@@ -23,6 +23,7 @@ import com.android.voyageur.ui.search.SearchUserProfileScreen
 import com.android.voyageur.ui.trip.AddActivityScreen
 import com.android.voyageur.ui.trip.TopTabs
 import com.android.voyageur.ui.trip.activities.ActivitiesForOneDayScreen
+import com.android.voyageur.ui.trip.activities.EditActivityScreen
 import com.google.android.libraries.places.api.net.PlacesClient
 
 @Composable
@@ -78,6 +79,7 @@ fun VoyageurApp(placesClient: PlacesClient) {
       composable(Screen.ACTIVITIES_FOR_ONE_DAY) {
         ActivitiesForOneDayScreen(tripsViewModel, navigationActions)
       }
+      composable(Screen.EDIT_ACTIVITY) { EditActivityScreen(navigationActions, tripsViewModel) }
     }
   }
 }

--- a/app/src/main/java/com/android/voyageur/model/trip/TripsViewModel.kt
+++ b/app/src/main/java/com/android/voyageur/model/trip/TripsViewModel.kt
@@ -4,6 +4,7 @@ import android.net.Uri
 import android.util.Log
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
+import com.android.voyageur.model.activity.Activity
 import com.google.firebase.Firebase
 import com.google.firebase.auth.auth
 import com.google.firebase.firestore.firestore
@@ -27,6 +28,9 @@ open class TripsViewModel(
   // useful for displaying the activities for one day:
   private val _selectedDay = MutableStateFlow<LocalDate?>(null)
   open val selectedDay: StateFlow<LocalDate?> = _selectedDay.asStateFlow()
+
+  private val _selectedActivity = MutableStateFlow<Activity?>(null)
+  open val selectedActivity: StateFlow<Activity?> = _selectedActivity.asStateFlow()
 
   init {
     tripsRepository.init {
@@ -57,6 +61,10 @@ open class TripsViewModel(
 
   fun selectDay(day: LocalDate) {
     _selectedDay.value = day
+  }
+
+  fun selectActivity(activity: Activity) {
+    _selectedActivity.value = activity
   }
 
   fun getNewTripId(): String = tripsRepository.getNewTripId()

--- a/app/src/main/java/com/android/voyageur/ui/formFields/DatePicker.kt
+++ b/app/src/main/java/com/android/voyageur/ui/formFields/DatePicker.kt
@@ -7,6 +7,8 @@ import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.material3.rememberDatePickerState
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -24,7 +26,8 @@ fun DatePickerModal(
             onClick = {
               onDateSelected(datePickerState.selectedDateMillis)
               onDismiss()
-            }) {
+            },
+            modifier = Modifier.testTag("datePickerModal")) {
               Text("OK")
             }
       },

--- a/app/src/main/java/com/android/voyageur/ui/formFields/TimePicker.kt
+++ b/app/src/main/java/com/android/voyageur/ui/formFields/TimePicker.kt
@@ -15,6 +15,7 @@ import androidx.compose.material3.rememberTimePickerState
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Dialog
@@ -39,7 +40,7 @@ fun TimePickerInput(
     Surface(
         shape = MaterialTheme.shapes.extraLarge,
         tonalElevation = 10.dp,
-        modifier = Modifier.padding(16.dp)) {
+        modifier = Modifier.padding(16.dp).testTag("timePickerDialog")) {
           Column(
               modifier = Modifier.padding(16.dp),
               horizontalAlignment = Alignment.CenterHorizontally,

--- a/app/src/main/java/com/android/voyageur/ui/navigation/NavigationActions.kt
+++ b/app/src/main/java/com/android/voyageur/ui/navigation/NavigationActions.kt
@@ -21,6 +21,7 @@ object Route {
   const val AUTH = "Auth"
   const val TOP_TABS = "TopTabs"
   const val SEARCH_USER_PROFILE = "Search User Profile Screen"
+  const val ACTIVITIES_FOR_ONE_DAY = "Activities For One Day Screen"
 }
 
 object Screen {
@@ -35,6 +36,7 @@ object Screen {
   const val ACTIVITIES_FOR_ONE_DAY = "Activities For One Day Screen"
   const val SEARCH_USER_PROFILE = "Search User Profile Screen"
   const val PLACE_DETAILS = "Place Details Screen"
+  const val EDIT_ACTIVITY = "Edit Activity Screen"
 }
 
 data class TopLevelDestination(

--- a/app/src/main/java/com/android/voyageur/ui/trip/AddActivity.kt
+++ b/app/src/main/java/com/android/voyageur/ui/trip/AddActivity.kt
@@ -49,12 +49,23 @@ fun AddActivityScreen(
   var location by remember { mutableStateOf(existingActivity?.location?.city ?: "") }
   var showModal by remember { mutableStateOf(false) }
   var activityDate by remember {
-    mutableStateOf<Long?>(existingActivity?.startTime?.toDate()?.time)
+    mutableStateOf<Long?>(existingActivity?.startTime?.toDate()?.time.takeIf { it != 0L })
   }
   var showTime by remember { mutableStateOf(false) }
   var selectedTimeField by remember { mutableStateOf<TimeField?>(null) }
-  var startTime by remember { mutableStateOf<Long?>(existingActivity?.startTime?.toDate()?.time) }
-  var endTime by remember { mutableStateOf<Long?>(existingActivity?.endTime?.toDate()?.time) }
+  var startTime by remember {
+    mutableStateOf<Long?>(
+        if (existingActivity?.startTime?.toDate()?.time != 0L && activityDate != null)
+            existingActivity?.startTime?.toDate()?.time
+        else null)
+  }
+  var endTime by remember {
+    mutableStateOf<Long?>(
+        if (existingActivity?.endTime?.toDate()?.time != 0L && activityDate != null)
+            existingActivity?.endTime?.toDate()?.time
+        else null)
+  }
+
   var priceInput by remember { mutableStateOf(existingActivity?.estimatedPrice?.toString() ?: "") }
   var estimatedPrice by remember {
     mutableStateOf<Double?>(existingActivity?.estimatedPrice ?: 0.0)
@@ -71,7 +82,8 @@ fun AddActivityScreen(
 
   val timeFormat = SimpleDateFormat("HH:mm", Locale.getDefault())
   var formattedStartTime = startTime?.let { timeFormat.format(Date(it)) } ?: ""
-  var formattedEndTime = endTime?.let { timeFormat.format(Date(it)) } ?: ""
+  var formattedEndTime =
+      if (endTime != null && activityDate != null) timeFormat.format(Date(endTime!!)) else ""
 
   val keyboardController = LocalSoftwareKeyboardController.current
 

--- a/app/src/main/java/com/android/voyageur/ui/trip/Tabs.kt
+++ b/app/src/main/java/com/android/voyageur/ui/trip/Tabs.kt
@@ -68,7 +68,7 @@ fun TopTabs(
     // Display content based on selected tab
     when (navigationActions.getNavigationState().currentTabIndexForTrip) {
       0 -> ScheduleScreen(tripsViewModel, selectedTrip, navigationActions)
-      1 -> ActivitiesScreen(selectedTrip, navigationActions)
+      1 -> ActivitiesScreen(selectedTrip, navigationActions, tripsViewModel)
       2 ->
           SettingsScreen(
               selectedTrip,

--- a/app/src/main/java/com/android/voyageur/ui/trip/activities/Activities.kt
+++ b/app/src/main/java/com/android/voyageur/ui/trip/activities/Activities.kt
@@ -23,6 +23,7 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.android.voyageur.model.trip.Trip
+import com.android.voyageur.model.trip.TripsViewModel
 import com.android.voyageur.ui.navigation.BottomNavigationMenu
 import com.android.voyageur.ui.navigation.LIST_TOP_LEVEL_DESTINATION
 import com.android.voyageur.ui.navigation.NavigationActions
@@ -34,6 +35,7 @@ import com.google.firebase.Timestamp
 fun ActivitiesScreen(
     trip: Trip,
     navigationActions: NavigationActions,
+    tripsViewModel: TripsViewModel
 ) {
 
   val drafts =
@@ -76,7 +78,7 @@ fun ActivitiesScreen(
           }
           drafts.forEach { activity ->
             item {
-              ActivityItem(activity)
+              ActivityItem(activity, navigationActions, tripsViewModel)
               Spacer(modifier = Modifier.height(10.dp))
             }
           }
@@ -89,7 +91,7 @@ fun ActivitiesScreen(
           }
           final.forEach { activity ->
             item {
-              ActivityItem(activity)
+              ActivityItem(activity, navigationActions, tripsViewModel)
               Spacer(modifier = Modifier.height(10.dp))
             }
           }

--- a/app/src/main/java/com/android/voyageur/ui/trip/activities/ActivitiesForOneDay.kt
+++ b/app/src/main/java/com/android/voyageur/ui/trip/activities/ActivitiesForOneDay.kt
@@ -74,7 +74,7 @@ fun ActivitiesForOneDayScreen(
           ) {
             activities.forEach { activity ->
               item {
-                ActivityItem(activity)
+                ActivityItem(activity, navigationActions, tripsViewModel)
                 Spacer(modifier = Modifier.height(10.dp))
               }
             }

--- a/app/src/main/java/com/android/voyageur/ui/trip/activities/ActivityItem.kt
+++ b/app/src/main/java/com/android/voyageur/ui/trip/activities/ActivityItem.kt
@@ -103,16 +103,10 @@ fun ActivityItem(
                           onClick = {
                             navigationActions.navigateTo(Screen.EDIT_ACTIVITY)
                             tripsViewModel.selectActivity(activity)
-                            //                              Toast.makeText(
-                            //                                  context,
-                            //                                  "Edit activity not implemented yet",
-                            //                                  Toast.LENGTH_SHORT)
-                            //                                  .show()
                           }) {
                             Icon(
                                 imageVector = Icons.TwoTone.Edit,
-                                contentDescription = "Edit Activity",
-                                tint = Color.Green)
+                                contentDescription = "Edit Activity")
                           }
                       IconButton(
                           onClick = { /*TODO: delete activity*/

--- a/app/src/main/java/com/android/voyageur/ui/trip/activities/ActivityItem.kt
+++ b/app/src/main/java/com/android/voyageur/ui/trip/activities/ActivityItem.kt
@@ -12,6 +12,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.ArrowDropDown
 import androidx.compose.material.icons.twotone.Delete
+import androidx.compose.material.icons.twotone.Edit
 import androidx.compose.material3.Card
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
@@ -35,6 +36,9 @@ import com.android.voyageur.model.activity.Activity
 import com.android.voyageur.model.activity.hasDescription
 import com.android.voyageur.model.activity.hasEndDate
 import com.android.voyageur.model.activity.hasStartTime
+import com.android.voyageur.model.trip.TripsViewModel
+import com.android.voyageur.ui.navigation.NavigationActions
+import com.android.voyageur.ui.navigation.Screen
 import java.time.ZoneId
 import java.time.format.DateTimeFormatter
 import java.util.Locale
@@ -47,6 +51,8 @@ import java.util.Locale
 @Composable
 fun ActivityItem(
     activity: Activity,
+    navigationActions: NavigationActions,
+    tripsViewModel: TripsViewModel
 ) {
   var isExpanded by remember { mutableStateOf(false) }
 
@@ -90,21 +96,38 @@ fun ActivityItem(
                 }
 
                 Row(verticalAlignment = Alignment.CenterVertically) {
-                  // Delete icon, visible only when expanded
+                  // Edit and Delete icons, visible only when expanded
                   AnimatedVisibility(visible = isExpanded) {
-                    IconButton(
-                        onClick = { /*TODO: delete activity*/
-                          Toast.makeText(
-                                  context,
-                                  "Delete activity not implemented yet",
-                                  Toast.LENGTH_SHORT)
-                              .show()
-                        }) {
-                          Icon(
-                              imageVector = Icons.TwoTone.Delete,
-                              contentDescription = "Delete Activity",
-                              tint = Color.Red)
-                        }
+                    Row {
+                      IconButton(
+                          onClick = {
+                            navigationActions.navigateTo(Screen.EDIT_ACTIVITY)
+                            tripsViewModel.selectActivity(activity)
+                            //                              Toast.makeText(
+                            //                                  context,
+                            //                                  "Edit activity not implemented yet",
+                            //                                  Toast.LENGTH_SHORT)
+                            //                                  .show()
+                          }) {
+                            Icon(
+                                imageVector = Icons.TwoTone.Edit,
+                                contentDescription = "Edit Activity",
+                                tint = Color.Green)
+                          }
+                      IconButton(
+                          onClick = { /*TODO: delete activity*/
+                            Toast.makeText(
+                                    context,
+                                    "Delete activity not implemented yet",
+                                    Toast.LENGTH_SHORT)
+                                .show()
+                          }) {
+                            Icon(
+                                imageVector = Icons.TwoTone.Delete,
+                                contentDescription = "Delete Activity",
+                                tint = Color.Red)
+                          }
+                    }
                   }
 
                   // Expand/collapse icon

--- a/app/src/main/java/com/android/voyageur/ui/trip/activities/EditActivity.kt
+++ b/app/src/main/java/com/android/voyageur/ui/trip/activities/EditActivity.kt
@@ -1,0 +1,32 @@
+package com.android.voyageur.ui.trip.activities
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Scaffold
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
+import com.android.voyageur.model.trip.TripsViewModel
+import com.android.voyageur.ui.navigation.NavigationActions
+import com.android.voyageur.ui.trip.AddActivityScreen
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun EditActivityScreen(
+    navigationActions: NavigationActions,
+    tripsViewModel: TripsViewModel,
+) {
+  val activity by tripsViewModel.selectedActivity.collectAsState()
+  val selectedActivity = activity!!
+
+  Scaffold(
+      modifier = Modifier.testTag("editActivityScreen"),
+      content = { pd ->
+        Box(modifier = Modifier.padding(pd)) {
+          AddActivityScreen(tripsViewModel, navigationActions, existingActivity = selectedActivity)
+        }
+      })
+}


### PR DESCRIPTION
## Summary

This PR introduces the feature of editing an existing activity. For each activity item, I added an edit button near the delete button which leads the user to editing the activity. The edit activity screen calls the add activity screen with an extra parameter, the already existing activity and makes the required changes.

I will attach a screen recording which presents the behavior.

## Changes

- **Models:** Added tripsViewModel and navigationActions as parameters to all the activity related screens/methods
- **Screens/UI:** The edit activity screen calls the add activity screen with the fields already completed
- **Bug Fixes/Improvements:** Addresses #185 .

## Checklist

Ensure all / most of these are checked before the pull request is submitted.
- [x] This PR resolves #185.
- [x] Tests have been added for new functionality.
- [x] Screenshots or UI changes have been attached (if applicable).
- [x] Documentation has been updated (if applicable).

##  Testing

Explain how this feature was tested and what kind of testing (unit, integration, UI) has been done. Mention platforms or configurations used for testing.
- **Manual Testing:**
    - [x] Tested on emulator / physical device.
- **Unit Tests**
    - [x] Added units tests for this

If you haven't added tests, please create a new issue and assign it.

##  Related Issues/Tickets

Closes #185 

## Screenshots (if applicable)


https://github.com/user-attachments/assets/c29f2c67-731a-4c49-ad5c-602fe7a66508



## 💡 Additional Context

- we need to decide for when editing a trip or an activity how we'll address the dates(i.e. if the date is now in the past the trip/activity can't be saved now)
