### PR TITLE
Fix/places api efficient fetching

### DIFF
--- a/app/src/main/java/com/android/voyageur/model/place/GooglePlacesRepository.kt
+++ b/app/src/main/java/com/android/voyageur/model/place/GooglePlacesRepository.kt
@@ -20,18 +20,17 @@ import kotlin.math.cos
  * @property placesClient The PlacesClient used to make API requests.
  */
 class GooglePlacesRepository(private val placesClient: PlacesClient) : PlacesRepository {
-  private val placeFields =
+  private val freePlaceFields =
+      listOf(Place.Field.ID, Place.Field.DISPLAY_NAME, Place.Field.ADDRESS, Place.Field.LAT_LNG)
+
+  private val advancedPlaceFields =
       listOf(
-          Place.Field.ID,
-          Place.Field.DISPLAY_NAME,
-          Place.Field.ADDRESS,
           Place.Field.PHOTO_METADATAS,
           Place.Field.INTERNATIONAL_PHONE_NUMBER,
           Place.Field.WEBSITE_URI,
           Place.Field.OPENING_HOURS,
           Place.Field.RATING,
           Place.Field.USER_RATINGS_TOTAL,
-          Place.Field.LAT_LNG,
           Place.Field.WEBSITE_URI,
           Place.Field.PRICE_LEVEL)
 
@@ -98,7 +97,7 @@ class GooglePlacesRepository(private val placesClient: PlacesClient) : PlacesRep
    * @param onSuccess Callback invoked with the list of detailed places.
    * @param onFailure Callback invoked with an exception if the fetch fails.
    */
-  fun fetchPlaceDetails(
+  private fun fetchPlaceDetails(
       placeIds: List<String>,
       onSuccess: (List<CustomPlace>) -> Unit,
       onFailure: (Exception) -> Unit
@@ -108,28 +107,13 @@ class GooglePlacesRepository(private val placesClient: PlacesClient) : PlacesRep
 
     // Define which fields to retrieve for each place
     placeIds.forEach { placeId ->
-      val request = FetchPlaceRequest.builder(placeId, placeFields).build()
+      val request = FetchPlaceRequest.builder(placeId, freePlaceFields).build()
       placesClient
           .fetchPlace(request)
           .addOnSuccessListener { response ->
             val place = response.place
-            val bitmaps = mutableListOf<ImageBitmap>()
-
-            val photosMetadata = ((place.photoMetadatas) ?: emptyList<PhotoMetadata>()).take(5)
-            for (photoMetadata in photosMetadata) {
-              val photoRequest = FetchPhotoRequest.builder(photoMetadata).build()
-              placesClient
-                  .fetchPhoto(photoRequest)
-                  .addOnSuccessListener { fetchPhotoResponse ->
-                    val bitmap = fetchPhotoResponse.bitmap.asImageBitmap()
-                    bitmaps.add(bitmap)
-                  }
-                  .addOnFailureListener { exception ->
-                    Log.e("PlacesRepository", "Failed to fetch photo for $placeId", exception)
-                  }
-            }
+            val bitmaps = emptyList<ImageBitmap>()
             places.add(CustomPlace(place, bitmaps))
-
             if (places.size + failedRequests == placeIds.size) {
               onSuccess(places)
             }
@@ -141,5 +125,42 @@ class GooglePlacesRepository(private val placesClient: PlacesClient) : PlacesRep
             }
           }
     }
+  }
+
+  /**
+   * Fetches advanced details for a place.
+   *
+   * @param placeId The ID of the place to fetch details for.
+   * @param onSuccess Callback invoked with the detailed place.
+   * @param onFailure Callback invoked with an exception if the fetch fails.
+   */
+  override fun fetchAdvancedDetails(
+      placeId: String,
+      onSuccess: (CustomPlace) -> Unit,
+      onFailure: (Exception) -> Unit
+  ) {
+    val request = FetchPlaceRequest.builder(placeId, advancedPlaceFields).build()
+    placesClient
+        .fetchPlace(request)
+        .addOnSuccessListener { response ->
+          val place = response.place
+          val bitmaps = mutableListOf<ImageBitmap>()
+
+          val photosMetadata = ((place.photoMetadatas) ?: emptyList<PhotoMetadata>()).take(5)
+          for (photoMetadata in photosMetadata) {
+            val photoRequest = FetchPhotoRequest.builder(photoMetadata).build()
+            placesClient
+                .fetchPhoto(photoRequest)
+                .addOnSuccessListener { fetchPhotoResponse ->
+                  val bitmap = fetchPhotoResponse.bitmap.asImageBitmap()
+                  bitmaps.add(bitmap)
+                }
+                .addOnFailureListener { exception ->
+                  Log.e("PlacesRepository", "Failed to fetch photo for $placeId", exception)
+                }
+          }
+          onSuccess(CustomPlace(place, bitmaps))
+        }
+        .addOnFailureListener { exception -> onFailure(exception) }
   }
 }

--- a/app/src/main/java/com/android/voyageur/model/place/PlacesRepository.kt
+++ b/app/src/main/java/com/android/voyageur/model/place/PlacesRepository.kt
@@ -9,4 +9,10 @@ interface PlacesRepository {
       onSuccess: (List<CustomPlace>) -> Unit,
       onFailure: (Exception) -> Unit
   )
+
+  fun fetchAdvancedDetails(
+      placeId: String,
+      onSuccess: (CustomPlace) -> Unit,
+      onFailure: (Exception) -> Unit
+  )
 }

--- a/app/src/main/java/com/android/voyageur/model/place/PlacesViewModel.kt
+++ b/app/src/main/java/com/android/voyageur/model/place/PlacesViewModel.kt
@@ -69,6 +69,16 @@ open class PlacesViewModel(private val placesRepository: PlacesRepository) : Vie
    */
   fun selectPlace(place: CustomPlace) {
     _selectedPlace.value = place
+    selectedPlace.value?.let {
+      place.place.id?.let { it1 ->
+        placesRepository.fetchAdvancedDetails(
+            it1,
+            onSuccess = { place -> _selectedPlace.value = place },
+            onFailure = { exception ->
+              Log.e("PlacesViewModel", "Failed to fetch place details", exception)
+            })
+      }
+    }
   }
 
   /** Deselects the currently selected place. */

--- a/app/src/main/java/com/android/voyageur/ui/search/SearchScreen.kt
+++ b/app/src/main/java/com/android/voyageur/ui/search/SearchScreen.kt
@@ -497,31 +497,10 @@ fun PlaceSearchResultItem(customPlace: CustomPlace, modifier: Modifier = Modifie
               color = MaterialTheme.colorScheme.onSurface)
 
           Spacer(modifier = Modifier.height(4.dp))
-          // Rating and review count
 
-          Row(verticalAlignment = Alignment.CenterVertically) {
-            if (place.rating != null) {
-              Text(
-                  text = "${place.rating} ",
-                  fontSize = 14.sp,
-                  color = MaterialTheme.colorScheme.onSurface)
-              Text(
-                  text = "★".repeat(place.rating.toInt()),
-                  fontSize = 14.sp,
-                  color = Color(0xFFFFA000) // Keep stars orange for visibility in both themes
-                  )
-              Text(
-                  text = " (${place.userRatingsTotal})",
-                  fontSize = 14.sp,
-                  color = MaterialTheme.colorScheme.onSurfaceVariant)
-            }
-          }
-
-          Spacer(modifier = Modifier.height(4.dp))
-
-          // Price level, type, and address
+          // Address
           Text(
-              text = "${"$".repeat(place.priceLevel ?: 1)} · ${place.address ?: "No address"}",
+              text = "· ${place.address ?: "No address"} ·",
               fontSize = 14.sp,
               color = MaterialTheme.colorScheme.onSurfaceVariant)
         }

--- a/app/src/test/java/com/android/voyageur/model/place/GooglePlacesRepositoryTest.kt
+++ b/app/src/test/java/com/android/voyageur/model/place/GooglePlacesRepositoryTest.kt
@@ -127,16 +127,16 @@ class GooglePlacesRepositoryTest {
     `when`(mockFetchPlaceResponse.place).thenReturn(mockPlace)
     `when`(mockPlace.id).thenReturn(placeId)
     `when`(mockFetchPlaceTask.addOnSuccessListener(any())).thenAnswer { invocation ->
-        val listener = invocation.arguments[0] as OnSuccessListener<FetchPlaceResponse>
-        listener.onSuccess(mockFetchPlaceResponse)
-        mockFetchPlaceTask
+      val listener = invocation.arguments[0] as OnSuccessListener<FetchPlaceResponse>
+      listener.onSuccess(mockFetchPlaceResponse)
+      mockFetchPlaceTask
     }
 
     `when`(mockPlacesClient.fetchPhoto(any())).thenReturn(mockFetchPhotoTask)
     `when`(mockFetchPhotoTask.addOnSuccessListener(any())).thenAnswer { invocation ->
-        val listener = invocation.arguments[0] as OnSuccessListener<FetchPhotoResponse>
-        listener.onSuccess(mockFetchPhotoResponse)
-        mockFetchPhotoTask
+      val listener = invocation.arguments[0] as OnSuccessListener<FetchPhotoResponse>
+      listener.onSuccess(mockFetchPhotoResponse)
+      mockFetchPhotoTask
     }
     `when`(mockPlace.photoMetadatas).thenReturn(listOf(mockPhotoMetadata))
 

--- a/app/src/test/java/com/android/voyageur/model/place/PlacesViewModelTest.kt
+++ b/app/src/test/java/com/android/voyageur/model/place/PlacesViewModelTest.kt
@@ -73,4 +73,13 @@ class PlacesViewModelTest {
     placesViewModel.deselectPlace()
     assert(placesViewModel.selectedPlace.value == null)
   }
+
+  @Test
+  fun testSelectPlaceFetchesDetails() {
+    val place = mock(Place::class.java)
+    `when`(place.id).thenReturn("test")
+    val customPlace = CustomPlace(place = place, photos = emptyList())
+    placesViewModel.selectPlace(customPlace)
+    verify(placesRepository).fetchAdvancedDetails(eq(place.id), any(), any())
+  }
 }


### PR DESCRIPTION
## Summary

This PR solves an issue concerning high api costs due to testing after M2 deliverable. To solve that, in the userSearch we only display details that can be fetched for free and when the users clicks on a certain place the rest of the details will be fetched, this will allow us to not exceed the free credits for the api and the usage will not cost.

## Changes

- **Models:** In the PlacesViewModel when selecting an element we fetch the remaining details.
- **Repositories:** Added a new fetchAdvancedDetails function in the PlacesRepository interface (its implementation is in the GooglePlacesRepositoryFile).

## Checklist

- [x] This PR resolves #194.
- [x] Tests have been added for new functionality.
- [x] Documentation has been updated.

##  Testing

- **Manual Testing:**
    - [x] Tested on emulator / physical device.
- **Unit Tests**
    - [x] Added units tests for this

##  Related Issues/Tickets

Closes #194 
Opened #202 to inform user when fetching for the rest of the details 


## 💡 Additional Context

Add any other context or details you think reviewers should know about.
