### PR TITLE
date picker remembers selected date

### DIFF
--- a/app/src/main/java/com/android/voyageur/ui/trip/AddActivity.kt
+++ b/app/src/main/java/com/android/voyageur/ui/trip/AddActivity.kt
@@ -303,7 +303,7 @@ fun AddActivityScreen(
                         showModal = false
                       },
                       onDismiss = { showModal = false },
-                      selectedDate = System.currentTimeMillis())
+                      selectedDate = activityDate ?: System.currentTimeMillis())
                 }
 
                 FlowRow(


### PR DESCRIPTION
## Summary

This PR introduces a small UI fix: the date picker shows the already selected date when you open it in edit mode for addActivityScreen.

## Changes

- **Screens/UI:** addActivityScreen/editActivityScreen.
- **Bug Fixes/Improvements:** Addresses #207 .

## Checklist

Ensure all / most of these are checked before the pull request is submitted.
- [x] This PR resolves #207 .
- [ ] Tests have been added for new functionality.
- [x] Screenshots or UI changes have been attached (if applicable).
- [x] Documentation has been updated (if applicable).

##  Testing

- **Manual Testing:**
    - [x] Tested on emulator / physical device.
- **Unit Tests**
    - [ ] Added units tests for this

If you haven't added tests, please create a new issue and assign it.

##  Related Issues/Tickets

Closes #207 

## Screenshots (if applicable)


https://github.com/user-attachments/assets/5eebe66a-21ae-4142-a44a-f13443de61a7


