### PR TITLE
Feat: gemini first version

### DIFF
--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -81,6 +81,12 @@ jobs:
           PLACES_API_KEY: ${{ secrets.PLACES_API_KEY }}
         run: echo "PLACES_API_KEY=\${{ secrets.PLACES_API_KEY }}" > ./local.properties
 
+      # Set the API key for the Gemini API
+      - name: Access GEMINI_API_KEY
+        env:
+          GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
+        run: echo "GEMINI_API_KEY=\${{ secrets.GEMINI_API_KEY }}" > ./local.properties
+
       - name: Grant execute permission for gradlew
         run: |
           chmod +x ./gradlew

--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -85,7 +85,7 @@ jobs:
       - name: Access GEMINI_API_KEY
         env:
           GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
-        run: echo "GEMINI_API_KEY=\${{ secrets.GEMINI_API_KEY }}" > ./local.properties
+        run: echo "GEMINI_API_KEY=\${{ secrets.GEMINI_API_KEY }}" >> ./local.properties
 
       - name: Grant execute permission for gradlew
         run: |

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -62,7 +62,7 @@ jobs:
       - name: Access GEMINI_API_KEY
         env:
           GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
-        run: echo "GEMINI_API_KEY=\${{ secrets.GEMINI_API_KEY }}" > ./local.properties
+        run: echo "GEMINI_API_KEY=\${{ secrets.GEMINI_API_KEY }}" >> ./local.properties
 
       - name: Build APK
         run: |

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -59,6 +59,11 @@ jobs:
           MAPS_API_KEY: $ {{ secrets.PLACES_API_KEY }}
         run: echo "PLACES_API_KEY=\${{ secrets.PLACES_API_KEY }}" > ./local.properties
 
+      - name: Access GEMINI_API_KEY
+        env:
+          GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
+        run: echo "GEMINI_API_KEY=\${{ secrets.GEMINI_API_KEY }}" > ./local.properties
+
       - name: Build APK
         run: |
           ./gradlew build assemble

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -23,6 +23,7 @@ android {
     }
 
     val placesApiKey = localProperties.getProperty("PLACES_API_KEY") ?: ""
+    val geminiApiKey = localProperties.getProperty("GEMINI_API_KEY") ?: ""
 
     defaultConfig {
         applicationId = "com.android.voyageur"
@@ -31,6 +32,7 @@ android {
         versionCode = 1
         versionName = "1.0"
         buildConfigField ("String", "PLACES_API_KEY", "\"${placesApiKey}\"")
+        buildConfigField("String", "GEMINI_API_KEY", "\"${geminiApiKey}\"")
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables {
@@ -240,6 +242,14 @@ dependencies {
 
     // For image cropping
     implementation("com.vanniktech:android-image-cropper:4.5.0")
+
+    // for the Google AI client SDK for Android
+    implementation("com.google.ai.client.generativeai:generativeai:0.7.0")
+
+    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-android:1.3.9")
+
+
+
 }
 
 tasks.withType<Test> {

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -193,6 +193,7 @@ dependencies {
     implementation(libs.firebase.storage.ktx)
     implementation(libs.androidx.foundation.android)
     implementation(libs.core)
+    implementation(libs.androidx.runtime.livedata)
 
     // Testing Unit
     testImplementation(libs.junit) {
@@ -246,7 +247,12 @@ dependencies {
     // for the Google AI client SDK for Android
     implementation("com.google.ai.client.generativeai:generativeai:0.7.0")
 
+    // for calling the Gemini API
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-android:1.3.9")
+
+    // for JSON serialization
+    implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.7.3")
+
 
 
 

--- a/app/src/androidTest/java/com/android/voyageur/ui/trip/activities/ActivityItemTest.kt
+++ b/app/src/androidTest/java/com/android/voyageur/ui/trip/activities/ActivityItemTest.kt
@@ -11,10 +11,13 @@ import com.android.voyageur.model.activity.ActivityType
 import com.android.voyageur.model.trip.TripRepository
 import com.android.voyageur.model.trip.TripsViewModel
 import com.android.voyageur.ui.navigation.NavigationActions
+import com.android.voyageur.ui.navigation.Screen
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
+import org.mockito.Mockito.doNothing
 import org.mockito.Mockito.mock
+import org.mockito.Mockito.verify
 
 class ActivityItemTest {
   private val sampleActivityWithoutDescription =
@@ -50,7 +53,10 @@ class ActivityItemTest {
   fun activityItem_expandAndCollapse() {
 
     composeTestRule.setContent {
-      ActivityItem(sampleActivityWithDescription, navigationActions, tripsViewModel)
+      ActivityItem(
+          activity = sampleActivityWithDescription,
+          navigationActions = navigationActions,
+          tripsViewModel = tripsViewModel)
     }
 
     composeTestRule.onNodeWithText("Price").assertIsNotDisplayed()
@@ -72,7 +78,10 @@ class ActivityItemTest {
   @Test
   fun activityCard_displaysCorrectTitle() {
     composeTestRule.setContent {
-      ActivityItem(sampleActivityWithDescription, navigationActions, tripsViewModel)
+      ActivityItem(
+          activity = sampleActivityWithDescription,
+          navigationActions = navigationActions,
+          tripsViewModel = tripsViewModel)
     }
 
     composeTestRule
@@ -85,7 +94,10 @@ class ActivityItemTest {
   fun activityCard_displaysCorrectDescription() {
 
     composeTestRule.setContent {
-      ActivityItem(sampleActivityWithDescription, navigationActions, tripsViewModel)
+      ActivityItem(
+          activity = sampleActivityWithDescription,
+          navigationActions = navigationActions,
+          tripsViewModel = tripsViewModel)
     }
     composeTestRule
         .onNodeWithTag("expandIcon_${sampleActivityWithDescription.title}")
@@ -101,7 +113,10 @@ class ActivityItemTest {
   fun activityCard_doesNotDisplayDescription() {
 
     composeTestRule.setContent {
-      ActivityItem(sampleActivityWithoutDescription, navigationActions, tripsViewModel)
+      ActivityItem(
+          activity = sampleActivityWithoutDescription,
+          navigationActions = navigationActions,
+          tripsViewModel = tripsViewModel)
     }
     composeTestRule
         .onNodeWithTag("expandIcon_${sampleActivityWithoutDescription.title}")
@@ -119,7 +134,10 @@ class ActivityItemTest {
   fun activityCard_displaysCorrectDateAndTime() {
 
     composeTestRule.setContent {
-      ActivityItem(sampleActivityWithDescription, navigationActions, tripsViewModel)
+      ActivityItem(
+          activity = sampleActivityWithDescription,
+          navigationActions = navigationActions,
+          tripsViewModel = tripsViewModel)
     }
 
     composeTestRule
@@ -131,7 +149,11 @@ class ActivityItemTest {
   @Test
   fun activityCard_displaysDeleteButton() {
     composeTestRule.setContent {
-      ActivityItem(activity = sampleActivityWithDescription, buttonPurpose = ButtonType.DELETE)
+      ActivityItem(
+          activity = sampleActivityWithDescription,
+          buttonPurpose = ButtonType.DELETE,
+          navigationActions = navigationActions,
+          tripsViewModel = tripsViewModel)
     }
     composeTestRule
         .onNodeWithTag("cardItem_${sampleActivityWithDescription.title}")
@@ -147,7 +169,11 @@ class ActivityItemTest {
   @Test
   fun activityCard_displaysAddButton() {
     composeTestRule.setContent {
-      ActivityItem(activity = sampleActivityWithDescription, buttonPurpose = ButtonType.ADD)
+      ActivityItem(
+          activity = sampleActivityWithDescription,
+          buttonPurpose = ButtonType.ADD,
+          navigationActions = navigationActions,
+          tripsViewModel = tripsViewModel)
     }
     composeTestRule
         .onNodeWithTag("cardItem_${sampleActivityWithDescription.title}")
@@ -158,5 +184,66 @@ class ActivityItemTest {
     composeTestRule
         .onNodeWithTag("addIcon_${sampleActivityWithDescription.title}")
         .assertIsDisplayed()
+  }
+
+  @Test
+  fun activityCard_displaysEditButton() {
+    composeTestRule.setContent {
+      ActivityItem(
+          activity = sampleActivityWithDescription,
+          isEditable = true,
+          navigationActions = navigationActions,
+          tripsViewModel = tripsViewModel)
+    }
+    composeTestRule
+        .onNodeWithTag("cardItem_${sampleActivityWithDescription.title}")
+        .assertIsDisplayed()
+    composeTestRule
+        .onNodeWithTag("expandIcon_${sampleActivityWithDescription.title}")
+        .performClick()
+    composeTestRule
+        .onNodeWithTag("editIcon_${sampleActivityWithDescription.title}")
+        .assertIsDisplayed()
+  }
+
+  @Test
+  fun activityCard_doesNotDisplayEditButton() {
+    composeTestRule.setContent {
+      ActivityItem(
+          activity = sampleActivityWithDescription,
+          isEditable = false,
+          navigationActions = navigationActions,
+          tripsViewModel = tripsViewModel)
+    }
+    composeTestRule
+        .onNodeWithTag("cardItem_${sampleActivityWithDescription.title}")
+        .assertIsDisplayed()
+    composeTestRule
+        .onNodeWithTag("expandIcon_${sampleActivityWithDescription.title}")
+        .performClick()
+    composeTestRule
+        .onNodeWithTag("editIcon_${sampleActivityWithDescription.title}")
+        .assertIsNotDisplayed()
+  }
+
+  @Test
+  fun clickingOnEditButton_navigatesToEditActivityScreen() {
+    doNothing().`when`(navigationActions).navigateTo(Screen.EDIT_ACTIVITY)
+    composeTestRule.setContent {
+      ActivityItem(
+          activity = sampleActivityWithDescription,
+          isEditable = true,
+          navigationActions = navigationActions,
+          tripsViewModel = tripsViewModel)
+    }
+    composeTestRule
+        .onNodeWithTag("cardItem_${sampleActivityWithDescription.title}")
+        .assertIsDisplayed()
+    composeTestRule
+        .onNodeWithTag("expandIcon_${sampleActivityWithDescription.title}")
+        .performClick()
+    composeTestRule.onNodeWithTag("editIcon_${sampleActivityWithDescription.title}").performClick()
+    verify(navigationActions).navigateTo(Screen.EDIT_ACTIVITY)
+    assert(tripsViewModel.selectedActivity.value == sampleActivityWithDescription)
   }
 }

--- a/app/src/androidTest/java/com/android/voyageur/ui/trip/activities/ActivityItemTest.kt
+++ b/app/src/androidTest/java/com/android/voyageur/ui/trip/activities/ActivityItemTest.kt
@@ -101,4 +101,36 @@ class ActivityItemTest {
         .assertIsDisplayed()
     composeTestRule.onNodeWithText("01/01/2022 12:00 PM - 02:00 PM").assertIsDisplayed()
   }
+
+  @Test
+  fun activityCard_displaysDeleteButton() {
+    composeTestRule.setContent {
+      ActivityItem(activity = sampleActivityWithDescription, buttonPurpose = ButtonType.DELETE)
+    }
+    composeTestRule
+        .onNodeWithTag("cardItem_${sampleActivityWithDescription.title}")
+        .assertIsDisplayed()
+    composeTestRule
+        .onNodeWithTag("expandIcon_${sampleActivityWithDescription.title}")
+        .performClick()
+    composeTestRule
+        .onNodeWithTag("deleteIcon_${sampleActivityWithDescription.title}")
+        .assertIsDisplayed()
+  }
+
+  @Test
+  fun activityCard_displaysAddButton() {
+    composeTestRule.setContent {
+      ActivityItem(activity = sampleActivityWithDescription, buttonPurpose = ButtonType.ADD)
+    }
+    composeTestRule
+        .onNodeWithTag("cardItem_${sampleActivityWithDescription.title}")
+        .assertIsDisplayed()
+    composeTestRule
+        .onNodeWithTag("expandIcon_${sampleActivityWithDescription.title}")
+        .performClick()
+    composeTestRule
+        .onNodeWithTag("addIcon_${sampleActivityWithDescription.title}")
+        .assertIsDisplayed()
+  }
 }

--- a/app/src/androidTest/java/com/android/voyageur/ui/trip/assistant/AssistantTest.kt
+++ b/app/src/androidTest/java/com/android/voyageur/ui/trip/assistant/AssistantTest.kt
@@ -110,6 +110,16 @@ class AssistantScreenTest {
   }
 
   @Test
+  fun checkButtonIsDisabledWhenLoading() {
+    val uiStateFlow = MutableStateFlow(UiState.Loading)
+    val tripFlow = MutableStateFlow(sampleTrip)
+    `when`(mockTripsViewModel.selectedTrip).thenReturn(tripFlow)
+    `when`(mockTripsViewModel.uiState).thenReturn(uiStateFlow)
+    composeTestRule.setContent { AssistantScreen(mockTripsViewModel, navigationActions) }
+    composeTestRule.onNodeWithTag("AIRequestButton").assertIsNotEnabled()
+  }
+
+  @Test
   fun checkJsonParsing() {
     val activities = extractActivitiesFromJson(sampleJson)
     assert(activities.size == 2)

--- a/app/src/androidTest/java/com/android/voyageur/ui/trip/assistant/AssistantTest.kt
+++ b/app/src/androidTest/java/com/android/voyageur/ui/trip/assistant/AssistantTest.kt
@@ -1,0 +1,121 @@
+package com.android.voyageur.ui.trip.assistant
+
+import androidx.compose.ui.test.*
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.navigation.NavHostController
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.android.voyageur.model.activity.Activity
+import com.android.voyageur.model.activity.extractActivitiesFromJson
+import com.android.voyageur.model.trip.Trip
+import com.android.voyageur.model.trip.TripRepository
+import com.android.voyageur.model.trip.TripsViewModel
+import com.android.voyageur.model.trip.UiState
+import com.android.voyageur.ui.navigation.NavigationActions
+import kotlinx.coroutines.flow.MutableStateFlow
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.Mockito.doNothing
+import org.mockito.Mockito.mock
+import org.mockito.Mockito.`when`
+import org.mockito.kotlin.verify
+
+@RunWith(AndroidJUnit4::class)
+class AssistantScreenTest {
+
+  private lateinit var navigationActions: NavigationActions
+  private lateinit var tripsViewModel: TripsViewModel
+  private lateinit var tripRepository: TripRepository
+  private lateinit var mockTripsViewModel: TripsViewModel
+  private lateinit var navHostController: NavHostController
+
+  @get:Rule val composeTestRule = createComposeRule()
+
+  private val sampleTrip = Trip(name = "Sample Trip")
+  private val sampleJson =
+      "[{\"title\":\"Activity 1\", \"description\": \"Description 1\"}, {\"title\":\"Activity 2\", \"description\": \"Description 1\"}]"
+
+  @Before
+  fun setUp() {
+    tripRepository = mock(TripRepository::class.java)
+    navHostController = mock(NavHostController::class.java)
+    navigationActions = NavigationActions(navHostController)
+    tripsViewModel = TripsViewModel(tripRepository)
+    mockTripsViewModel = mock(TripsViewModel::class.java)
+  }
+
+  @Test
+  fun initialRenderingOfScreen() {
+    tripsViewModel.selectTrip(sampleTrip)
+    composeTestRule.setContent { AssistantScreen(tripsViewModel, navigationActions) }
+    composeTestRule.onNodeWithTag("assistantScreen").assertIsDisplayed()
+    composeTestRule.onNodeWithTag("topBar").assertIsDisplayed()
+    composeTestRule.onNodeWithTag("AIRequestTextField").assertIsDisplayed()
+    composeTestRule.onNodeWithTag("AIRequestButton").assertIsDisplayed()
+  }
+
+  @Test
+  fun loadingIndicatorDisplayedWhenLoading() {
+    val uiStateFlow = MutableStateFlow(UiState.Loading)
+    val tripFlow = MutableStateFlow(sampleTrip)
+    `when`(mockTripsViewModel.selectedTrip).thenReturn(tripFlow)
+    `when`(mockTripsViewModel.uiState).thenReturn(uiStateFlow)
+    composeTestRule.setContent { AssistantScreen(mockTripsViewModel, navigationActions) }
+
+    composeTestRule.onNodeWithTag("loadingIndicator").assertIsDisplayed()
+  }
+
+  @Test
+  fun errorTextDisplayedWhenError() {
+    val errorMessage = "An error occurred"
+    val uiStateFlow = MutableStateFlow(UiState.Error(errorMessage))
+    val tripFlow = MutableStateFlow(sampleTrip)
+    `when`(mockTripsViewModel.selectedTrip).thenReturn(tripFlow)
+    `when`(mockTripsViewModel.uiState).thenReturn(uiStateFlow)
+    composeTestRule.setContent { AssistantScreen(mockTripsViewModel, navigationActions) }
+
+    composeTestRule.onNodeWithTag("errorMessage").assertIsDisplayed()
+  }
+
+  @Test
+  fun activitiesDisplayedWhenSuccess() {
+    val uiStateFlow = MutableStateFlow(UiState.Success(sampleJson))
+    val tripFlow = MutableStateFlow(sampleTrip)
+    `when`(mockTripsViewModel.selectedTrip).thenReturn(tripFlow)
+    `when`(mockTripsViewModel.uiState).thenReturn(uiStateFlow)
+    composeTestRule.setContent { AssistantScreen(mockTripsViewModel, navigationActions) }
+    composeTestRule.onNodeWithTag("cardItem_Activity 1").assertIsDisplayed()
+    composeTestRule.onNodeWithTag("cardItem_Activity 2").assertIsDisplayed()
+  }
+
+  @Test
+  fun activityRemovedWhenAddButtonClicked() {
+    val uiStateFlow = MutableStateFlow(UiState.Success(sampleJson))
+    val tripFlow = MutableStateFlow(sampleTrip)
+    `when`(mockTripsViewModel.selectedTrip).thenReturn(tripFlow)
+    `when`(mockTripsViewModel.uiState).thenReturn(uiStateFlow)
+    val mockActivity = Activity(title = "Activity 1", description = "Description 1")
+    doNothing().`when`(mockTripsViewModel).addActivityToTrip(mockActivity)
+    composeTestRule.setContent { AssistantScreen(mockTripsViewModel, navigationActions) }
+    // Act
+    composeTestRule.onNodeWithTag("cardItem_Activity 1").assertIsDisplayed()
+    // click on expand icon
+    composeTestRule.onNodeWithTag("expandIcon_Activity 1").performClick()
+
+    composeTestRule.onNodeWithTag("addIcon_Activity 1").performClick()
+    verify(mockTripsViewModel).addActivityToTrip(mockActivity)
+
+    composeTestRule.onNodeWithText("Activity 1").assertIsNotDisplayed()
+  }
+
+  @Test
+  fun checkJsonParsing() {
+    val activities = extractActivitiesFromJson(sampleJson)
+    assert(activities.size == 2)
+    assert(activities[0].title == "Activity 1")
+    assert(activities[0].description == "Description 1")
+    assert(activities[1].title == "Activity 2")
+    assert(activities[1].description == "Description 1")
+  }
+}

--- a/app/src/androidTest/java/com/android/voyageur/ui/trip/schedule/ScheduleScreenTest.kt
+++ b/app/src/androidTest/java/com/android/voyageur/ui/trip/schedule/ScheduleScreenTest.kt
@@ -42,7 +42,7 @@ class ScheduleScreenTest {
     navHostController = Mockito.mock(NavHostController::class.java)
     navigationActions = NavigationActions(navHostController)
 
-      mockNavigationActions = Mockito.mock(NavigationActions::class.java)
+    mockNavigationActions = Mockito.mock(NavigationActions::class.java)
 
     mockTrip =
         Trip(
@@ -70,16 +70,14 @@ class ScheduleScreenTest {
                                         .toInstant(ZoneOffset.UTC))),
                         0.0,
                         ActivityType.MUSEUM)))
-
-
   }
 
   @Test
   fun scheduleScreen_initialStateIsDaily() {
-      composeTestRule.setContent {
-          ScheduleScreen(
-              tripsViewModel = tripsViewModel, trip = mockTrip, navigationActions = navigationActions)
-      }
+    composeTestRule.setContent {
+      ScheduleScreen(
+          tripsViewModel = tripsViewModel, trip = mockTrip, navigationActions = navigationActions)
+    }
     // Initially Daily view should be shown
     composeTestRule.onNodeWithText("Daily").assertIsEnabled()
     composeTestRule.onNodeWithText("Daily").assertIsDisplayed()
@@ -88,10 +86,10 @@ class ScheduleScreenTest {
 
   @Test
   fun scheduleScreen_toggleToWeeklyView() {
-      composeTestRule.setContent {
-          ScheduleScreen(
-              tripsViewModel = tripsViewModel, trip = mockTrip, navigationActions = navigationActions)
-      }
+    composeTestRule.setContent {
+      ScheduleScreen(
+          tripsViewModel = tripsViewModel, trip = mockTrip, navigationActions = navigationActions)
+    }
     // Click Weekly button
     composeTestRule.onNodeWithText("Weekly").performClick()
 
@@ -102,10 +100,10 @@ class ScheduleScreenTest {
 
   @Test
   fun scheduleScreen_toggleBetweenViews() {
-      composeTestRule.setContent {
-          ScheduleScreen(
-              tripsViewModel = tripsViewModel, trip = mockTrip, navigationActions = navigationActions)
-      }
+    composeTestRule.setContent {
+      ScheduleScreen(
+          tripsViewModel = tripsViewModel, trip = mockTrip, navigationActions = navigationActions)
+    }
     // Start with Daily view
     composeTestRule.onNodeWithTag("byDayScreen").assertExists()
 
@@ -122,10 +120,10 @@ class ScheduleScreenTest {
 
   @Test
   fun scheduleScreen_verifyViewToggleVisuals() {
-      composeTestRule.setContent {
-          ScheduleScreen(
-              tripsViewModel = tripsViewModel, trip = mockTrip, navigationActions = navigationActions)
-      }
+    composeTestRule.setContent {
+      ScheduleScreen(
+          tripsViewModel = tripsViewModel, trip = mockTrip, navigationActions = navigationActions)
+    }
     // Verify both buttons and separator exist
     composeTestRule.onNodeWithText("Daily").assertExists()
     composeTestRule.onNodeWithText("Weekly").assertExists()
@@ -134,10 +132,10 @@ class ScheduleScreenTest {
 
   @Test
   fun scheduleScreen_toggleButtonsAreClickable() {
-      composeTestRule.setContent {
-          ScheduleScreen(
-              tripsViewModel = tripsViewModel, trip = mockTrip, navigationActions = navigationActions)
-      }
+    composeTestRule.setContent {
+      ScheduleScreen(
+          tripsViewModel = tripsViewModel, trip = mockTrip, navigationActions = navigationActions)
+    }
     // Verify both buttons are enabled and can be clicked
     composeTestRule.onNodeWithText("Daily").assertHasClickAction()
     composeTestRule.onNodeWithText("Weekly").assertHasClickAction()
@@ -145,10 +143,10 @@ class ScheduleScreenTest {
 
   @Test
   fun scheduleScreen_verifyProperViewSwitching() {
-      composeTestRule.setContent {
-          ScheduleScreen(
-              tripsViewModel = tripsViewModel, trip = mockTrip, navigationActions = navigationActions)
-      }
+    composeTestRule.setContent {
+      ScheduleScreen(
+          tripsViewModel = tripsViewModel, trip = mockTrip, navigationActions = navigationActions)
+    }
     // Start with Daily view
     composeTestRule.onNodeWithTag("byDayScreen").assertExists()
 
@@ -165,10 +163,10 @@ class ScheduleScreenTest {
 
   @Test
   fun scheduleScreen_verifyWeeklyViewShowsCorrectData() {
-      composeTestRule.setContent {
-          ScheduleScreen(
-              tripsViewModel = tripsViewModel, trip = mockTrip, navigationActions = navigationActions)
-      }
+    composeTestRule.setContent {
+      ScheduleScreen(
+          tripsViewModel = tripsViewModel, trip = mockTrip, navigationActions = navigationActions)
+    }
     // Switch to Weekly view
     composeTestRule.onNodeWithText("Weekly").performClick()
 
@@ -181,10 +179,10 @@ class ScheduleScreenTest {
 
   @Test
   fun scheduleScreen_verifyToggleButtonsStayEnabled() {
-      composeTestRule.setContent {
-          ScheduleScreen(
-              tripsViewModel = tripsViewModel, trip = mockTrip, navigationActions = navigationActions)
-      }
+    composeTestRule.setContent {
+      ScheduleScreen(
+          tripsViewModel = tripsViewModel, trip = mockTrip, navigationActions = navigationActions)
+    }
     // Initially both should be enabled
     composeTestRule.onNodeWithText("Daily").assertIsEnabled()
     composeTestRule.onNodeWithText("Weekly").assertIsEnabled()
@@ -197,10 +195,10 @@ class ScheduleScreenTest {
 
   @Test
   fun checkIfIsDailyViewSelected_updatesProperly() {
-      composeTestRule.setContent {
-          ScheduleScreen(
-              tripsViewModel = tripsViewModel, trip = mockTrip, navigationActions = navigationActions)
-      }
+    composeTestRule.setContent {
+      ScheduleScreen(
+          tripsViewModel = tripsViewModel, trip = mockTrip, navigationActions = navigationActions)
+    }
     assert(navigationActions.getNavigationState().isDailyViewSelected)
     composeTestRule.onNodeWithText("Weekly").performClick()
 
@@ -209,17 +207,18 @@ class ScheduleScreenTest {
     assert(navigationActions.getNavigationState().isDailyViewSelected)
   }
 
-    @Test
-    fun checkNavigationToAssistantScreen() {
-        doReturn(NavigationState()).`when`(mockNavigationActions).getNavigationState()
-        doNothing().`when`(tripsViewModel).setInitialUiState()
-        composeTestRule.setContent {
-            ScheduleScreen(
-                tripsViewModel = tripsViewModel, trip = mockTrip, navigationActions = mockNavigationActions)
-        }
-        composeTestRule.onNodeWithText("Ask Assistant").performClick()
-        Mockito.verify(tripsViewModel).setInitialUiState()
-        Mockito.verify(mockNavigationActions).navigateTo("Assistant Screen")
+  @Test
+  fun checkNavigationToAssistantScreen() {
+    doReturn(NavigationState()).`when`(mockNavigationActions).getNavigationState()
+    doNothing().`when`(tripsViewModel).setInitialUiState()
+    composeTestRule.setContent {
+      ScheduleScreen(
+          tripsViewModel = tripsViewModel,
+          trip = mockTrip,
+          navigationActions = mockNavigationActions)
     }
-
+    composeTestRule.onNodeWithText("Ask Assistant").performClick()
+    Mockito.verify(tripsViewModel).setInitialUiState()
+    Mockito.verify(mockNavigationActions).navigateTo("Assistant Screen")
+  }
 }

--- a/app/src/androidTest/java/com/android/voyageur/ui/trip/schedule/ScheduleScreenTest.kt
+++ b/app/src/androidTest/java/com/android/voyageur/ui/trip/schedule/ScheduleScreenTest.kt
@@ -9,6 +9,7 @@ import com.android.voyageur.model.location.Location
 import com.android.voyageur.model.trip.Trip
 import com.android.voyageur.model.trip.TripsViewModel
 import com.android.voyageur.ui.navigation.NavigationActions
+import com.android.voyageur.ui.navigation.NavigationState
 import com.google.firebase.Timestamp
 import java.time.LocalDateTime
 import java.time.ZoneOffset
@@ -17,6 +18,10 @@ import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.mockito.Mockito
+import org.mockito.Mockito.`when`
+import org.mockito.kotlin.doNothing
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.mock
 
 class ScheduleScreenTest {
   @get:Rule val composeTestRule = createComposeRule()
@@ -25,6 +30,7 @@ class ScheduleScreenTest {
   private lateinit var mockTrip: Trip
   private lateinit var tripsViewModel: TripsViewModel
   private lateinit var navHostController: NavHostController
+  private lateinit var mockNavigationActions: NavigationActions
 
   @Before
   fun setUp() {
@@ -35,6 +41,8 @@ class ScheduleScreenTest {
 
     navHostController = Mockito.mock(NavHostController::class.java)
     navigationActions = NavigationActions(navHostController)
+
+      mockNavigationActions = Mockito.mock(NavigationActions::class.java)
 
     mockTrip =
         Trip(
@@ -63,14 +71,15 @@ class ScheduleScreenTest {
                         0.0,
                         ActivityType.MUSEUM)))
 
-    composeTestRule.setContent {
-      ScheduleScreen(
-          tripsViewModel = tripsViewModel, trip = mockTrip, navigationActions = navigationActions)
-    }
+
   }
 
   @Test
   fun scheduleScreen_initialStateIsDaily() {
+      composeTestRule.setContent {
+          ScheduleScreen(
+              tripsViewModel = tripsViewModel, trip = mockTrip, navigationActions = navigationActions)
+      }
     // Initially Daily view should be shown
     composeTestRule.onNodeWithText("Daily").assertIsEnabled()
     composeTestRule.onNodeWithText("Daily").assertIsDisplayed()
@@ -79,6 +88,10 @@ class ScheduleScreenTest {
 
   @Test
   fun scheduleScreen_toggleToWeeklyView() {
+      composeTestRule.setContent {
+          ScheduleScreen(
+              tripsViewModel = tripsViewModel, trip = mockTrip, navigationActions = navigationActions)
+      }
     // Click Weekly button
     composeTestRule.onNodeWithText("Weekly").performClick()
 
@@ -89,6 +102,10 @@ class ScheduleScreenTest {
 
   @Test
   fun scheduleScreen_toggleBetweenViews() {
+      composeTestRule.setContent {
+          ScheduleScreen(
+              tripsViewModel = tripsViewModel, trip = mockTrip, navigationActions = navigationActions)
+      }
     // Start with Daily view
     composeTestRule.onNodeWithTag("byDayScreen").assertExists()
 
@@ -105,6 +122,10 @@ class ScheduleScreenTest {
 
   @Test
   fun scheduleScreen_verifyViewToggleVisuals() {
+      composeTestRule.setContent {
+          ScheduleScreen(
+              tripsViewModel = tripsViewModel, trip = mockTrip, navigationActions = navigationActions)
+      }
     // Verify both buttons and separator exist
     composeTestRule.onNodeWithText("Daily").assertExists()
     composeTestRule.onNodeWithText("Weekly").assertExists()
@@ -113,6 +134,10 @@ class ScheduleScreenTest {
 
   @Test
   fun scheduleScreen_toggleButtonsAreClickable() {
+      composeTestRule.setContent {
+          ScheduleScreen(
+              tripsViewModel = tripsViewModel, trip = mockTrip, navigationActions = navigationActions)
+      }
     // Verify both buttons are enabled and can be clicked
     composeTestRule.onNodeWithText("Daily").assertHasClickAction()
     composeTestRule.onNodeWithText("Weekly").assertHasClickAction()
@@ -120,6 +145,10 @@ class ScheduleScreenTest {
 
   @Test
   fun scheduleScreen_verifyProperViewSwitching() {
+      composeTestRule.setContent {
+          ScheduleScreen(
+              tripsViewModel = tripsViewModel, trip = mockTrip, navigationActions = navigationActions)
+      }
     // Start with Daily view
     composeTestRule.onNodeWithTag("byDayScreen").assertExists()
 
@@ -136,6 +165,10 @@ class ScheduleScreenTest {
 
   @Test
   fun scheduleScreen_verifyWeeklyViewShowsCorrectData() {
+      composeTestRule.setContent {
+          ScheduleScreen(
+              tripsViewModel = tripsViewModel, trip = mockTrip, navigationActions = navigationActions)
+      }
     // Switch to Weekly view
     composeTestRule.onNodeWithText("Weekly").performClick()
 
@@ -148,6 +181,10 @@ class ScheduleScreenTest {
 
   @Test
   fun scheduleScreen_verifyToggleButtonsStayEnabled() {
+      composeTestRule.setContent {
+          ScheduleScreen(
+              tripsViewModel = tripsViewModel, trip = mockTrip, navigationActions = navigationActions)
+      }
     // Initially both should be enabled
     composeTestRule.onNodeWithText("Daily").assertIsEnabled()
     composeTestRule.onNodeWithText("Weekly").assertIsEnabled()
@@ -160,6 +197,10 @@ class ScheduleScreenTest {
 
   @Test
   fun checkIfIsDailyViewSelected_updatesProperly() {
+      composeTestRule.setContent {
+          ScheduleScreen(
+              tripsViewModel = tripsViewModel, trip = mockTrip, navigationActions = navigationActions)
+      }
     assert(navigationActions.getNavigationState().isDailyViewSelected)
     composeTestRule.onNodeWithText("Weekly").performClick()
 
@@ -167,4 +208,18 @@ class ScheduleScreenTest {
     composeTestRule.onNodeWithText("Daily").performClick()
     assert(navigationActions.getNavigationState().isDailyViewSelected)
   }
+
+    @Test
+    fun checkNavigationToAssistantScreen() {
+        doReturn(NavigationState()).`when`(mockNavigationActions).getNavigationState()
+        doNothing().`when`(tripsViewModel).setInitialUiState()
+        composeTestRule.setContent {
+            ScheduleScreen(
+                tripsViewModel = tripsViewModel, trip = mockTrip, navigationActions = mockNavigationActions)
+        }
+        composeTestRule.onNodeWithText("Ask Assistant").performClick()
+        Mockito.verify(tripsViewModel).setInitialUiState()
+        Mockito.verify(mockNavigationActions).navigateTo("Assistant Screen")
+    }
+
 }

--- a/app/src/androidTest/java/com/android/voyageur/ui/trip/schedule/ScheduleScreenTest.kt
+++ b/app/src/androidTest/java/com/android/voyageur/ui/trip/schedule/ScheduleScreenTest.kt
@@ -22,10 +22,8 @@ import org.junit.Rule
 import org.junit.Test
 import org.mockito.Mockito
 import org.mockito.Mockito.mock
-import org.mockito.Mockito.`when`
 import org.mockito.kotlin.doNothing
 import org.mockito.kotlin.doReturn
-import org.mockito.kotlin.mock
 
 class ScheduleScreenTest {
   @get:Rule val composeTestRule = createComposeRule()

--- a/app/src/androidTest/java/com/android/voyageur/ui/trip/schedule/ScheduleScreenTest.kt
+++ b/app/src/androidTest/java/com/android/voyageur/ui/trip/schedule/ScheduleScreenTest.kt
@@ -21,11 +21,11 @@ import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.mockito.Mockito
+import org.mockito.Mockito.mock
 import org.mockito.Mockito.`when`
 import org.mockito.kotlin.doNothing
 import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.mock
-import org.mockito.Mockito.mock
 
 class ScheduleScreenTest {
   @get:Rule val composeTestRule = createComposeRule()
@@ -79,18 +79,17 @@ class ScheduleScreenTest {
                                         .toInstant(ZoneOffset.UTC))),
                         0.0,
                         ActivityType.MUSEUM)))
-
   }
 
   @Test
   fun scheduleScreen_initialStateIsDaily() {
-      composeTestRule.setContent {
-          ScheduleScreen(
-              tripsViewModel = tripsViewModel,
-              trip = mockTrip,
-              navigationActions = navigationActions,
-              userViewModel)
-      }
+    composeTestRule.setContent {
+      ScheduleScreen(
+          tripsViewModel = tripsViewModel,
+          trip = mockTrip,
+          navigationActions = navigationActions,
+          userViewModel)
+    }
     // Initially Daily view should be shown
     composeTestRule.onNodeWithText("Daily").assertIsEnabled()
     composeTestRule.onNodeWithText("Daily").assertIsDisplayed()
@@ -99,13 +98,13 @@ class ScheduleScreenTest {
 
   @Test
   fun scheduleScreen_toggleToWeeklyView() {
-      composeTestRule.setContent {
-          ScheduleScreen(
-              tripsViewModel = tripsViewModel,
-              trip = mockTrip,
-              navigationActions = navigationActions,
-              userViewModel)
-      }
+    composeTestRule.setContent {
+      ScheduleScreen(
+          tripsViewModel = tripsViewModel,
+          trip = mockTrip,
+          navigationActions = navigationActions,
+          userViewModel)
+    }
     // Click Weekly button
     composeTestRule.onNodeWithText("Weekly").performClick()
 
@@ -116,13 +115,13 @@ class ScheduleScreenTest {
 
   @Test
   fun scheduleScreen_toggleBetweenViews() {
-      composeTestRule.setContent {
-          ScheduleScreen(
-              tripsViewModel = tripsViewModel,
-              trip = mockTrip,
-              navigationActions = navigationActions,
-              userViewModel)
-      }
+    composeTestRule.setContent {
+      ScheduleScreen(
+          tripsViewModel = tripsViewModel,
+          trip = mockTrip,
+          navigationActions = navigationActions,
+          userViewModel)
+    }
     // Start with Daily view
     composeTestRule.onNodeWithTag("byDayScreen").assertExists()
 
@@ -139,13 +138,13 @@ class ScheduleScreenTest {
 
   @Test
   fun scheduleScreen_verifyViewToggleVisuals() {
-      composeTestRule.setContent {
-          ScheduleScreen(
-              tripsViewModel = tripsViewModel,
-              trip = mockTrip,
-              navigationActions = navigationActions,
-              userViewModel)
-      }
+    composeTestRule.setContent {
+      ScheduleScreen(
+          tripsViewModel = tripsViewModel,
+          trip = mockTrip,
+          navigationActions = navigationActions,
+          userViewModel)
+    }
     // Verify both buttons and separator exist
     composeTestRule.onNodeWithText("Daily").assertExists()
     composeTestRule.onNodeWithText("Weekly").assertExists()
@@ -154,13 +153,13 @@ class ScheduleScreenTest {
 
   @Test
   fun scheduleScreen_toggleButtonsAreClickable() {
-      composeTestRule.setContent {
-          ScheduleScreen(
-              tripsViewModel = tripsViewModel,
-              trip = mockTrip,
-              navigationActions = navigationActions,
-              userViewModel)
-      }
+    composeTestRule.setContent {
+      ScheduleScreen(
+          tripsViewModel = tripsViewModel,
+          trip = mockTrip,
+          navigationActions = navigationActions,
+          userViewModel)
+    }
     // Verify both buttons are enabled and can be clicked
     composeTestRule.onNodeWithText("Daily").assertHasClickAction()
     composeTestRule.onNodeWithText("Weekly").assertHasClickAction()
@@ -168,13 +167,13 @@ class ScheduleScreenTest {
 
   @Test
   fun scheduleScreen_verifyProperViewSwitching() {
-      composeTestRule.setContent {
-          ScheduleScreen(
-              tripsViewModel = tripsViewModel,
-              trip = mockTrip,
-              navigationActions = navigationActions,
-              userViewModel)
-      }
+    composeTestRule.setContent {
+      ScheduleScreen(
+          tripsViewModel = tripsViewModel,
+          trip = mockTrip,
+          navigationActions = navigationActions,
+          userViewModel)
+    }
     // Start with Daily view
     composeTestRule.onNodeWithTag("byDayScreen").assertExists()
 
@@ -191,13 +190,13 @@ class ScheduleScreenTest {
 
   @Test
   fun scheduleScreen_verifyWeeklyViewShowsCorrectData() {
-      composeTestRule.setContent {
-          ScheduleScreen(
-              tripsViewModel = tripsViewModel,
-              trip = mockTrip,
-              navigationActions = navigationActions,
-              userViewModel)
-      }
+    composeTestRule.setContent {
+      ScheduleScreen(
+          tripsViewModel = tripsViewModel,
+          trip = mockTrip,
+          navigationActions = navigationActions,
+          userViewModel)
+    }
     // Switch to Weekly view
     composeTestRule.onNodeWithText("Weekly").performClick()
 
@@ -210,13 +209,13 @@ class ScheduleScreenTest {
 
   @Test
   fun scheduleScreen_verifyToggleButtonsStayEnabled() {
-      composeTestRule.setContent {
-          ScheduleScreen(
-              tripsViewModel = tripsViewModel,
-              trip = mockTrip,
-              navigationActions = navigationActions,
-              userViewModel)
-      }
+    composeTestRule.setContent {
+      ScheduleScreen(
+          tripsViewModel = tripsViewModel,
+          trip = mockTrip,
+          navigationActions = navigationActions,
+          userViewModel)
+    }
     // Initially both should be enabled
     composeTestRule.onNodeWithText("Daily").assertIsEnabled()
     composeTestRule.onNodeWithText("Weekly").assertIsEnabled()
@@ -229,13 +228,13 @@ class ScheduleScreenTest {
 
   @Test
   fun checkIfIsDailyViewSelected_updatesProperly() {
-      composeTestRule.setContent {
-          ScheduleScreen(
-              tripsViewModel = tripsViewModel,
-              trip = mockTrip,
-              navigationActions = navigationActions,
-              userViewModel)
-      }
+    composeTestRule.setContent {
+      ScheduleScreen(
+          tripsViewModel = tripsViewModel,
+          trip = mockTrip,
+          navigationActions = navigationActions,
+          userViewModel)
+    }
     assert(navigationActions.getNavigationState().isDailyViewSelected)
     composeTestRule.onNodeWithText("Weekly").performClick()
 
@@ -248,13 +247,13 @@ class ScheduleScreenTest {
   fun checkNavigationToAssistantScreen() {
     doReturn(NavigationState()).`when`(mockNavigationActions).getNavigationState()
     doNothing().`when`(tripsViewModel).setInitialUiState()
-      composeTestRule.setContent {
-          ScheduleScreen(
-              tripsViewModel = tripsViewModel,
-              trip = mockTrip,
-              navigationActions = mockNavigationActions,
-              userViewModel)
-      }
+    composeTestRule.setContent {
+      ScheduleScreen(
+          tripsViewModel = tripsViewModel,
+          trip = mockTrip,
+          navigationActions = mockNavigationActions,
+          userViewModel)
+    }
     composeTestRule.onNodeWithText("Ask Assistant").performClick()
     Mockito.verify(tripsViewModel).setInitialUiState()
     Mockito.verify(mockNavigationActions).navigateTo("Assistant Screen")

--- a/app/src/main/java/com/android/voyageur/App.kt
+++ b/app/src/main/java/com/android/voyageur/App.kt
@@ -23,10 +23,11 @@ import com.android.voyageur.ui.search.SearchUserProfileScreen
 import com.android.voyageur.ui.trip.AddActivityScreen
 import com.android.voyageur.ui.trip.TopTabs
 import com.android.voyageur.ui.trip.activities.ActivitiesForOneDayScreen
+import com.google.ai.client.generativeai.GenerativeModel
 import com.google.android.libraries.places.api.net.PlacesClient
 
 @Composable
-fun VoyageurApp(placesClient: PlacesClient) {
+fun VoyageurApp(placesClient: PlacesClient, generativeModel: GenerativeModel) {
   val navController = rememberNavController()
   val navigationActions = NavigationActions(navController)
   val tripsViewModel: TripsViewModel = viewModel(factory = TripsViewModel.Factory)
@@ -46,7 +47,7 @@ fun VoyageurApp(placesClient: PlacesClient) {
         route = Route.OVERVIEW,
     ) {
       composable(Screen.OVERVIEW) {
-        OverviewScreen(tripsViewModel, navigationActions, userViewModel)
+        OverviewScreen(tripsViewModel, navigationActions, userViewModel, generativeModel)
       }
       composable(Screen.ADD_TRIP) { AddTripScreen(tripsViewModel, navigationActions) }
     }

--- a/app/src/main/java/com/android/voyageur/App.kt
+++ b/app/src/main/java/com/android/voyageur/App.kt
@@ -25,8 +25,8 @@ import com.android.voyageur.ui.search.SearchUserProfileScreen
 import com.android.voyageur.ui.trip.AddActivityScreen
 import com.android.voyageur.ui.trip.TopTabs
 import com.android.voyageur.ui.trip.activities.ActivitiesForOneDayScreen
-import com.android.voyageur.ui.trip.assistant.AssistantScreen
 import com.android.voyageur.ui.trip.activities.EditActivityScreen
+import com.android.voyageur.ui.trip.assistant.AssistantScreen
 import com.google.android.libraries.places.api.net.PlacesClient
 
 @Composable

--- a/app/src/main/java/com/android/voyageur/App.kt
+++ b/app/src/main/java/com/android/voyageur/App.kt
@@ -23,11 +23,11 @@ import com.android.voyageur.ui.search.SearchUserProfileScreen
 import com.android.voyageur.ui.trip.AddActivityScreen
 import com.android.voyageur.ui.trip.TopTabs
 import com.android.voyageur.ui.trip.activities.ActivitiesForOneDayScreen
-import com.google.ai.client.generativeai.GenerativeModel
+import com.android.voyageur.ui.trip.assistant.AssistantScreen
 import com.google.android.libraries.places.api.net.PlacesClient
 
 @Composable
-fun VoyageurApp(placesClient: PlacesClient, generativeModel: GenerativeModel) {
+fun VoyageurApp(placesClient: PlacesClient) {
   val navController = rememberNavController()
   val navigationActions = NavigationActions(navController)
   val tripsViewModel: TripsViewModel = viewModel(factory = TripsViewModel.Factory)
@@ -47,7 +47,7 @@ fun VoyageurApp(placesClient: PlacesClient, generativeModel: GenerativeModel) {
         route = Route.OVERVIEW,
     ) {
       composable(Screen.OVERVIEW) {
-        OverviewScreen(tripsViewModel, navigationActions, userViewModel, generativeModel)
+        OverviewScreen(tripsViewModel, navigationActions, userViewModel)
       }
       composable(Screen.ADD_TRIP) { AddTripScreen(tripsViewModel, navigationActions) }
     }
@@ -75,6 +75,7 @@ fun VoyageurApp(placesClient: PlacesClient, generativeModel: GenerativeModel) {
       composable(Screen.ACTIVITIES_FOR_ONE_DAY) {
         ActivitiesForOneDayScreen(tripsViewModel, navigationActions)
       }
+      composable(Screen.ASSISTANT) { AssistantScreen(tripsViewModel, navigationActions) }
     }
   }
 }

--- a/app/src/main/java/com/android/voyageur/MainActivity.kt
+++ b/app/src/main/java/com/android/voyageur/MainActivity.kt
@@ -11,12 +11,14 @@ import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.semantics.testTag
 import com.android.voyageur.resources.C
 import com.android.voyageur.ui.theme.VoyageurTheme
+import com.google.ai.client.generativeai.GenerativeModel
 import com.google.android.libraries.places.api.Places
 import com.google.android.libraries.places.api.net.PlacesClient
 import com.google.firebase.FirebaseApp
 
 class MainActivity : ComponentActivity() {
   private lateinit var placesClient: PlacesClient
+  private lateinit var generativeModel: GenerativeModel
 
   override fun onCreate(savedInstanceState: Bundle?) {
     super.onCreate(savedInstanceState)
@@ -24,6 +26,13 @@ class MainActivity : ComponentActivity() {
       FirebaseApp.initializeApp(this)
       Places.initialize(applicationContext, BuildConfig.PLACES_API_KEY)
       placesClient = Places.createClient(this)
+      generativeModel =
+          GenerativeModel(
+              // Specify a Gemini model appropriate for your use case
+              modelName = "gemini-1.5-flash-latest",
+              // Access your API key as a Build Configuration variable (see "Set up your API
+              // key" above)
+              apiKey = BuildConfig.GEMINI_API_KEY)
     } catch (e: Exception) {
       e.printStackTrace()
     }
@@ -32,7 +41,7 @@ class MainActivity : ComponentActivity() {
         Surface(
             modifier = Modifier.fillMaxSize().semantics { testTag = C.Tag.main_screen_container },
             color = MaterialTheme.colorScheme.background) {
-              VoyageurApp(placesClient)
+              VoyageurApp(placesClient, generativeModel)
             }
       }
     }

--- a/app/src/main/java/com/android/voyageur/MainActivity.kt
+++ b/app/src/main/java/com/android/voyageur/MainActivity.kt
@@ -11,14 +11,12 @@ import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.semantics.testTag
 import com.android.voyageur.resources.C
 import com.android.voyageur.ui.theme.VoyageurTheme
-import com.google.ai.client.generativeai.GenerativeModel
 import com.google.android.libraries.places.api.Places
 import com.google.android.libraries.places.api.net.PlacesClient
 import com.google.firebase.FirebaseApp
 
 class MainActivity : ComponentActivity() {
   private lateinit var placesClient: PlacesClient
-  private lateinit var generativeModel: GenerativeModel
 
   override fun onCreate(savedInstanceState: Bundle?) {
     super.onCreate(savedInstanceState)
@@ -26,13 +24,6 @@ class MainActivity : ComponentActivity() {
       FirebaseApp.initializeApp(this)
       Places.initialize(applicationContext, BuildConfig.PLACES_API_KEY)
       placesClient = Places.createClient(this)
-      generativeModel =
-          GenerativeModel(
-              // Specify a Gemini model appropriate for your use case
-              modelName = "gemini-1.5-flash-latest",
-              // Access your API key as a Build Configuration variable (see "Set up your API
-              // key" above)
-              apiKey = BuildConfig.GEMINI_API_KEY)
     } catch (e: Exception) {
       e.printStackTrace()
     }
@@ -41,7 +32,7 @@ class MainActivity : ComponentActivity() {
         Surface(
             modifier = Modifier.fillMaxSize().semantics { testTag = C.Tag.main_screen_container },
             color = MaterialTheme.colorScheme.background) {
-              VoyageurApp(placesClient, generativeModel)
+              VoyageurApp(placesClient)
             }
       }
     }

--- a/app/src/main/java/com/android/voyageur/model/activity/Activity.kt
+++ b/app/src/main/java/com/android/voyageur/model/activity/Activity.kt
@@ -1,8 +1,13 @@
 package com.android.voyageur.model.activity
 
+import android.util.Log
 import com.android.voyageur.model.location.Location
 import com.google.firebase.Timestamp
+import com.google.gson.Gson
+import com.google.gson.reflect.TypeToken
+import kotlinx.serialization.Serializable
 
+@Serializable
 data class Activity(
     val title: String = "",
     val description: String = "",
@@ -30,3 +35,11 @@ fun Activity.hasStartTime() = startTime != Timestamp(0, 0)
 fun Activity.hasEndDate() = endTime != Timestamp(0, 0)
 
 fun Activity.isDraft() = !(hasStartTime() && hasEndDate())
+
+fun extractActivitiesFromJson(jsonString: String): MutableList<Activity> {
+  Log.d("testGemini", "extract")
+
+  val gson = Gson()
+  val activityListType = object : TypeToken<List<Activity>>() {}.type
+  return gson.fromJson(jsonString, activityListType)
+}

--- a/app/src/main/java/com/android/voyageur/model/activity/Activity.kt
+++ b/app/src/main/java/com/android/voyageur/model/activity/Activity.kt
@@ -1,6 +1,5 @@
 package com.android.voyageur.model.activity
 
-import android.util.Log
 import com.android.voyageur.model.location.Location
 import com.google.firebase.Timestamp
 import com.google.gson.Gson

--- a/app/src/main/java/com/android/voyageur/model/activity/Activity.kt
+++ b/app/src/main/java/com/android/voyageur/model/activity/Activity.kt
@@ -37,8 +37,6 @@ fun Activity.hasEndDate() = endTime != Timestamp(0, 0)
 fun Activity.isDraft() = !(hasStartTime() && hasEndDate())
 
 fun extractActivitiesFromJson(jsonString: String): MutableList<Activity> {
-  Log.d("testGemini", "extract")
-
   val gson = Gson()
   val activityListType = object : TypeToken<List<Activity>>() {}.type
   return gson.fromJson(jsonString, activityListType)

--- a/app/src/main/java/com/android/voyageur/model/trip/TripsViewModel.kt
+++ b/app/src/main/java/com/android/voyageur/model/trip/TripsViewModel.kt
@@ -4,15 +4,24 @@ import android.net.Uri
 import android.util.Log
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
+import androidx.lifecycle.viewModelScope
+import com.android.voyageur.BuildConfig
+import com.android.voyageur.model.activity.Activity
+import com.google.ai.client.generativeai.GenerativeModel
+import com.google.ai.client.generativeai.type.FunctionType
+import com.google.ai.client.generativeai.type.Schema
+import com.google.ai.client.generativeai.type.generationConfig
 import com.google.firebase.Firebase
 import com.google.firebase.auth.auth
 import com.google.firebase.firestore.firestore
 import com.google.firebase.storage.FirebaseStorage
 import java.time.LocalDate
 import java.util.UUID
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
 
 open class TripsViewModel(
     private val tripsRepository: TripRepository,
@@ -27,6 +36,10 @@ open class TripsViewModel(
   // useful for displaying the activities for one day:
   private val _selectedDay = MutableStateFlow<LocalDate?>(null)
   open val selectedDay: StateFlow<LocalDate?> = _selectedDay.asStateFlow()
+
+  // used for the AI assistant
+  private val _uiState: MutableStateFlow<UiState> = MutableStateFlow(UiState.Initial)
+  open val uiState: StateFlow<UiState> = _uiState.asStateFlow()
 
   init {
     tripsRepository.init {
@@ -105,5 +118,78 @@ open class TripsViewModel(
               .addOnFailureListener { exception -> onFailure(exception) }
         }
         .addOnFailureListener { exception -> onFailure(exception) }
+  }
+
+  open fun addActivityToTrip(activity: Activity) {
+    if (selectedTrip.value != null) {
+      val trip = selectedTrip.value!!
+      val updatedTrip = trip.copy(activities = trip.activities + activity)
+      updateTrip(
+          updatedTrip,
+          onSuccess = {
+            /*
+                This is a trick to force a recompose, because the reference wouldn't
+                change and update the UI.
+            */
+            selectTrip(Trip())
+            selectTrip(updatedTrip)
+          })
+    }
+  }
+
+  // ****************************************************************************************************
+  // AI assistant
+  // ****************************************************************************************************
+  private val generativeModel =
+      GenerativeModel(
+          modelName = "gemini-1.5-flash",
+          apiKey = BuildConfig.GEMINI_API_KEY,
+          generationConfig =
+              generationConfig {
+                responseMimeType = "application/json"
+                responseSchema =
+                    Schema(
+                        name = "activities",
+                        description = "List of activities",
+                        type = FunctionType.ARRAY,
+                        items =
+                            Schema(
+                                name = "activity",
+                                description = "An activity",
+                                type = FunctionType.OBJECT,
+                                properties =
+                                    mapOf(
+                                        "title" to
+                                            Schema(
+                                                name = "title",
+                                                description = "Title of the activity",
+                                                type = FunctionType.STRING),
+                                        "description" to
+                                            Schema(
+                                                name = "description",
+                                                description = "Description of the activity",
+                                                type = FunctionType.STRING)),
+                                required = listOf("title", "description")))
+              })
+
+  fun sendActivitiesPrompt(trip: Trip, prompt: String) {
+    _uiState.value = UiState.Loading
+
+    viewModelScope.launch(Dispatchers.IO) {
+      try {
+        val response =
+            generativeModel.generateContent(
+                "List a few popular specific activities to do on a trip called ${trip.name} and with the following prompt: $prompt")
+        Log.d("testGemini", response.text ?: "")
+        response.text?.let { outputContent -> _uiState.value = UiState.Success(outputContent) }
+      } catch (e: Exception) {
+        Log.e("Error", e.localizedMessage ?: "")
+        _uiState.value = UiState.Error(e.localizedMessage ?: "")
+      }
+    }
+  }
+
+  fun setInitialUiState() {
+    _uiState.value = UiState.Initial
   }
 }

--- a/app/src/main/java/com/android/voyageur/model/trip/TripsViewModel.kt
+++ b/app/src/main/java/com/android/voyageur/model/trip/TripsViewModel.kt
@@ -180,16 +180,14 @@ open class TripsViewModel(
         val response =
             generativeModel.generateContent(
                 "List a few popular specific activities to do on a trip called ${trip.name} and with the following prompt: $prompt")
-        Log.d("testGemini", response.text ?: "")
         response.text?.let { outputContent -> _uiState.value = UiState.Success(outputContent) }
       } catch (e: Exception) {
-        Log.e("Error", e.localizedMessage ?: "")
         _uiState.value = UiState.Error(e.localizedMessage ?: "")
       }
     }
   }
 
-  fun setInitialUiState() {
+  open fun setInitialUiState() {
     _uiState.value = UiState.Initial
   }
 }

--- a/app/src/main/java/com/android/voyageur/model/trip/TripsViewModel.kt
+++ b/app/src/main/java/com/android/voyageur/model/trip/TripsViewModel.kt
@@ -189,7 +189,7 @@ open class TripsViewModel(
                 "List a few popular specific activities to do on a trip called ${trip.name} and with the following prompt: $prompt")
         response.text?.let { outputContent -> _uiState.value = UiState.Success(outputContent) }
       } catch (e: Exception) {
-        _uiState.value = UiState.Error(e.localizedMessage ?: "")
+        _uiState.value = UiState.Error(e.localizedMessage ?: "unknown error")
       }
     }
   }

--- a/app/src/main/java/com/android/voyageur/model/trip/UiState.kt
+++ b/app/src/main/java/com/android/voyageur/model/trip/UiState.kt
@@ -1,0 +1,17 @@
+package com.android.voyageur.model.trip
+
+/** A sealed hierarchy describing the state of the text generation. */
+sealed interface UiState {
+
+  /** Empty state when the screen is first shown */
+  object Initial : UiState
+
+  /** Still loading */
+  object Loading : UiState
+
+  /** Text has been generated */
+  data class Success(val outputText: String) : UiState
+
+  /** There was an error generating text */
+  data class Error(val errorMessage: String) : UiState
+}

--- a/app/src/main/java/com/android/voyageur/ui/navigation/NavigationActions.kt
+++ b/app/src/main/java/com/android/voyageur/ui/navigation/NavigationActions.kt
@@ -35,6 +35,7 @@ object Screen {
   const val ACTIVITIES_FOR_ONE_DAY = "Activities For One Day Screen"
   const val SEARCH_USER_PROFILE = "Search User Profile Screen"
   const val PLACE_DETAILS = "Place Details Screen"
+  const val ASSISTANT = "Assistant Screen"
 }
 
 data class TopLevelDestination(

--- a/app/src/main/java/com/android/voyageur/ui/overview/Overview.kt
+++ b/app/src/main/java/com/android/voyageur/ui/overview/Overview.kt
@@ -31,7 +31,6 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
@@ -52,11 +51,9 @@ import com.android.voyageur.ui.navigation.BottomNavigationMenu
 import com.android.voyageur.ui.navigation.LIST_TOP_LEVEL_DESTINATION
 import com.android.voyageur.ui.navigation.NavigationActions
 import com.android.voyageur.ui.navigation.Screen
-import com.google.ai.client.generativeai.GenerativeModel
 import com.google.firebase.Firebase
 import com.google.firebase.Timestamp
 import com.google.firebase.auth.auth
-import kotlinx.coroutines.launch
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -64,10 +61,8 @@ fun OverviewScreen(
     tripsViewModel: TripsViewModel,
     navigationActions: NavigationActions,
     userViewModel: UserViewModel,
-    generativeModel: GenerativeModel
 ) {
   val trips by tripsViewModel.trips.collectAsState()
-  val coroutineScope = rememberCoroutineScope()
   LaunchedEffect(trips) {
     userViewModel.getUsersByIds(
         trips.map { it.participants }.flatten(), { userViewModel._allParticipants.value = it })
@@ -75,13 +70,7 @@ fun OverviewScreen(
   Scaffold(
       floatingActionButton = {
         FloatingActionButton(
-            onClick = {
-              coroutineScope.launch {
-                val prompt = "Write a two sentence story about a magic backpack."
-                val response = generativeModel.generateContent(prompt)
-              }
-              navigationActions.navigateTo(Screen.ADD_TRIP)
-            },
+            onClick = { navigationActions.navigateTo(Screen.ADD_TRIP) },
             modifier = Modifier.testTag("createTripButton")) {
               Icon(
                   Icons.Outlined.Add,

--- a/app/src/main/java/com/android/voyageur/ui/overview/Overview.kt
+++ b/app/src/main/java/com/android/voyageur/ui/overview/Overview.kt
@@ -31,6 +31,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
@@ -51,18 +52,22 @@ import com.android.voyageur.ui.navigation.BottomNavigationMenu
 import com.android.voyageur.ui.navigation.LIST_TOP_LEVEL_DESTINATION
 import com.android.voyageur.ui.navigation.NavigationActions
 import com.android.voyageur.ui.navigation.Screen
+import com.google.ai.client.generativeai.GenerativeModel
 import com.google.firebase.Firebase
 import com.google.firebase.Timestamp
 import com.google.firebase.auth.auth
+import kotlinx.coroutines.launch
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun OverviewScreen(
     tripsViewModel: TripsViewModel,
     navigationActions: NavigationActions,
-    userViewModel: UserViewModel
+    userViewModel: UserViewModel,
+    generativeModel: GenerativeModel
 ) {
   val trips by tripsViewModel.trips.collectAsState()
+  val coroutineScope = rememberCoroutineScope()
   LaunchedEffect(trips) {
     userViewModel.getUsersByIds(
         trips.map { it.participants }.flatten(), { userViewModel._allParticipants.value = it })
@@ -70,7 +75,13 @@ fun OverviewScreen(
   Scaffold(
       floatingActionButton = {
         FloatingActionButton(
-            onClick = { navigationActions.navigateTo(Screen.ADD_TRIP) },
+            onClick = {
+              coroutineScope.launch {
+                val prompt = "Write a two sentence story about a magic backpack."
+                val response = generativeModel.generateContent(prompt)
+              }
+              navigationActions.navigateTo(Screen.ADD_TRIP)
+            },
             modifier = Modifier.testTag("createTripButton")) {
               Icon(
                   Icons.Outlined.Add,

--- a/app/src/main/java/com/android/voyageur/ui/trip/activities/Activities.kt
+++ b/app/src/main/java/com/android/voyageur/ui/trip/activities/Activities.kt
@@ -1,6 +1,7 @@
 package com.android.voyageur.ui.trip.activities
 
 import android.annotation.SuppressLint
+import android.widget.Toast
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -18,6 +19,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
@@ -50,6 +52,7 @@ fun ActivitiesScreen(
                   { it.startTime }, // First, sort by startTime
                   { it.endTime } // If startTime is equal, sort by endTime
                   ))
+  val context = LocalContext.current
 
   Scaffold(
       // TODO: Search Bar
@@ -76,7 +79,14 @@ fun ActivitiesScreen(
           }
           drafts.forEach { activity ->
             item {
-              ActivityItem(activity)
+              ActivityItem(
+                  activity,
+                  onClickButton = {
+                    Toast.makeText(
+                            context, "Delete activity not implemented yet", Toast.LENGTH_SHORT)
+                        .show()
+                  },
+                  ButtonType.DELETE)
               Spacer(modifier = Modifier.height(10.dp))
             }
           }
@@ -89,7 +99,14 @@ fun ActivitiesScreen(
           }
           final.forEach { activity ->
             item {
-              ActivityItem(activity)
+              ActivityItem(
+                  activity,
+                  onClickButton = {
+                    Toast.makeText(
+                            context, "Delete activity not implemented yet", Toast.LENGTH_SHORT)
+                        .show()
+                  },
+                  ButtonType.DELETE)
               Spacer(modifier = Modifier.height(10.dp))
             }
           }

--- a/app/src/main/java/com/android/voyageur/ui/trip/activities/Activities.kt
+++ b/app/src/main/java/com/android/voyageur/ui/trip/activities/Activities.kt
@@ -86,6 +86,7 @@ fun ActivitiesScreen(
             item {
               ActivityItem(
                   activity,
+                  true,
                   onClickButton = {
                     Toast.makeText(
                             context, "Delete activity not implemented yet", Toast.LENGTH_SHORT)
@@ -108,6 +109,7 @@ fun ActivitiesScreen(
             item {
               ActivityItem(
                   activity,
+                  true,
                   onClickButton = {
                     Toast.makeText(
                             context, "Delete activity not implemented yet", Toast.LENGTH_SHORT)

--- a/app/src/main/java/com/android/voyageur/ui/trip/activities/Activities.kt
+++ b/app/src/main/java/com/android/voyageur/ui/trip/activities/Activities.kt
@@ -92,7 +92,8 @@ fun ActivitiesScreen(
                         .show()
                   },
                   ButtonType.DELETE,
-                  navigationActions, tripsViewModel)
+                  navigationActions,
+                  tripsViewModel)
               Spacer(modifier = Modifier.height(10.dp))
             }
           }
@@ -112,7 +113,9 @@ fun ActivitiesScreen(
                             context, "Delete activity not implemented yet", Toast.LENGTH_SHORT)
                         .show()
                   },
-                  ButtonType.DELETE, navigationActions, tripsViewModel)
+                  ButtonType.DELETE,
+                  navigationActions,
+                  tripsViewModel)
               Spacer(modifier = Modifier.height(10.dp))
             }
           }

--- a/app/src/main/java/com/android/voyageur/ui/trip/activities/ActivitiesForOneDay.kt
+++ b/app/src/main/java/com/android/voyageur/ui/trip/activities/ActivitiesForOneDay.kt
@@ -78,6 +78,7 @@ fun ActivitiesForOneDayScreen(
               item {
                 ActivityItem(
                     activity,
+                    true,
                     onClickButton = {
                       Toast.makeText(
                               context, "Delete activity not implemented yet", Toast.LENGTH_SHORT)

--- a/app/src/main/java/com/android/voyageur/ui/trip/activities/ActivitiesForOneDay.kt
+++ b/app/src/main/java/com/android/voyageur/ui/trip/activities/ActivitiesForOneDay.kt
@@ -83,7 +83,9 @@ fun ActivitiesForOneDayScreen(
                               context, "Delete activity not implemented yet", Toast.LENGTH_SHORT)
                           .show()
                     },
-                    ButtonType.DELETE, navigationActions, tripsViewModel)
+                    ButtonType.DELETE,
+                    navigationActions,
+                    tripsViewModel)
                 Spacer(modifier = Modifier.height(10.dp))
               }
             }

--- a/app/src/main/java/com/android/voyageur/ui/trip/activities/ActivitiesForOneDay.kt
+++ b/app/src/main/java/com/android/voyageur/ui/trip/activities/ActivitiesForOneDay.kt
@@ -1,5 +1,6 @@
 package com.android.voyageur.ui.trip.activities
 
+import android.widget.Toast
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Spacer
@@ -14,6 +15,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.unit.dp
 import com.android.voyageur.model.trip.TripsViewModel
@@ -50,7 +52,7 @@ fun ActivitiesForOneDayScreen(
                   { it.startTime }, // First, sort by startTime
                   { it.endTime } // If startTime is equal, sort by endTime
                   ))
-
+  val context = LocalContext.current
   Scaffold(
       modifier = Modifier.testTag("activitiesForOneDayScreen"),
       topBar = {
@@ -74,7 +76,14 @@ fun ActivitiesForOneDayScreen(
           ) {
             activities.forEach { activity ->
               item {
-                ActivityItem(activity)
+                ActivityItem(
+                    activity,
+                    onClickButton = {
+                      Toast.makeText(
+                              context, "Delete activity not implemented yet", Toast.LENGTH_SHORT)
+                          .show()
+                    },
+                    ButtonType.DELETE)
                 Spacer(modifier = Modifier.height(10.dp))
               }
             }

--- a/app/src/main/java/com/android/voyageur/ui/trip/activities/ActivityItem.kt
+++ b/app/src/main/java/com/android/voyageur/ui/trip/activities/ActivityItem.kt
@@ -11,8 +11,8 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.ArrowDropDown
 import androidx.compose.material.icons.twotone.Delete
-import androidx.compose.material3.Button
 import androidx.compose.material.icons.twotone.Edit
+import androidx.compose.material3.Button
 import androidx.compose.material3.Card
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
@@ -106,29 +106,29 @@ fun ActivityItem(
                                 imageVector = Icons.TwoTone.Edit,
                                 contentDescription = "Edit Activity")
                           }
-                    // Delete icon
-                    if (buttonPurpose == ButtonType.DELETE) {
-                      IconButton(
-                          onClick = onClickButton,
-                          modifier = Modifier.testTag("deleteIcon_${activity.title}"),
-                      ) {
-                        Icon(
-                            imageVector = Icons.TwoTone.Delete,
-                            contentDescription = "Delete Activity",
-                            tint = Color.Red)
-                      }
-                    } else {
-                      // Add icon
-                      if (buttonPurpose == ButtonType.ADD) {
-                        Button(
+                      // Delete icon
+                      if (buttonPurpose == ButtonType.DELETE) {
+                        IconButton(
                             onClick = onClickButton,
-                            modifier = Modifier.testTag("addIcon_${activity.title}")) {
-                              Text(text = "Add")
-                            }
-                          }
+                            modifier = Modifier.testTag("deleteIcon_${activity.title}"),
+                        ) {
+                          Icon(
+                              imageVector = Icons.TwoTone.Delete,
+                              contentDescription = "Delete Activity",
+                              tint = Color.Red)
+                        }
+                      } else {
+                        // Add icon
+                        if (buttonPurpose == ButtonType.ADD) {
+                          Button(
+                              onClick = onClickButton,
+                              modifier = Modifier.testTag("addIcon_${activity.title}")) {
+                                Text(text = "Add")
+                              }
+                        }
                       }
                     }
-                      }
+                  }
 
                   // Expand/collapse icon
                   IconButton(

--- a/app/src/main/java/com/android/voyageur/ui/trip/activities/ActivityItem.kt
+++ b/app/src/main/java/com/android/voyageur/ui/trip/activities/ActivityItem.kt
@@ -50,6 +50,7 @@ import java.util.Locale
 @Composable
 fun ActivityItem(
     activity: Activity,
+    isEditable: Boolean = false,
     onClickButton: () -> Unit = {}, // Default do nothing
     buttonPurpose: ButtonType = ButtonType.NOTHING,
     navigationActions: NavigationActions,
@@ -97,15 +98,19 @@ fun ActivityItem(
                 Row(verticalAlignment = Alignment.CenterVertically) {
                   AnimatedVisibility(visible = isExpanded) {
                     Row {
-                      IconButton(
-                          onClick = {
-                            navigationActions.navigateTo(Screen.EDIT_ACTIVITY)
-                            tripsViewModel.selectActivity(activity)
-                          }) {
-                            Icon(
-                                imageVector = Icons.TwoTone.Edit,
-                                contentDescription = "Edit Activity")
-                          }
+                      if (isEditable) {
+                        // Edit icon
+                        IconButton(
+                            onClick = {
+                              navigationActions.navigateTo(Screen.EDIT_ACTIVITY)
+                              tripsViewModel.selectActivity(activity)
+                            },
+                            modifier = Modifier.testTag("editIcon_${activity.title}")) {
+                              Icon(
+                                  imageVector = Icons.TwoTone.Edit,
+                                  contentDescription = "Edit Activity")
+                            }
+                      }
                       // Delete icon
                       if (buttonPurpose == ButtonType.DELETE) {
                         IconButton(

--- a/app/src/main/java/com/android/voyageur/ui/trip/activities/ActivityItem.kt
+++ b/app/src/main/java/com/android/voyageur/ui/trip/activities/ActivityItem.kt
@@ -1,6 +1,5 @@
 package com.android.voyageur.ui.trip.activities
 
-import android.widget.Toast
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
@@ -12,6 +11,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.ArrowDropDown
 import androidx.compose.material.icons.twotone.Delete
+import androidx.compose.material3.Button
 import androidx.compose.material3.Card
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
@@ -26,7 +26,6 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.rotate
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
@@ -47,6 +46,8 @@ import java.util.Locale
 @Composable
 fun ActivityItem(
     activity: Activity,
+    onClickButton: () -> Unit = {}, // Default do nothing
+    buttonPurpose: ButtonType = ButtonType.NOTHING
 ) {
   var isExpanded by remember { mutableStateOf(false) }
 
@@ -63,8 +64,6 @@ fun ActivityItem(
   val dateFormatted = dateFormat.format(startLocalDateTime)
   val startTimeFormatted = timeFormat.format(startLocalDateTime)
   val endTimeFormatted = timeFormat.format(endLocalDateTime)
-
-  val context = LocalContext.current
 
   Card(
       shape = MaterialTheme.shapes.medium,
@@ -90,21 +89,28 @@ fun ActivityItem(
                 }
 
                 Row(verticalAlignment = Alignment.CenterVertically) {
-                  // Delete icon, visible only when expanded
                   AnimatedVisibility(visible = isExpanded) {
-                    IconButton(
-                        onClick = { /*TODO: delete activity*/
-                          Toast.makeText(
-                                  context,
-                                  "Delete activity not implemented yet",
-                                  Toast.LENGTH_SHORT)
-                              .show()
-                        }) {
-                          Icon(
-                              imageVector = Icons.TwoTone.Delete,
-                              contentDescription = "Delete Activity",
-                              tint = Color.Red)
-                        }
+                    // Delete icon
+                    if (buttonPurpose == ButtonType.DELETE) {
+                      IconButton(
+                          onClick = onClickButton,
+                          modifier = Modifier.testTag("deleteIcon_${activity.title}"),
+                      ) {
+                        Icon(
+                            imageVector = Icons.TwoTone.Delete,
+                            contentDescription = "Delete Activity",
+                            tint = Color.Red)
+                      }
+                    } else {
+                      // Add icon
+                      if (buttonPurpose == ButtonType.ADD) {
+                        Button(
+                            onClick = onClickButton,
+                            modifier = Modifier.testTag("addIcon_${activity.title}")) {
+                              Text(text = "Add")
+                            }
+                      }
+                    }
                   }
 
                   // Expand/collapse icon
@@ -154,4 +160,14 @@ fun ActivityItem(
           }
         }
       })
+}
+
+/**
+ * Enum class for the types of buttons that can be displayed in the activity item. DELETE: deletes
+ * the activity from the trip ADD: adds the activity to the trip NOTHING: no button is displayed
+ */
+enum class ButtonType {
+  DELETE,
+  ADD,
+  NOTHING
 }

--- a/app/src/main/java/com/android/voyageur/ui/trip/assistant/Assistant.kt
+++ b/app/src/main/java/com/android/voyageur/ui/trip/assistant/Assistant.kt
@@ -108,7 +108,9 @@ fun AssistantScreen(tripsViewModel: TripsViewModel, navigationActions: Navigatio
                           // add this activity to the trip
                           tripsViewModel.addActivityToTrip(activity)
                         },
-                        buttonPurpose = ButtonType.ADD)
+                        buttonPurpose = ButtonType.ADD,
+                        navigationActions,
+                        tripsViewModel)
                     Spacer(modifier = Modifier.height(10.dp))
                   }
                 }

--- a/app/src/main/java/com/android/voyageur/ui/trip/assistant/Assistant.kt
+++ b/app/src/main/java/com/android/voyageur/ui/trip/assistant/Assistant.kt
@@ -1,6 +1,5 @@
 package com.android.voyageur.ui.trip.assistant
 
-import android.util.Log
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -104,15 +103,10 @@ fun AssistantScreen(tripsViewModel: TripsViewModel, navigationActions: Navigatio
                     ActivityItem(
                         activity = activity,
                         onClickButton = {
-                          Log.d("NewActivitiesScreen", "Adding activity: $activity")
-                          Log.d("NewActivitiesScreen", "Current activities: $activities")
+                            // remove this activity from the list
                           activities = activities.filter { it != activity }
                           // add this activity to the trip
                           tripsViewModel.addActivityToTrip(activity)
-                          Log.d("NewActivitiesScreen", trip.activities.toString())
-                          //                        activities = activities.toMutableList().apply {
-                          // remove(activity) }
-                          Log.d("NewActivitiesScreen", "After removing: $activities")
                         },
                         buttonPurpose = ButtonType.ADD)
                     Spacer(modifier = Modifier.height(10.dp))

--- a/app/src/main/java/com/android/voyageur/ui/trip/assistant/Assistant.kt
+++ b/app/src/main/java/com/android/voyageur/ui/trip/assistant/Assistant.kt
@@ -1,0 +1,126 @@
+package com.android.voyageur.ui.trip.assistant
+
+import android.util.Log
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.Button
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextField
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import com.android.voyageur.model.activity.Activity
+import com.android.voyageur.model.activity.extractActivitiesFromJson
+import com.android.voyageur.model.trip.TripsViewModel
+import com.android.voyageur.model.trip.UiState
+import com.android.voyageur.ui.navigation.NavigationActions
+import com.android.voyageur.ui.trip.activities.ActivityItem
+import com.android.voyageur.ui.trip.activities.ButtonType
+import com.android.voyageur.ui.trip.schedule.TopBarWithImageAndText
+
+@Composable
+fun AssistantScreen(tripsViewModel: TripsViewModel, navigationActions: NavigationActions) {
+  var result by rememberSaveable { mutableStateOf("placeholderResult") }
+  val uiState by tripsViewModel.uiState.collectAsState()
+  var prompt by rememberSaveable { mutableStateOf("") }
+  var activities by remember { mutableStateOf(emptyList<Activity>()) }
+
+  val trip =
+      tripsViewModel.selectedTrip.value ?: return Text(text = "No trip selected. Should not happen")
+
+  Scaffold(
+      modifier = Modifier.testTag("assistantScreen"),
+      content = { pd ->
+        Column {
+          TopBarWithImageAndText(trip, navigationActions, "Ask the AI assistant!", trip.name)
+          Row(modifier = Modifier.padding(all = 16.dp)) {
+            TextField(
+                value = prompt,
+                label = { Text("prompt") },
+                onValueChange = { prompt = it },
+                modifier =
+                    Modifier.testTag("AIRequestTextField")
+                        .weight(0.8f)
+                        .padding(end = 16.dp)
+                        .align(Alignment.CenterVertically))
+            Button(
+                onClick = { tripsViewModel.sendActivitiesPrompt(trip, prompt) },
+                modifier = Modifier.testTag("AIRequestButton").align(Alignment.CenterVertically)) {
+                  Text(text = "go")
+                }
+          }
+
+          if (uiState is UiState.Loading) {
+            CircularProgressIndicator(
+                modifier = Modifier.testTag("loadingIndicator").align(Alignment.CenterHorizontally))
+          } else {
+            val scrollState = rememberScrollState()
+            if (uiState is UiState.Error) {
+              result = (uiState as UiState.Error).errorMessage
+              Text(
+                  text = result,
+                  textAlign = TextAlign.Start,
+                  color = MaterialTheme.colorScheme.error,
+                  modifier =
+                      Modifier.testTag("errorMessage")
+                          .align(Alignment.CenterHorizontally)
+                          .padding(16.dp)
+                          .fillMaxSize()
+                          .verticalScroll(scrollState))
+            } else if (uiState is UiState.Success) {
+              result = (uiState as UiState.Success).outputText
+              activities = extractActivitiesFromJson(result)
+              LazyColumn(
+                  modifier =
+                      Modifier.padding(pd)
+                          .padding(top = 16.dp)
+                          .fillMaxWidth()
+                          .testTag("lazyColumn"),
+                  verticalArrangement = Arrangement.spacedBy(10.dp, Alignment.Top),
+              ) {
+                activities.forEach { activity ->
+                  item {
+                    ActivityItem(
+                        activity = activity,
+                        onClickButton = {
+                          Log.d("NewActivitiesScreen", "Adding activity: $activity")
+                          Log.d("NewActivitiesScreen", "Current activities: $activities")
+                          activities = activities.filter { it != activity }
+                          // add this activity to the trip
+                          tripsViewModel.addActivityToTrip(activity)
+                          Log.d("NewActivitiesScreen", trip.activities.toString())
+                          //                        activities = activities.toMutableList().apply {
+                          // remove(activity) }
+                          Log.d("NewActivitiesScreen", "After removing: $activities")
+                        },
+                        buttonPurpose = ButtonType.ADD)
+                    Spacer(modifier = Modifier.height(10.dp))
+                  }
+                }
+              }
+            }
+          }
+        }
+      })
+}

--- a/app/src/main/java/com/android/voyageur/ui/trip/assistant/Assistant.kt
+++ b/app/src/main/java/com/android/voyageur/ui/trip/assistant/Assistant.kt
@@ -103,7 +103,7 @@ fun AssistantScreen(tripsViewModel: TripsViewModel, navigationActions: Navigatio
                     ActivityItem(
                         activity = activity,
                         onClickButton = {
-                            // remove this activity from the list
+                          // remove this activity from the list
                           activities = activities.filter { it != activity }
                           // add this activity to the trip
                           tripsViewModel.addActivityToTrip(activity)

--- a/app/src/main/java/com/android/voyageur/ui/trip/assistant/Assistant.kt
+++ b/app/src/main/java/com/android/voyageur/ui/trip/assistant/Assistant.kt
@@ -102,6 +102,7 @@ fun AssistantScreen(tripsViewModel: TripsViewModel, navigationActions: Navigatio
                   item {
                     ActivityItem(
                         activity = activity,
+                        false,
                         onClickButton = {
                           // remove this activity from the list
                           activities = activities.filter { it != activity }

--- a/app/src/main/java/com/android/voyageur/ui/trip/schedule/ScheduleScreen.kt
+++ b/app/src/main/java/com/android/voyageur/ui/trip/schedule/ScheduleScreen.kt
@@ -10,8 +10,6 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.font.FontWeight
@@ -19,6 +17,7 @@ import androidx.compose.ui.unit.dp
 import com.android.voyageur.model.trip.Trip
 import com.android.voyageur.model.trip.TripsViewModel
 import com.android.voyageur.ui.navigation.NavigationActions
+import com.android.voyageur.ui.navigation.Screen
 
 @Composable
 fun ScheduleScreen(
@@ -28,42 +27,63 @@ fun ScheduleScreen(
 ) {
 
   Column(modifier = Modifier.fillMaxSize().padding(top = 8.dp)) {
-    // Row for the "Daily" and "Weekly" buttons
     Row(
-        modifier = Modifier.fillMaxWidth().padding(bottom = 8.dp, end = 16.dp),
-        horizontalArrangement = Arrangement.End,
+        modifier = Modifier.fillMaxWidth().padding(bottom = 8.dp, start = 16.dp, end = 16.dp),
+        horizontalArrangement = Arrangement.SpaceBetween,
         verticalAlignment = Alignment.CenterVertically) {
+          // "Ask Assistant" button on the left
           TextButton(
-              onClick = { navigationActions.getNavigationState().isDailyViewSelected = true }) {
+              onClick = {
+                //              tripsViewModel.sendActivityPrompt(trip)
+                tripsViewModel.setInitialUiState()
+                navigationActions.navigateTo(Screen.ASSISTANT)
+              }) {
                 Text(
-                    text = "Daily",
+                    text = "Ask Assistant",
                     style = MaterialTheme.typography.bodyMedium,
-                    color =
-                        if (navigationActions.getNavigationState().isDailyViewSelected)
-                            MaterialTheme.colorScheme.primary
-                        else MaterialTheme.colorScheme.onSurface.copy(alpha = 0.6f),
-                    fontWeight =
-                        if (navigationActions.getNavigationState().isDailyViewSelected)
-                            FontWeight.Bold
-                        else FontWeight.Normal)
+                    color = MaterialTheme.colorScheme.primary,
+                    fontWeight = FontWeight.Bold)
               }
-          Text(
-              text = " / ",
-              style = MaterialTheme.typography.bodyMedium,
-              color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.6f))
-          TextButton(
-              onClick = { navigationActions.getNavigationState().isDailyViewSelected = false }) {
+          Row(
+              modifier = Modifier.fillMaxWidth().padding(bottom = 8.dp, end = 16.dp),
+              horizontalArrangement = Arrangement.End,
+              verticalAlignment = Alignment.CenterVertically) {
+                TextButton(
+                    onClick = {
+                      navigationActions.getNavigationState().isDailyViewSelected = true
+                    }) {
+                      Text(
+                          text = "Daily",
+                          style = MaterialTheme.typography.bodyMedium,
+                          color =
+                              if (navigationActions.getNavigationState().isDailyViewSelected)
+                                  MaterialTheme.colorScheme.primary
+                              else MaterialTheme.colorScheme.onSurface.copy(alpha = 0.6f),
+                          fontWeight =
+                              if (navigationActions.getNavigationState().isDailyViewSelected)
+                                  FontWeight.Bold
+                              else FontWeight.Normal)
+                    }
                 Text(
-                    text = "Weekly",
+                    text = " / ",
                     style = MaterialTheme.typography.bodyMedium,
-                    color =
-                        if (!navigationActions.getNavigationState().isDailyViewSelected)
-                            MaterialTheme.colorScheme.primary
-                        else MaterialTheme.colorScheme.onSurface.copy(alpha = 0.6f),
-                    fontWeight =
-                        if (!navigationActions.getNavigationState().isDailyViewSelected)
-                            FontWeight.Bold
-                        else FontWeight.Normal)
+                    color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.6f))
+                TextButton(
+                    onClick = {
+                      navigationActions.getNavigationState().isDailyViewSelected = false
+                    }) {
+                      Text(
+                          text = "Weekly",
+                          style = MaterialTheme.typography.bodyMedium,
+                          color =
+                              if (!navigationActions.getNavigationState().isDailyViewSelected)
+                                  MaterialTheme.colorScheme.primary
+                              else MaterialTheme.colorScheme.onSurface.copy(alpha = 0.6f),
+                          fontWeight =
+                              if (!navigationActions.getNavigationState().isDailyViewSelected)
+                                  FontWeight.Bold
+                              else FontWeight.Normal)
+                    }
               }
         }
 

--- a/app/src/main/java/com/android/voyageur/ui/trip/schedule/ScheduleScreen.kt
+++ b/app/src/main/java/com/android/voyageur/ui/trip/schedule/ScheduleScreen.kt
@@ -34,7 +34,6 @@ fun ScheduleScreen(
           // "Ask Assistant" button on the left
           TextButton(
               onClick = {
-                //              tripsViewModel.sendActivityPrompt(trip)
                 tripsViewModel.setInitialUiState()
                 navigationActions.navigateTo(Screen.ASSISTANT)
               }) {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -81,6 +81,7 @@ testng = "6.9.6"
 foundationAndroid = "1.7.5"
 core = "1.46.0"
 junitKtx = "1.2.1"
+runtimeLivedata = "1.7.5"
 
 [libraries]
 accompanist-permissions = { module = "com.google.accompanist:accompanist-permissions", version.ref = "accompanistPermissions" }
@@ -147,6 +148,7 @@ testng = { group = "org.testng", name = "testng", version.ref = "testng" }
 androidx-foundation-android = { group = "androidx.compose.foundation", name = "foundation-android", version.ref = "foundationAndroid" }
 core = { group = "com.google.ar", name = "core", version.ref = "core" }
 androidx-junit-ktx = { group = "androidx.test.ext", name = "junit-ktx", version.ref = "junitKtx" }
+androidx-runtime-livedata = { group = "androidx.compose.runtime", name = "runtime-livedata", version.ref = "runtimeLivedata" }
 
 
 [plugins]


### PR DESCRIPTION
## Summary

This new feature allows users to receive recommendations for activities based on the trip name and a custom prompt they enter. The button used to access the AI assistant lives on the Schedule screen. If users like any of the activities, they can directly add an activity to the trip by clicking a button. 
An error may occur when entering a prompt (usually it's related to the Gemini servers). I this case, the users must try again. In a future PR we will automatically retry requests until they are successful, but for now the retries must be done manually.


## Changes

- **Models:** added UiState - with {initial, success, error, loading} we can now display a loading icon and also more easily differentiate between success and error. Also added the Gemini API call to TripsViewModel, and other useful methods for handling the assistant such as addActivityToTrip. 
- **Screens/UI:** Added the AssistantScreen that can be accessed from the Schedule screen. ActivityItem now has 3 more parameters: isEditable (True if the edit button should appear), onClickButton (the expected action when the button is clicked), buttonPurpose (Until now we distinguish two types of buttons: Delete and Add)
- **Bug Fixes/Improvements:** Activity Items can now have a delete button, an add button or no button. ActivityItems aren't editable by default.

## Checklist

Ensure all / most of these are checked before the pull request is submitted.
- [x] This PR resolves #183 
- [x] Tests have been added for new functionality.
- [x] Screenshots or UI changes have been attached (if applicable).
- [x] Documentation has been updated (if applicable).

##  Testing

- **Manual Testing:**
    - [x] Tested on emulator / physical device.
- **Unit Tests**
    - [x] Added units tests for this



## Screenshots (if applicable)

[gemini first use.webm](https://github.com/user-attachments/assets/3ec454c0-3f47-4a5b-a074-64f3883fcf1e)
