### PR TITLE
avoid duplicate savings

### DIFF
--- a/app/src/main/java/com/android/voyageur/model/trip/TripsViewModel.kt
+++ b/app/src/main/java/com/android/voyageur/model/trip/TripsViewModel.kt
@@ -17,7 +17,6 @@ import com.google.firebase.firestore.firestore
 import com.google.firebase.storage.FirebaseStorage
 import java.time.LocalDate
 import java.util.UUID
-import android.util.Log
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -105,12 +104,9 @@ open class TripsViewModel(
 
   fun deleteTripById(id: String, onSuccess: () -> Unit = {}) {
     tripsRepository.deleteTripById(
-        
         id = id,
-       
         onSuccess = { getTrips(onSuccess) },
-       
-        onFailure = { exception -> Log.e("TripsViewModel", "Failed to delete trip", exception)  exception -> Log.e("TripsViewModel", "Failed to delete trip", exception) })
+        onFailure = { exception -> Log.e("TripsViewModel", "Failed to delete trip", exception) })
   }
 
   fun updateTrip(trip: Trip, onSuccess: () -> Unit = {}, onFailure: (Exception) -> Unit = {}) {

--- a/app/src/main/java/com/android/voyageur/model/trip/TripsViewModel.kt
+++ b/app/src/main/java/com/android/voyageur/model/trip/TripsViewModel.kt
@@ -1,6 +1,7 @@
 package com.android.voyageur.model.trip
 
 import android.net.Uri
+import android.util.Log
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
 import com.android.voyageur.model.activity.Activity
@@ -10,7 +11,6 @@ import com.google.firebase.firestore.firestore
 import com.google.firebase.storage.FirebaseStorage
 import java.time.LocalDate
 import java.util.UUID
-import android.util.Log
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -91,7 +91,10 @@ open class TripsViewModel(
   }
 
   fun deleteTripById(id: String, onSuccess: () -> Unit = {}) {
-    tripsRepository.deleteTripById(id = id, onSuccess = { getTrips(onSuccess) }, onFailure = {})
+    tripsRepository.deleteTripById(
+        id = id,
+        onSuccess = { getTrips(onSuccess) },
+        onFailure = { exception -> Log.e("TripsViewModel", "Failed to delete trip", exception) })
   }
 
   fun updateTrip(trip: Trip, onSuccess: () -> Unit = {}, onFailure: (Exception) -> Unit = {}) {

--- a/app/src/main/java/com/android/voyageur/model/trip/TripsViewModel.kt
+++ b/app/src/main/java/com/android/voyageur/model/trip/TripsViewModel.kt
@@ -84,7 +84,7 @@ open class TripsViewModel(
         onFailure = {})
   }
 
-  fun createTrip(trip: Trip, onSuccess: () -> Unit = {}, onFailure: (Exception) -> Unit) {
+  fun createTrip(trip: Trip, onSuccess: () -> Unit = {}, onFailure: (Exception) -> Unit = {}) {
     tripsRepository.createTrip(
         trip = trip, onSuccess = { getTrips(onSuccess) }, onFailure = { onFailure(it) })
   }
@@ -93,7 +93,7 @@ open class TripsViewModel(
     tripsRepository.deleteTripById(id = id, onSuccess = { getTrips(onSuccess) }, onFailure = {})
   }
 
-  fun updateTrip(trip: Trip, onSuccess: () -> Unit = {}, onFailure: (Exception) -> Unit) {
+  fun updateTrip(trip: Trip, onSuccess: () -> Unit = {}, onFailure: (Exception) -> Unit = {}) {
     tripsRepository.updateTrip(
         trip = trip, onSuccess = { getTrips(onSuccess) }, onFailure = { onFailure(it) })
   }

--- a/app/src/main/java/com/android/voyageur/model/trip/TripsViewModel.kt
+++ b/app/src/main/java/com/android/voyageur/model/trip/TripsViewModel.kt
@@ -85,7 +85,7 @@ open class TripsViewModel(
         onFailure = {})
   }
 
-  fun createTrip(trip: Trip, onSuccess: () -> Unit = {}) {
+  fun createTrip(trip: Trip, onSuccess: () -> Unit = {}, onFailure: (Exception) -> Unit) {
     tripsRepository.createTrip(trip = trip, onSuccess = { getTrips(onSuccess) }, onFailure = {})
   }
 
@@ -93,7 +93,7 @@ open class TripsViewModel(
     tripsRepository.deleteTripById(id = id, onSuccess = { getTrips(onSuccess) }, onFailure = {})
   }
 
-  fun updateTrip(trip: Trip, onSuccess: () -> Unit = {}) {
+  fun updateTrip(trip: Trip, onSuccess: () -> Unit = {}, onFailure: (Exception) -> Unit) {
     tripsRepository.updateTrip(
         trip = trip,
         onSuccess = { getTrips(onSuccess) },

--- a/app/src/main/java/com/android/voyageur/model/trip/TripsViewModel.kt
+++ b/app/src/main/java/com/android/voyageur/model/trip/TripsViewModel.kt
@@ -1,7 +1,6 @@
 package com.android.voyageur.model.trip
 
 import android.net.Uri
-import android.util.Log
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
 import com.android.voyageur.model.activity.Activity
@@ -86,7 +85,8 @@ open class TripsViewModel(
   }
 
   fun createTrip(trip: Trip, onSuccess: () -> Unit = {}, onFailure: (Exception) -> Unit) {
-    tripsRepository.createTrip(trip = trip, onSuccess = { getTrips(onSuccess) }, onFailure = {})
+    tripsRepository.createTrip(
+        trip = trip, onSuccess = { getTrips(onSuccess) }, onFailure = { onFailure(it) })
   }
 
   fun deleteTripById(id: String, onSuccess: () -> Unit = {}) {
@@ -95,9 +95,7 @@ open class TripsViewModel(
 
   fun updateTrip(trip: Trip, onSuccess: () -> Unit = {}, onFailure: (Exception) -> Unit) {
     tripsRepository.updateTrip(
-        trip = trip,
-        onSuccess = { getTrips(onSuccess) },
-        onFailure = { Log.e("Fail", it.message ?: "") })
+        trip = trip, onSuccess = { getTrips(onSuccess) }, onFailure = { onFailure(it) })
   }
 
   fun uploadImageToFirebase(uri: Uri, onSuccess: (String) -> Unit, onFailure: (Exception) -> Unit) {

--- a/app/src/main/java/com/android/voyageur/model/trip/TripsViewModel.kt
+++ b/app/src/main/java/com/android/voyageur/model/trip/TripsViewModel.kt
@@ -10,6 +10,7 @@ import com.google.firebase.firestore.firestore
 import com.google.firebase.storage.FirebaseStorage
 import java.time.LocalDate
 import java.util.UUID
+import android.util.Log
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow

--- a/app/src/main/java/com/android/voyageur/ui/overview/AddTrip.kt
+++ b/app/src/main/java/com/android/voyageur/ui/overview/AddTrip.kt
@@ -217,6 +217,12 @@ fun AddTripScreen(
           onSuccess = {
             isSaving = false
             Toast.makeText(context, "Trip created successfully!", Toast.LENGTH_SHORT).show()
+          },
+          onFailure = { error ->
+            isSaving = false
+            Toast.makeText(context, "Failed to create trip: ${error.message}", Toast.LENGTH_SHORT)
+                .show()
+            Log.e("AddTripScreen", "Error creating trip: ${error.message}", error)
           })
       navigationActions.goBack()
     } else {
@@ -233,6 +239,12 @@ fun AddTripScreen(
             tripsViewModel.selectTrip(Trip())
             tripsViewModel.selectTrip(trip)
             onUpdate()
+          },
+          onFailure = { error ->
+            isSaving = false
+            Toast.makeText(context, "Failed to update trip: ${error.message}", Toast.LENGTH_SHORT)
+                .show()
+            Log.e("AddTripScreen", "Error updating trip: ${error.message}", error)
           })
     }
   }

--- a/app/src/main/java/com/android/voyageur/ui/trip/AddActivity.kt
+++ b/app/src/main/java/com/android/voyageur/ui/trip/AddActivity.kt
@@ -1,6 +1,7 @@
 package com.android.voyageur.ui.trip
 
 import android.annotation.SuppressLint
+import android.util.Log
 import android.widget.Toast
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.*
@@ -238,6 +239,13 @@ fun AddActivityScreen(
           tripsViewModel.selectTrip(Trip())
           tripsViewModel.selectTrip(updatedTrip)
           navigationActions.goBack()
+        },
+        onFailure = { error ->
+          isSaving = false
+          Toast.makeText(
+                  context, "Failed to add/edit activity: ${error.message}", Toast.LENGTH_SHORT)
+              .show()
+          Log.e("AddActivityScreen", "Error adding/editing activity: ${error.message}", error)
         })
   }
 

--- a/app/src/main/java/com/android/voyageur/ui/trip/AddActivity.kt
+++ b/app/src/main/java/com/android/voyageur/ui/trip/AddActivity.kt
@@ -85,9 +85,13 @@ fun AddActivityScreen(
   var formattedEndTime =
       if (endTime != null && activityDate != null) timeFormat.format(Date(endTime!!)) else ""
 
+  var isSaving by remember { mutableStateOf(false) }
+
   val keyboardController = LocalSoftwareKeyboardController.current
 
   fun createActivity() {
+    if (isSaving) return // Prevent duplicate saves
+
     fun normalizeToMidnight(date: Date): Date {
       val calendar =
           Calendar.getInstance().apply {
@@ -222,9 +226,11 @@ fun AddActivityScreen(
         }
 
     val updatedTrip = selectedTrip.copy(activities = updatedActivities)
+    isSaving = true
     tripsViewModel.updateTrip(
         updatedTrip,
         onSuccess = {
+          isSaving = false
           /*
               This is a trick to force a recompose, because the reference wouldn't
               change and update the UI.
@@ -443,7 +449,7 @@ fun AddActivityScreen(
 
           Button(
               onClick = { createActivity() },
-              enabled = title.isNotBlank(),
+              enabled = title.isNotBlank() && !isSaving,
               modifier = Modifier.fillMaxWidth().padding(16.dp).testTag("activitySave")) {
                 Text("Save")
               }


### PR DESCRIPTION
## Summary

This PR introduces a fix which prevents duplicate savings. Until now, if the save button was pressed multiple times quickly enough duplicate trips would've been created and in case of the activities, the user was redirected to the Overview screen.

## Changes

- **Screens/UI:** Fixes the behavior of multiple clicks on save in addActivityScreen and addTripScreen
- **Bug Fixes/Improvements:** Addresses #206 .

## Checklist

Ensure all / most of these are checked before the pull request is submitted.
- [x] This PR resolves #206 .
- [ ] Tests have been added for new functionality.
- [ ] Screenshots or UI changes have been attached (if applicable).
- [x] Documentation has been updated (if applicable).

##  Testing

- **Manual Testing:**
    - [x] Tested on emulator / physical device.
- **Unit Tests**
    - [ ] Added units tests for this

##  Related Issues/Tickets

Closes #206 

