### PR TITLE
Feat/Display contact request and accept/delete

### DIFF
--- a/app/src/androidTest/java/com/android/voyageur/ui/profile/ProfileScreenTest.kt
+++ b/app/src/androidTest/java/com/android/voyageur/ui/profile/ProfileScreenTest.kt
@@ -1,10 +1,13 @@
 package com.android.voyageur.ui.profile
 
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
+import com.android.voyageur.model.notifications.FriendRequest
 import com.android.voyageur.model.notifications.FriendRequestRepository
 import com.android.voyageur.model.user.User
 import com.android.voyageur.model.user.UserRepository
@@ -71,8 +74,15 @@ class ProfileScreenTest {
     // Set the content for Compose rule
     composeTestRule.setContent {
       ProfileScreen(userViewModel = userViewModel, navigationActions = navigationActions)
+      ExpandableFriendReqMenu(
+          friendRequests = friendRequests.value,
+          notificationUsers = notificationUsers.value,
+          userViewModel = userViewModel)
     }
   }
+
+  val friendRequests = mutableStateOf(emptyList<FriendRequest>())
+  val notificationUsers = mutableStateOf(emptyList<User>())
 
   @Test
   fun displayLoadingIndicatorWhenIsLoading() {
@@ -194,5 +204,34 @@ class ProfileScreenTest {
 
     // Assert: Check that the "No interests added yet" message is displayed
     composeTestRule.onNodeWithTag("noInterests").assertIsDisplayed()
+  }
+
+  @Test
+  fun friendRequestItemsAreDisplayedInExpandedMenu() {
+    // Arrange: Update friend requests and notification users
+    composeTestRule.runOnUiThread {
+      friendRequests.value = listOf(FriendRequest("1", "user1"), FriendRequest("2", "user2"))
+      notificationUsers.value =
+          listOf(
+              User("user1", "Alice", "alice@example.com", ""),
+              User("user2", "Bob", "bob@example.com", ""))
+    }
+
+    // Act: Expand the menu
+    composeTestRule.onNodeWithContentDescription("Expand").performClick()
+
+    // Assert: Check that friend request items are displayed
+    composeTestRule.onNodeWithText("Alice").assertIsDisplayed()
+    composeTestRule.onNodeWithText("Bob").assertIsDisplayed()
+  }
+
+  @Test
+  fun expandedMenuIsDisplayedOnIconButtonClick() {
+    // Arrange: Update friend requests
+    composeTestRule.runOnUiThread {
+      friendRequests.value = listOf(FriendRequest("1", "user1"), FriendRequest("2", "user2"))
+    }
+    composeTestRule.onNodeWithContentDescription("Expand").performClick()
+    composeTestRule.onNodeWithTag("closeButton").assertIsDisplayed()
   }
 }

--- a/app/src/main/java/com/android/voyageur/model/notifications/FriendRequestRepository.kt
+++ b/app/src/main/java/com/android/voyageur/model/notifications/FriendRequestRepository.kt
@@ -17,5 +17,7 @@ interface FriendRequestRepository {
 
   fun createRequest(req: FriendRequest, onSuccess: () -> Unit, onFailure: (Exception) -> Unit)
 
+  fun deleteRequest(reqId: String, onSuccess: () -> Unit, onFailure: (Exception) -> Unit)
+
   fun getNewId(): String
 }

--- a/app/src/main/java/com/android/voyageur/model/notifications/FriendRequestRepositoryFirebase.kt
+++ b/app/src/main/java/com/android/voyageur/model/notifications/FriendRequestRepositoryFirebase.kt
@@ -64,6 +64,18 @@ class FriendRequestRepositoryFirebase(private val db: FirebaseFirestore) : Frien
         .addOnSuccessListener { onSuccess() }
         .addOnFailureListener { exception -> onFailure(exception) }
   }
+  /**
+   * @param reqId the ID of the friend request to delete
+   * @param onSuccess callback to execute after successful deletion
+   * @param onFailure exception handling callback
+   */
+  override fun deleteRequest(reqId: String, onSuccess: () -> Unit, onFailure: (Exception) -> Unit) {
+    db.collection(collectionPath)
+        .document(reqId)
+        .delete()
+        .addOnSuccessListener { onSuccess() }
+        .addOnFailureListener { exception -> onFailure(exception) }
+  }
 
   override fun init(onSuccess: () -> Unit) {
     db.collection(collectionPath)

--- a/app/src/main/java/com/android/voyageur/ui/navigation/BottomNavigationMenu.kt
+++ b/app/src/main/java/com/android/voyageur/ui/navigation/BottomNavigationMenu.kt
@@ -42,7 +42,7 @@ fun BottomNavigationMenu(
   var isPolling by remember { mutableStateOf(true) }
 
   if (Firebase.auth.uid != null) {
-    userViewModel.getNotificationsCount {}
+    userViewModel.getNotificationsCount { if (it > 0) userViewModel.getFriendRequests {} }
   }
   NavigationBar(
       modifier = Modifier.fillMaxWidth().height(60.dp).testTag("bottomNavigationMenu"),

--- a/app/src/main/java/com/android/voyageur/ui/profile/ProfileScreen.kt
+++ b/app/src/main/java/com/android/voyageur/ui/profile/ProfileScreen.kt
@@ -137,6 +137,16 @@ fun ProfileContent(
       }
 }
 
+/**
+ * A composable function that displays a menu for handling pending friend requests. The menu can be
+ * toggled between a collapsed view and an expanded dialog view for reviewing and managing friend
+ * requests.
+ *
+ * @param friendRequests A list of [FriendRequest] objects representing the pending friend requests.
+ * @param notificationUsers A list of [User] objects of users who sent the friend requests.
+ * @param userViewModel An instance of [UserViewModel] for managing user-related actions such as
+ *   accepting or rejecting friend requests.
+ */
 @Composable
 fun ExpandableFriendReqMenu(
     friendRequests: List<FriendRequest>,
@@ -209,7 +219,15 @@ fun ExpandableFriendReqMenu(
     }
   }
 }
-
+/**
+ * A composable function that displays a single friend request item. The item shows the user's
+ * profile picture, name, and buttons to accept or reject the friend request.
+ *
+ * @param friendRequest Represents a pending friend request.
+ * @param fromUser The [User] object representing the sender of the friend request.
+ * @param userViewModel The [UserViewModel] used to handle actions like accepting or rejecting the
+ *   friend request.
+ */
 @Composable
 fun FriendRequestItem(friendRequest: FriendRequest, fromUser: User, userViewModel: UserViewModel) {
   Row(

--- a/app/src/main/java/com/android/voyageur/ui/profile/ProfileScreen.kt
+++ b/app/src/main/java/com/android/voyageur/ui/profile/ProfileScreen.kt
@@ -57,9 +57,6 @@ fun ProfileScreen(userViewModel: UserViewModel, navigationActions: NavigationAct
   // Observe user and loading state from UserViewModel
   val user by userViewModel.user.collectAsState()
   val isLoading by userViewModel.isLoading.collectAsState()
-  // Collect the friend requests and the user corresponding to them
-  val friendRequests by userViewModel.friendRequests.collectAsState()
-  val notificationUsers by userViewModel.notificationUsers.collectAsState()
   var isSigningOut by remember { mutableStateOf(false) }
 
   // Navigate to AUTH if user is null and not loading
@@ -104,8 +101,6 @@ fun ProfileScreen(userViewModel: UserViewModel, navigationActions: NavigationAct
                       userData = user!!,
                       signedInUserId = user!!.id,
                       onSignOut = { isSigningOut = true },
-                      friendRequests = friendRequests,
-                      notificationUsers = notificationUsers,
                       userViewModel = userViewModel,
                       onEdit = { navigationActions.navigateTo(Route.EDIT_PROFILE) })
                 }
@@ -122,11 +117,11 @@ fun ProfileContent(
     userData: User,
     signedInUserId: String,
     onSignOut: () -> Unit,
-    friendRequests: List<FriendRequest>,
-    notificationUsers: List<User>,
     userViewModel: UserViewModel,
     onEdit: () -> Unit
 ) {
+  val friendRequests by userViewModel.friendRequests.collectAsState()
+  val notificationUsers by userViewModel.notificationUsers.collectAsState()
   Column(
       modifier = Modifier.fillMaxSize().padding(top = 16.dp), // Space for profile content
       horizontalAlignment = Alignment.CenterHorizontally) {
@@ -146,10 +141,9 @@ fun ProfileContent(
 fun ExpandableFriendReqMenu(
     friendRequests: List<FriendRequest>,
     notificationUsers: List<User>,
-    userViewModel: UserViewModel
+    userViewModel: UserViewModel,
 ) {
   var expanded by remember { mutableStateOf(false) } // Toggle for expanded state
-
   // Collapsed Menu
   Card(
       shape = RoundedCornerShape(12.dp),
@@ -175,7 +169,7 @@ fun ExpandableFriendReqMenu(
 
   // Expanded Pop-Up Friend Request Menu as a Dialog
   if (expanded) {
-    Dialog(onDismissRequest = { expanded = false }) {
+    Dialog(onDismissRequest = { expanded = true }) {
       Card(
           shape = RoundedCornerShape(16.dp),
           modifier = Modifier.fillMaxWidth().fillMaxHeight(0.85f).padding(10.dp)) {
@@ -190,12 +184,14 @@ fun ExpandableFriendReqMenu(
                     )
 
                     // Collapses the menu
-                    IconButton(onClick = { expanded = false }) {
-                      Icon(
-                          imageVector = Icons.Default.Close,
-                          contentDescription = "Close",
-                      )
-                    }
+                    IconButton(
+                        onClick = { expanded = false },
+                        modifier = Modifier.testTag("closeButton")) {
+                          Icon(
+                              imageVector = Icons.Default.Close,
+                              contentDescription = "Close",
+                          )
+                        }
                   }
 
               // Scrollable List of FriendRequestItems
@@ -224,7 +220,8 @@ fun FriendRequestItem(friendRequest: FriendRequest, fromUser: User, userViewMode
         Image(
             painter = rememberAsyncImagePainter(fromUser.profilePicture),
             contentDescription = "Profile Picture",
-            modifier = Modifier.size(40.dp).clip(RoundedCornerShape(20.dp)))
+            modifier =
+                Modifier.size(40.dp).clip(RoundedCornerShape(20.dp)).testTag("profilePicture"))
 
         Text(
             text = fromUser.name,
@@ -234,6 +231,7 @@ fun FriendRequestItem(friendRequest: FriendRequest, fromUser: User, userViewMode
         // Accept and Reject Icons
         Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
           IconButton(
+              modifier = Modifier.testTag("acceptButton"),
               onClick = {
                 // Accept user's friend request and add to contacts
                 userViewModel.addContact(fromUser.id, friendRequest.id)
@@ -245,6 +243,7 @@ fun FriendRequestItem(friendRequest: FriendRequest, fromUser: User, userViewMode
               }
 
           IconButton(
+              modifier = Modifier.testTag("denyButton"),
               onClick = {
                 // Delete the user friend request
                 userViewModel.deleteFriendRequest(friendRequest.id)

--- a/app/src/main/java/com/android/voyageur/ui/profile/ProfileScreen.kt
+++ b/app/src/main/java/com/android/voyageur/ui/profile/ProfileScreen.kt
@@ -1,12 +1,32 @@
 package com.android.voyageur.ui.profile
 
 import UserProfileContent
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Check
+import androidx.compose.material.icons.filled.Close
+import androidx.compose.material.icons.filled.KeyboardArrowDown
+import androidx.compose.material3.Card
 import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -18,7 +38,13 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.window.Dialog
+import coil.compose.rememberAsyncImagePainter
+import com.android.voyageur.model.notifications.FriendRequest
 import com.android.voyageur.model.user.User
 import com.android.voyageur.model.user.UserViewModel
 import com.android.voyageur.ui.navigation.BottomNavigationMenu
@@ -31,6 +57,9 @@ fun ProfileScreen(userViewModel: UserViewModel, navigationActions: NavigationAct
   // Observe user and loading state from UserViewModel
   val user by userViewModel.user.collectAsState()
   val isLoading by userViewModel.isLoading.collectAsState()
+  // Collect the friend requests and the user corresponding to them
+  val friendRequests by userViewModel.friendRequests.collectAsState()
+  val notificationUsers by userViewModel.notificationUsers.collectAsState()
   var isSigningOut by remember { mutableStateOf(false) }
 
   // Navigate to AUTH if user is null and not loading
@@ -46,7 +75,6 @@ fun ProfileScreen(userViewModel: UserViewModel, navigationActions: NavigationAct
       navigationActions.navigateTo(Route.AUTH)
     }
   }
-
   // Main Scaffold layout for ProfileScreen with Bottom Navigation
   Scaffold(
       modifier = Modifier.testTag("profileScreen"),
@@ -76,6 +104,9 @@ fun ProfileScreen(userViewModel: UserViewModel, navigationActions: NavigationAct
                       userData = user!!,
                       signedInUserId = user!!.id,
                       onSignOut = { isSigningOut = true },
+                      friendRequests = friendRequests,
+                      notificationUsers = notificationUsers,
+                      userViewModel = userViewModel,
                       onEdit = { navigationActions.navigateTo(Route.EDIT_PROFILE) })
                 }
                 else -> {
@@ -91,12 +122,138 @@ fun ProfileContent(
     userData: User,
     signedInUserId: String,
     onSignOut: () -> Unit,
+    friendRequests: List<FriendRequest>,
+    notificationUsers: List<User>,
+    userViewModel: UserViewModel,
     onEdit: () -> Unit
 ) {
-  UserProfileContent(
-      userData = userData,
-      signedInUserId = signedInUserId,
-      showEditAndSignOutButtons = true,
-      onSignOut = onSignOut,
-      onEdit = onEdit)
+  Column(
+      modifier = Modifier.fillMaxSize().padding(top = 16.dp), // Space for profile content
+      horizontalAlignment = Alignment.CenterHorizontally) {
+        UserProfileContent(
+            userData = userData,
+            signedInUserId = signedInUserId,
+            showEditAndSignOutButtons = true,
+            onSignOut = onSignOut,
+            onEdit = onEdit)
+        Spacer(modifier = Modifier.height(20.dp))
+        // Expandable Friend Requests Menu
+        ExpandableFriendReqMenu(friendRequests, notificationUsers, userViewModel)
+      }
+}
+
+@Composable
+fun ExpandableFriendReqMenu(
+    friendRequests: List<FriendRequest>,
+    notificationUsers: List<User>,
+    userViewModel: UserViewModel
+) {
+  var expanded by remember { mutableStateOf(false) } // Toggle for expanded state
+
+  // Collapsed Menu
+  Card(
+      shape = RoundedCornerShape(12.dp),
+      modifier = Modifier.fillMaxWidth(0.80f).padding(horizontal = 10.dp, vertical = 8.dp),
+  ) {
+    Column(modifier = Modifier.padding(12.dp)) {
+      // Header row with title and expand/collapse button
+      Row(
+          modifier = Modifier.fillMaxWidth(),
+          verticalAlignment = Alignment.CenterVertically,
+          horizontalArrangement = Arrangement.SpaceBetween) {
+            Text(text = "${friendRequests.size} Pending Friend Requests", color = Color.DarkGray)
+
+            IconButton(onClick = { expanded = true }) {
+              Icon(
+                  imageVector = Icons.Default.KeyboardArrowDown,
+                  contentDescription = "Expand",
+                  tint = Color.Gray)
+            }
+          }
+    }
+  }
+
+  // Expanded Pop-Up Friend Request Menu as a Dialog
+  if (expanded) {
+    Dialog(onDismissRequest = { expanded = false }) {
+      Card(
+          shape = RoundedCornerShape(16.dp),
+          modifier = Modifier.fillMaxWidth().fillMaxHeight(0.85f).padding(10.dp)) {
+            Column(modifier = Modifier.fillMaxSize().background(Color.White).padding(12.dp)) {
+              // Header and close button
+              Row(
+                  modifier = Modifier.fillMaxWidth().padding(bottom = 8.dp),
+                  verticalAlignment = Alignment.CenterVertically,
+                  horizontalArrangement = Arrangement.SpaceBetween) {
+                    Text(
+                        text = "${friendRequests.size} Pending Friend Requests",
+                    )
+
+                    // Collapses the menu
+                    IconButton(onClick = { expanded = false }) {
+                      Icon(
+                          imageVector = Icons.Default.Close,
+                          contentDescription = "Close",
+                      )
+                    }
+                  }
+
+              // Scrollable List of FriendRequestItems
+              LazyColumn(modifier = Modifier.fillMaxSize().padding(top = 8.dp)) {
+                items(friendRequests) { request ->
+                  val fromUser = notificationUsers.find { it.id == request.from }
+                  fromUser?.let {
+                    FriendRequestItem(
+                        friendRequest = request, fromUser = fromUser, userViewModel = userViewModel)
+                  }
+                }
+              }
+            }
+          }
+    }
+  }
+}
+
+@Composable
+fun FriendRequestItem(friendRequest: FriendRequest, fromUser: User, userViewModel: UserViewModel) {
+  Row(
+      modifier = Modifier.fillMaxWidth().padding(8.dp),
+      verticalAlignment = Alignment.CenterVertically,
+      horizontalArrangement = Arrangement.SpaceBetween) {
+        // Display the Profile Picture of the user from which you have a request
+        Image(
+            painter = rememberAsyncImagePainter(fromUser.profilePicture),
+            contentDescription = "Profile Picture",
+            modifier = Modifier.size(40.dp).clip(RoundedCornerShape(20.dp)))
+
+        Text(
+            text = fromUser.name,
+            modifier = Modifier.padding(start = 8.dp).weight(1f) // Take remaining space
+            )
+
+        // Accept and Reject Icons
+        Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+          IconButton(
+              onClick = {
+                // Accept user's friend request and add to contacts
+                userViewModel.addContact(fromUser.id, friendRequest.id)
+              }) {
+                Icon(
+                    imageVector = Icons.Default.Check,
+                    contentDescription = "Accept",
+                    tint = Color.Green)
+              }
+
+          IconButton(
+              onClick = {
+                // Delete the user friend request
+                userViewModel.deleteFriendRequest(friendRequest.id)
+              }) {
+                Icon(
+                    imageVector = Icons.Default.Close,
+                    contentDescription = "Reject",
+                    tint = Color.Red)
+              }
+        }
+      }
 }

--- a/app/src/main/java/com/android/voyageur/ui/search/SearchScreen.kt
+++ b/app/src/main/java/com/android/voyageur/ui/search/SearchScreen.kt
@@ -30,7 +30,6 @@ import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.BasicTextField
 import androidx.compose.foundation.text.KeyboardOptions
-import androidx.compose.foundation.text.input.InputTransformation.Companion.keyboardOptions
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.List
 import androidx.compose.material.icons.filled.Place
@@ -446,7 +445,7 @@ fun UserSearchResultItem(
             }
 
         Button(
-            onClick = { userViewModel.addContact(user.id) },
+            onClick = { userViewModel.sendContactRequest(user.id) },
             enabled = !isContactAdded,
             shape = RoundedCornerShape(20.dp),
             colors =

--- a/app/src/main/java/com/android/voyageur/ui/search/SearchUserProfile.kt
+++ b/app/src/main/java/com/android/voyageur/ui/search/SearchUserProfile.kt
@@ -97,7 +97,7 @@ fun SearchUserProfileContent(userData: User, userViewModel: UserViewModel) {
         if (isContactAdded) {
           userViewModel.removeContact(userData.id)
         } else {
-          userViewModel.addContact(userData.id)
+          userViewModel.sendContactRequest(userData.id)
         }
       })
 }

--- a/app/src/test/java/com/android/voyageur/model/user/UserViewModelTest.kt
+++ b/app/src/test/java/com/android/voyageur/model/user/UserViewModelTest.kt
@@ -242,7 +242,7 @@ class UserViewModelTest {
   }
 
   @Test
-  fun addContact_createsFriendRequest() {
+  fun sendContact_Request_createsFriendRequest() {
     val userId = "contactUserId"
     val generatedId = "testFriendRequestId"
 
@@ -258,7 +258,7 @@ class UserViewModelTest {
         .createRequest(any(), any(), any())
 
     // Call the method under test
-    userViewModel.addContact(userId)
+    userViewModel.sendContactRequest(userId)
 
     // Verify that createRequest was called with the correct parameters
     verify(friendRequestRepository)


### PR DESCRIPTION
## Summary

This PR introduces Friend Requests displayed in the Profile Screen as a DropDown which opens a Dialog displaying them. The user has the option to:
 accept -> user is added to contacts (displays as Added in Search Screen) and friend request is deleted.
 deny -> friend request is deleted. The friend request displays the user's profile picture and their name.

## Changes

- **Models:** Adapted `UserViewModel`.
- **Screens/UI:** Introduced Drop Down Menu with Dialog displaying friend requests in the Profile Screen.
- **Logic/Controllers:** `UserViewModel` now contains `deleteFriendRequest()` method and `addContact()` (re-introduced).
- **Repositories:**`FriendRequestRepositoryFirebase` now contains `deleteRequest()` method.
- **Bug Fixes/Improvements:** Addresses #200.

## Checklist

Ensure all / most of these are checked before the pull request is submitted.
- [X] This PR resolves #200 .
- [X] Tests have been added for new functionality.
- [X] Screenshots or UI changes have been attached (if applicable).
- [X] Documentation has been updated (if applicable).

##  Testing

Explain how this feature was tested and what kind of testing (unit, integration, UI) has been done. Mention platforms or configurations used for testing.
- **Manual Testing:**
    - [X] Tested on emulator / physical device.
- **Unit Tests**
    - [X] Added units tests for this

##  Related Issues/Tickets

Closes #200.

## Screenshots (if applicable)


https://github.com/user-attachments/assets/ead3a65e-6f81-440d-9a28-7a22396ae771

https://github.com/user-attachments/assets/c364eedb-5d33-4abe-ac0c-933491177e9a




## 💡 Additional Context

The Dialog now closes after the user accepts a friend request. A better implementation should be found such that the dialog composable doesn't close after accepting a friend request. A new issue has been opened for this (#215). 
