### PR TITLE
activity date fix

### DIFF
--- a/app/src/main/java/com/android/voyageur/ui/trip/AddActivity.kt
+++ b/app/src/main/java/com/android/voyageur/ui/trip/AddActivity.kt
@@ -171,11 +171,6 @@ fun AddActivityScreen(
         Toast.makeText(context, "Please select an activity date first", Toast.LENGTH_SHORT).show()
         return
       }
-      activityDate != null && dateNormalized.before(today) -> {
-        Toast.makeText(context, "The activity date cannot be in the past", Toast.LENGTH_SHORT)
-            .show()
-        return
-      }
       activityDate != null &&
           (dateNormalized.after(endDateNormalized) ||
               dateNormalized.before(startDateNormalized)) -> {


### PR DESCRIPTION
- the activity date must be between the trip's dates, even if it is in the past

## Summary

This small fix removes the check for the activity date if it is in the past, and checks just for the date to be between the trip's dates. i.e. it solves the problem when creating/editing an activity during an ongoing trip.

## Changes

- **Bug Fixes/Improvements:** Addresses #219 

## Checklist

Ensure all / most of these are checked before the pull request is submitted.
- [x] This PR resolves #219 .
- [ ] Tests have been added for new functionality.
- [ ] Screenshots or UI changes have been attached (if applicable).
- [x] Documentation has been updated (if applicable).

##  Testing

Explain how this feature was tested and what kind of testing (unit, integration, UI) has been done. Mention platforms or configurations used for testing.
- **Manual Testing:**
    - [x] Tested on emulator / physical device.
- **Unit Tests**
    - [ ] Added units tests for this

If you haven't added tests, please create a new issue and assign it.

##  Related Issues/Tickets

Closes #219 


