### PR TITLE
allow editing ongoing trip

### DIFF
--- a/app/src/main/java/com/android/voyageur/ui/overview/AddTrip.kt
+++ b/app/src/main/java/com/android/voyageur/ui/overview/AddTrip.kt
@@ -165,9 +165,15 @@ fun AddTripScreen(
     val startDateNormalized = normalizeToMidnight(Date(startDate!!))
     val endDateNormalized = normalizeToMidnight(Date(endDate!!))
 
-    if (startDateNormalized.before(today) || endDateNormalized.before(today)) {
+    if (!isEditMode && (startDateNormalized.before(today) || endDateNormalized.before(today))) {
       Toast.makeText(context, "Start and end dates cannot be in the past", Toast.LENGTH_SHORT)
           .show()
+      return
+    }
+    // if the trip is ongoing then the start date is in the past already so we check just for the
+    // end date
+    if (isEditMode && endDateNormalized.before(today)) {
+      Toast.makeText(context, "End date cannot be in the past", Toast.LENGTH_SHORT).show()
       return
     }
     if (startDateNormalized.after(endDateNormalized)) {


### PR DESCRIPTION
## Summary

When editing an ongoing trip, you couldn't save it because the start date was in the past. I fixed the behavior so that when editing a trip, you could save it with a start date in the past.

## Changes

- **Models:** AddTripScreen
- **Bug Fixes/Improvements:** Addresses #197 

## Checklist

Ensure all / most of these are checked before the pull request is submitted.
- [x] This PR resolves #197 .
- [ ] Tests have been added for new functionality.
- [ ] Screenshots or UI changes have been attached (if applicable).
- [x] Documentation has been updated (if applicable).

##  Testing

Explain how this feature was tested and what kind of testing (unit, integration, UI) has been done. Mention platforms or configurations used for testing.
- **Manual Testing:**
    - [x] Tested on emulator / physical device.
- **Unit Tests**
    - [ ] Added units tests for this

If you haven't added tests, please create a new issue and assign it.

##  Related Issues/Tickets

Closes #197 
