### PR TITLE
Feat/search place component

### DIFF
--- a/app/src/androidTest/java/com/android/voyageur/ui/components/PlaceSearchWidgetTest.kt
+++ b/app/src/androidTest/java/com/android/voyageur/ui/components/PlaceSearchWidgetTest.kt
@@ -1,0 +1,69 @@
+package com.android.voyageur.ui.components
+
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.performTextInput
+import com.android.voyageur.model.place.CustomPlace
+import com.android.voyageur.model.place.PlacesRepository
+import com.android.voyageur.model.place.PlacesViewModel
+import com.google.android.libraries.places.api.model.Place
+import kotlinx.coroutines.flow.MutableStateFlow
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.mockito.Mockito
+import org.mockito.Mockito.`when`
+import org.mockito.kotlin.any
+
+class PlaceSearchWidgetTest {
+
+    @get:Rule
+    val composeTestRule = createComposeRule()
+
+    private lateinit var placesViewModel: PlacesViewModel
+    private lateinit var placesRepository: PlacesRepository
+
+
+    @Before
+    fun setUp() {
+        placesRepository = Mockito.mock(PlacesRepository::class.java)
+        placesViewModel = PlacesViewModel(placesRepository)
+    }
+
+    @Test
+    fun testInitialState() {
+        `when`(placesRepository.searchPlaces(any(), any(), any(), any())).thenAnswer {
+            val onSuccess = it.arguments[1] as (List<Place>) -> Unit
+            onSuccess(emptyList())
+        }
+        composeTestRule.setContent {
+            PlaceSearchWidget(
+                placesViewModel = placesViewModel,
+                onSelect = {}
+            )
+        }
+
+        composeTestRule.onNodeWithTag("searchTextField").assertIsDisplayed()
+    }
+
+    @Test
+    fun testSearch() {
+        val place = CustomPlace(Place.builder().setName("Test Place").build(), emptyList())
+        val searchedPlaces = MutableStateFlow(listOf(place))
+        `when`(placesRepository.searchPlaces(any(), any(), any(), any())).thenAnswer {
+            val onSuccess = it.arguments[1] as (List<CustomPlace>) -> Unit
+            onSuccess(searchedPlaces.value)
+        }
+        composeTestRule.setContent {
+            PlaceSearchWidget(
+                placesViewModel = placesViewModel,
+                onSelect = {}
+            )
+        }
+
+        composeTestRule.onNodeWithTag("searchTextField").performTextInput("Test")
+        composeTestRule.onNodeWithTag("searchDropdown").assertIsDisplayed()
+    }
+
+}

--- a/app/src/androidTest/java/com/android/voyageur/ui/components/PlaceSearchWidgetTest.kt
+++ b/app/src/androidTest/java/com/android/voyageur/ui/components/PlaceSearchWidgetTest.kt
@@ -18,52 +18,43 @@ import org.mockito.kotlin.any
 
 class PlaceSearchWidgetTest {
 
-    @get:Rule
-    val composeTestRule = createComposeRule()
+  @get:Rule val composeTestRule = createComposeRule()
 
-    private lateinit var placesViewModel: PlacesViewModel
-    private lateinit var placesRepository: PlacesRepository
+  private lateinit var placesViewModel: PlacesViewModel
+  private lateinit var placesRepository: PlacesRepository
 
+  @Before
+  fun setUp() {
+    placesRepository = Mockito.mock(PlacesRepository::class.java)
+    placesViewModel = PlacesViewModel(placesRepository)
+  }
 
-    @Before
-    fun setUp() {
-        placesRepository = Mockito.mock(PlacesRepository::class.java)
-        placesViewModel = PlacesViewModel(placesRepository)
+  @Test
+  fun testInitialState() {
+    `when`(placesRepository.searchPlaces(any(), any(), any(), any())).thenAnswer {
+      val onSuccess = it.arguments[1] as (List<Place>) -> Unit
+      onSuccess(emptyList())
+    }
+    composeTestRule.setContent {
+      PlaceSearchWidget(placesViewModel = placesViewModel, onSelect = {})
     }
 
-    @Test
-    fun testInitialState() {
-        `when`(placesRepository.searchPlaces(any(), any(), any(), any())).thenAnswer {
-            val onSuccess = it.arguments[1] as (List<Place>) -> Unit
-            onSuccess(emptyList())
-        }
-        composeTestRule.setContent {
-            PlaceSearchWidget(
-                placesViewModel = placesViewModel,
-                onSelect = {}
-            )
-        }
+    composeTestRule.onNodeWithTag("searchTextField").assertIsDisplayed()
+  }
 
-        composeTestRule.onNodeWithTag("searchTextField").assertIsDisplayed()
+  @Test
+  fun testSearch() {
+    val place = CustomPlace(Place.builder().setName("Test Place").build(), emptyList())
+    val searchedPlaces = MutableStateFlow(listOf(place))
+    `when`(placesRepository.searchPlaces(any(), any(), any(), any())).thenAnswer {
+      val onSuccess = it.arguments[1] as (List<CustomPlace>) -> Unit
+      onSuccess(searchedPlaces.value)
+    }
+    composeTestRule.setContent {
+      PlaceSearchWidget(placesViewModel = placesViewModel, onSelect = {})
     }
 
-    @Test
-    fun testSearch() {
-        val place = CustomPlace(Place.builder().setName("Test Place").build(), emptyList())
-        val searchedPlaces = MutableStateFlow(listOf(place))
-        `when`(placesRepository.searchPlaces(any(), any(), any(), any())).thenAnswer {
-            val onSuccess = it.arguments[1] as (List<CustomPlace>) -> Unit
-            onSuccess(searchedPlaces.value)
-        }
-        composeTestRule.setContent {
-            PlaceSearchWidget(
-                placesViewModel = placesViewModel,
-                onSelect = {}
-            )
-        }
-
-        composeTestRule.onNodeWithTag("searchTextField").performTextInput("Test")
-        composeTestRule.onNodeWithTag("searchDropdown").assertIsDisplayed()
-    }
-
+    composeTestRule.onNodeWithTag("searchTextField").performTextInput("Test")
+    composeTestRule.onNodeWithTag("searchDropdown").assertIsDisplayed()
+  }
 }

--- a/app/src/main/java/com/android/voyageur/ui/components/PlaceSearchWidget.kt
+++ b/app/src/main/java/com/android/voyageur/ui/components/PlaceSearchWidget.kt
@@ -1,0 +1,56 @@
+package com.android.voyageur.ui.components
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.text.input.TextFieldValue
+import androidx.compose.ui.window.PopupProperties
+import com.android.voyageur.model.place.CustomPlace
+import com.android.voyageur.model.place.PlacesViewModel
+
+/**
+ * A search widget for searching for places.
+ *
+ * @param placesViewModel The ViewModel used to search for places.
+ */
+@Composable
+fun PlaceSearchWidget(
+    placesViewModel: PlacesViewModel,
+    onSelect: (CustomPlace) -> Unit,
+    modifier: Modifier = Modifier
+) {
+  var query by remember { mutableStateOf(TextFieldValue("")) }
+  var expanded by remember { mutableStateOf(false) }
+  val searchedPlaces by placesViewModel.searchedPlaces.collectAsState()
+
+  Column {
+    OutlinedTextField(
+        value = query,
+        onValueChange = {
+          placesViewModel.setQuery(it.text, null)
+          expanded = it.text.isNotEmpty() && it.text != query.text
+          query = it
+        },
+        modifier = modifier.fillMaxWidth().testTag("searchTextField"),
+        placeholder = { Text("Search places...") })
+
+    DropdownMenu(
+        expanded = expanded,
+        onDismissRequest = { expanded = false },
+        modifier = Modifier.fillMaxWidth().testTag("searchDropdown"),
+        properties = PopupProperties(focusable = false)) {
+          searchedPlaces.forEach { place ->
+            DropdownMenuItem(
+                text = { Text(place.place.displayName ?: "Unknown Place") },
+                onClick = {
+                  onSelect(place)
+                  expanded = false
+                },
+               modifier = Modifier.testTag("item-${place.place.id}"))
+          }
+        }
+  }
+}

--- a/app/src/main/java/com/android/voyageur/ui/components/PlaceSearchWidget.kt
+++ b/app/src/main/java/com/android/voyageur/ui/components/PlaceSearchWidget.kt
@@ -49,7 +49,7 @@ fun PlaceSearchWidget(
                   onSelect(place)
                   expanded = false
                 },
-               modifier = Modifier.testTag("item-${place.place.id}"))
+                modifier = Modifier.testTag("item-${place.place.id}"))
           }
         }
   }


### PR DESCRIPTION
## Summary

This PR uses a widget that allows searching for places that can be used in other screens for example in the Add activity screen.

## Changes


- **Screens/UI:** Created a dropdown widget that allows the user search for places that uses the places view model


## Checklist

Ensure all / most of these are checked before the pull request is submitted.
- [x] This PR resolves #84.
- [x] Tests have been added for new functionality.
- [x] Documentation has been updated.

##  Testing

- **Manual Testing:**
    - [x] Tested on emulator / physical device.
- **Unit Tests**
    - [x] Added units tests for this

Displayed the widget in a separate screen and also tested it manually.

##  Related Issues/Tickets

Closes #84 
Now #82 is unblocked

