### PR TITLE
Feat/delete activity

### DIFF
--- a/app/src/main/java/com/android/voyageur/model/trip/TripsViewModel.kt
+++ b/app/src/main/java/com/android/voyageur/model/trip/TripsViewModel.kt
@@ -71,7 +71,7 @@ open class TripsViewModel(
     _selectedTrip.value = trip
   }
 
-  fun selectDay(day: LocalDate) {
+  open fun selectDay(day: LocalDate) {
     _selectedDay.value = day
   }
 
@@ -130,6 +130,10 @@ open class TripsViewModel(
         .addOnFailureListener { exception -> onFailure(exception) }
   }
 
+  open fun getActivitiesForSelectedTrip(): List<Activity> {
+    return selectedTrip.value?.activities ?: emptyList()
+  }
+
   open fun addActivityToTrip(activity: Activity) {
     if (selectedTrip.value != null) {
       val trip = selectedTrip.value!!
@@ -147,22 +151,22 @@ open class TripsViewModel(
     }
   }
 
-    open fun removeActivityFromTrip(activity: Activity) {
-        if (selectedTrip.value != null) {
-            val trip = selectedTrip.value!!
-            val updatedTrip = trip.copy(activities = trip.activities - activity)
-            updateTrip(
-                updatedTrip,
-                onSuccess = {
-                    /*
-                        This is a trick to force a recompose, because the reference wouldn't
-                        change and update the UI.
-                    */
-                    selectTrip(Trip())
-                    selectTrip(updatedTrip)
-                })
-        }
+  open fun removeActivityFromTrip(activity: Activity) {
+    if (selectedTrip.value != null) {
+      val trip = selectedTrip.value!!
+      val updatedTrip = trip.copy(activities = trip.activities - activity)
+      updateTrip(
+          updatedTrip,
+          onSuccess = {
+            /*
+                This is a trick to force a recompose, because the reference wouldn't
+                change and update the UI.
+            */
+            selectTrip(Trip())
+            selectTrip(updatedTrip)
+          })
     }
+  }
 
   // ****************************************************************************************************
   // AI assistant

--- a/app/src/main/java/com/android/voyageur/model/trip/TripsViewModel.kt
+++ b/app/src/main/java/com/android/voyageur/model/trip/TripsViewModel.kt
@@ -147,6 +147,23 @@ open class TripsViewModel(
     }
   }
 
+    open fun removeActivityFromTrip(activity: Activity) {
+        if (selectedTrip.value != null) {
+            val trip = selectedTrip.value!!
+            val updatedTrip = trip.copy(activities = trip.activities - activity)
+            updateTrip(
+                updatedTrip,
+                onSuccess = {
+                    /*
+                        This is a trick to force a recompose, because the reference wouldn't
+                        change and update the UI.
+                    */
+                    selectTrip(Trip())
+                    selectTrip(updatedTrip)
+                })
+        }
+    }
+
   // ****************************************************************************************************
   // AI assistant
   // ****************************************************************************************************

--- a/app/src/main/java/com/android/voyageur/ui/trip/Tabs.kt
+++ b/app/src/main/java/com/android/voyageur/ui/trip/Tabs.kt
@@ -8,7 +8,6 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.testTag
 import com.android.voyageur.model.trip.TripsViewModel
@@ -68,7 +67,7 @@ fun TopTabs(
     // Display content based on selected tab
     when (navigationActions.getNavigationState().currentTabIndexForTrip) {
       0 -> ScheduleScreen(tripsViewModel, selectedTrip, navigationActions, userViewModel)
-      1 -> ActivitiesScreen(selectedTrip, navigationActions, userViewModel, tripsViewModel)
+      1 -> ActivitiesScreen(navigationActions, userViewModel, tripsViewModel)
       2 ->
           SettingsScreen(
               selectedTrip,

--- a/app/src/main/java/com/android/voyageur/ui/trip/activities/Activities.kt
+++ b/app/src/main/java/com/android/voyageur/ui/trip/activities/Activities.kt
@@ -3,19 +3,26 @@ package com.android.voyageur.ui.trip.activities
 import android.annotation.SuppressLint
 import android.widget.Toast
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.outlined.Add
+import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.FloatingActionButton
 import androidx.compose.material3.Icon
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateListOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -24,6 +31,7 @@ import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import com.android.voyageur.model.activity.Activity
 import com.android.voyageur.model.trip.Trip
 import com.android.voyageur.model.trip.TripsViewModel
 import com.android.voyageur.model.user.UserViewModel
@@ -41,12 +49,36 @@ fun ActivitiesScreen(
     tripsViewModel: TripsViewModel
 ) {
 
-  var drafts =
-      trip.activities.filter { activity ->
-        activity.startTime == Timestamp(0, 0) || activity.endTime == Timestamp(0, 0)
-      }
-  val final =
-      trip.activities
+//  var drafts =
+//      trip.activities.filter { activity ->
+//        activity.startTime == Timestamp(0, 0) || activity.endTime == Timestamp(0, 0)
+//      }
+
+    var drafts by remember { mutableStateOf(emptyList<Activity>()) }
+    var final by remember { mutableStateOf(emptyList<Activity>()) }
+//  val final =
+//      trip.activities
+//          .filter { activity ->
+//            activity.startTime != Timestamp(0, 0) && activity.endTime != Timestamp(0, 0)
+//          }
+//          .sortedWith(
+//              compareBy(
+//                  { it.startTime }, // First, sort by startTime
+//                  { it.endTime } // If startTime is equal, sort by endTime
+//                  ))
+  val context = LocalContext.current
+
+    var showDialog by remember { mutableStateOf(false) }
+    var activityToDelete by remember { mutableStateOf<Activity?>(null) }
+    var isLoading by remember { mutableStateOf(false) }
+
+    // Fetch the activities from the trip
+    LaunchedEffect (Unit) {
+        isLoading = true
+        drafts = trip.activities.filter { activity ->
+            activity.startTime == Timestamp(0, 0) || activity.endTime == Timestamp(0, 0)
+        }
+        final =    trip.activities
           .filter { activity ->
             activity.startTime != Timestamp(0, 0) && activity.endTime != Timestamp(0, 0)
           }
@@ -55,7 +87,9 @@ fun ActivitiesScreen(
                   { it.startTime }, // First, sort by startTime
                   { it.endTime } // If startTime is equal, sort by endTime
                   ))
-  val context = LocalContext.current
+        isLoading = false
+
+    }
 
   Scaffold(
       // TODO: Search Bar
@@ -69,58 +103,95 @@ fun ActivitiesScreen(
       },
       floatingActionButton = { AddActivityButton(navigationActions) },
       content = { pd ->
-        LazyColumn(
-            modifier =
-                Modifier.padding(pd).padding(top = 16.dp).fillMaxWidth().testTag("lazyColumn"),
-            verticalArrangement = Arrangement.spacedBy(10.dp, Alignment.Top),
-        ) {
-          item {
-            Text(
-                text = "Drafts",
-                fontSize = 24.sp,
-                fontWeight = FontWeight.Bold,
-                modifier = Modifier.padding(start = 10.dp))
+          if (isLoading) {
+              // Display a loading indicator while fetching data
+              Box(
+                  modifier = Modifier.fillMaxSize(),
+                  contentAlignment = Alignment.Center
+              ) {
+                  CircularProgressIndicator(modifier = Modifier.testTag("loadingIndicator"))
+              }
           }
-          drafts.forEach { activity ->
-            item {
-              ActivityItem(
-                  activity,
-                  true,
-                  onClickButton = {
-                    Toast.makeText(
-                            context, "Delete activity not implemented yet", Toast.LENGTH_SHORT)
-                        .show()
-                  },
-                  ButtonType.DELETE,
-                  navigationActions,
-                  tripsViewModel)
-              Spacer(modifier = Modifier.height(10.dp))
-            }
+          else {
+              LazyColumn(
+                  modifier =
+                  Modifier
+                      .padding(pd)
+                      .padding(top = 16.dp)
+                      .fillMaxWidth()
+                      .testTag("lazyColumn"),
+                  verticalArrangement = Arrangement.spacedBy(10.dp, Alignment.Top),
+              ) {
+                  item {
+                      Text(
+                          text = "Drafts",
+                          fontSize = 24.sp,
+                          fontWeight = FontWeight.Bold,
+                          modifier = Modifier.padding(start = 10.dp)
+                      )
+                  }
+                  drafts.forEach { activity ->
+                      item {
+                          ActivityItem(
+                              activity,
+                              true,
+                              onClickButton = {
+                                  Toast.makeText(
+                                      context,
+                                      "Delete activity not implemented yet",
+                                      Toast.LENGTH_SHORT
+                                  )
+                                      .show()
+                              },
+                              ButtonType.DELETE,
+                              navigationActions,
+                              tripsViewModel
+                          )
+                          Spacer(modifier = Modifier.height(10.dp))
+                      }
+                  }
+                  item {
+                      Text(
+                          text = "Final",
+                          fontSize = 24.sp,
+                          fontWeight = FontWeight.Bold,
+                          modifier = Modifier.padding(start = 10.dp)
+                      )
+                  }
+                  final.forEach { activity ->
+                      item {
+                          ActivityItem(
+                              activity,
+                              true,
+                              onClickButton = {
+                                  activityToDelete = activity
+                                  showDialog = true
+                              },
+                              ButtonType.DELETE,
+                              navigationActions,
+                              tripsViewModel
+                          )
+                          Spacer(modifier = Modifier.height(10.dp))
+                      }
+                  }
+              }
+
+              if (showDialog) {
+                  DeleteActivityAlertDialog(
+                      onDismissRequest = { showDialog = false },
+                      activityToDelete = activityToDelete,
+                      tripsViewModel = tripsViewModel,
+                      confirmButtonOnClick = {
+                          showDialog = false
+                          tripsViewModel.selectedTrip.value?.let {
+                              tripsViewModel.removeActivityFromTrip(activityToDelete!!)
+                              final = final.filter { it != activityToDelete }
+                          }
+                          final = final.filter { it != activityToDelete }
+                      }
+                  )
+              }
           }
-          item {
-            Text(
-                text = "Final",
-                fontSize = 24.sp,
-                fontWeight = FontWeight.Bold,
-                modifier = Modifier.padding(start = 10.dp))
-          }
-          final.forEach { activity ->
-            item {
-              ActivityItem(
-                  activity,
-                  true,
-                  onClickButton = {
-                    Toast.makeText(
-                            context, "Delete activity not implemented yet", Toast.LENGTH_SHORT)
-                        .show()
-                  },
-                  ButtonType.DELETE,
-                  navigationActions,
-                  tripsViewModel)
-              Spacer(modifier = Modifier.height(10.dp))
-            }
-          }
-        }
       })
 }
 

--- a/app/src/main/java/com/android/voyageur/ui/trip/activities/Activities.kt
+++ b/app/src/main/java/com/android/voyageur/ui/trip/activities/Activities.kt
@@ -1,38 +1,26 @@
 package com.android.voyageur.ui.trip.activities
 
 import android.annotation.SuppressLint
-import android.widget.Toast
 import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.outlined.Add
-import androidx.compose.material3.CircularProgressIndicator
-import androidx.compose.material3.FloatingActionButton
-import androidx.compose.material3.Icon
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateListOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.android.voyageur.model.activity.Activity
-import com.android.voyageur.model.trip.Trip
 import com.android.voyageur.model.trip.TripsViewModel
 import com.android.voyageur.model.user.UserViewModel
 import com.android.voyageur.ui.navigation.BottomNavigationMenu
@@ -43,53 +31,33 @@ import com.google.firebase.Timestamp
 @SuppressLint("UnusedMaterial3ScaffoldPaddingParameter")
 @Composable
 fun ActivitiesScreen(
-    trip: Trip,
     navigationActions: NavigationActions,
     userViewModel: UserViewModel,
     tripsViewModel: TripsViewModel
 ) {
 
-//  var drafts =
-//      trip.activities.filter { activity ->
-//        activity.startTime == Timestamp(0, 0) || activity.endTime == Timestamp(0, 0)
-//      }
+  var drafts by remember {
+    mutableStateOf(
+        tripsViewModel.getActivitiesForSelectedTrip().filter { activity ->
+          activity.startTime == Timestamp(0, 0) || activity.endTime == Timestamp(0, 0)
+        })
+  }
+  var final by remember {
+    mutableStateOf(
+        tripsViewModel
+            .getActivitiesForSelectedTrip()
+            .filter { activity ->
+              activity.startTime != Timestamp(0, 0) && activity.endTime != Timestamp(0, 0)
+            }
+            .sortedWith(
+                compareBy(
+                    { it.startTime }, // First, sort by startTime
+                    { it.endTime } // If startTime is equal, sort by endTime
+                    )))
+  }
 
-    var drafts by remember { mutableStateOf(emptyList<Activity>()) }
-    var final by remember { mutableStateOf(emptyList<Activity>()) }
-//  val final =
-//      trip.activities
-//          .filter { activity ->
-//            activity.startTime != Timestamp(0, 0) && activity.endTime != Timestamp(0, 0)
-//          }
-//          .sortedWith(
-//              compareBy(
-//                  { it.startTime }, // First, sort by startTime
-//                  { it.endTime } // If startTime is equal, sort by endTime
-//                  ))
-  val context = LocalContext.current
-
-    var showDialog by remember { mutableStateOf(false) }
-    var activityToDelete by remember { mutableStateOf<Activity?>(null) }
-    var isLoading by remember { mutableStateOf(false) }
-
-    // Fetch the activities from the trip
-    LaunchedEffect (Unit) {
-        isLoading = true
-        drafts = trip.activities.filter { activity ->
-            activity.startTime == Timestamp(0, 0) || activity.endTime == Timestamp(0, 0)
-        }
-        final =    trip.activities
-          .filter { activity ->
-            activity.startTime != Timestamp(0, 0) && activity.endTime != Timestamp(0, 0)
-          }
-          .sortedWith(
-              compareBy(
-                  { it.startTime }, // First, sort by startTime
-                  { it.endTime } // If startTime is equal, sort by endTime
-                  ))
-        isLoading = false
-
-    }
+  var showDialog by remember { mutableStateOf(false) }
+  var activityToDelete by remember { mutableStateOf<Activity?>(null) }
 
   Scaffold(
       // TODO: Search Bar
@@ -103,95 +71,67 @@ fun ActivitiesScreen(
       },
       floatingActionButton = { AddActivityButton(navigationActions) },
       content = { pd ->
-          if (isLoading) {
-              // Display a loading indicator while fetching data
-              Box(
-                  modifier = Modifier.fillMaxSize(),
-                  contentAlignment = Alignment.Center
-              ) {
-                  CircularProgressIndicator(modifier = Modifier.testTag("loadingIndicator"))
-              }
+        LazyColumn(
+            modifier =
+                Modifier.padding(pd).padding(top = 16.dp).fillMaxWidth().testTag("lazyColumn"),
+            verticalArrangement = Arrangement.spacedBy(10.dp, Alignment.Top),
+        ) {
+          item {
+            Text(
+                text = "Drafts",
+                fontSize = 24.sp,
+                fontWeight = FontWeight.Bold,
+                modifier = Modifier.padding(start = 10.dp))
           }
-          else {
-              LazyColumn(
-                  modifier =
-                  Modifier
-                      .padding(pd)
-                      .padding(top = 16.dp)
-                      .fillMaxWidth()
-                      .testTag("lazyColumn"),
-                  verticalArrangement = Arrangement.spacedBy(10.dp, Alignment.Top),
-              ) {
-                  item {
-                      Text(
-                          text = "Drafts",
-                          fontSize = 24.sp,
-                          fontWeight = FontWeight.Bold,
-                          modifier = Modifier.padding(start = 10.dp)
-                      )
-                  }
-                  drafts.forEach { activity ->
-                      item {
-                          ActivityItem(
-                              activity,
-                              true,
-                              onClickButton = {
-                                  Toast.makeText(
-                                      context,
-                                      "Delete activity not implemented yet",
-                                      Toast.LENGTH_SHORT
-                                  )
-                                      .show()
-                              },
-                              ButtonType.DELETE,
-                              navigationActions,
-                              tripsViewModel
-                          )
-                          Spacer(modifier = Modifier.height(10.dp))
-                      }
-                  }
-                  item {
-                      Text(
-                          text = "Final",
-                          fontSize = 24.sp,
-                          fontWeight = FontWeight.Bold,
-                          modifier = Modifier.padding(start = 10.dp)
-                      )
-                  }
-                  final.forEach { activity ->
-                      item {
-                          ActivityItem(
-                              activity,
-                              true,
-                              onClickButton = {
-                                  activityToDelete = activity
-                                  showDialog = true
-                              },
-                              ButtonType.DELETE,
-                              navigationActions,
-                              tripsViewModel
-                          )
-                          Spacer(modifier = Modifier.height(10.dp))
-                      }
-                  }
-              }
+          drafts.forEach { activity ->
+            item {
+              ActivityItem(
+                  activity,
+                  true,
+                  onClickButton = {
+                    activityToDelete = activity
+                    showDialog = true
+                  },
+                  ButtonType.DELETE,
+                  navigationActions,
+                  tripsViewModel)
+              Spacer(modifier = Modifier.height(10.dp))
+            }
+          }
+          item {
+            Text(
+                text = "Final",
+                fontSize = 24.sp,
+                fontWeight = FontWeight.Bold,
+                modifier = Modifier.padding(start = 10.dp))
+          }
+          final.forEach { activity ->
+            item {
+              ActivityItem(
+                  activity,
+                  true,
+                  onClickButton = {
+                    activityToDelete = activity
+                    showDialog = true
+                  },
+                  ButtonType.DELETE,
+                  navigationActions,
+                  tripsViewModel)
+              Spacer(modifier = Modifier.height(10.dp))
+            }
+          }
+        }
 
-              if (showDialog) {
-                  DeleteActivityAlertDialog(
-                      onDismissRequest = { showDialog = false },
-                      activityToDelete = activityToDelete,
-                      tripsViewModel = tripsViewModel,
-                      confirmButtonOnClick = {
-                          showDialog = false
-                          tripsViewModel.selectedTrip.value?.let {
-                              tripsViewModel.removeActivityFromTrip(activityToDelete!!)
-                              final = final.filter { it != activityToDelete }
-                          }
-                          final = final.filter { it != activityToDelete }
-                      }
-                  )
-              }
-          }
+        if (showDialog) {
+          DeleteActivityAlertDialog(
+              onDismissRequest = { showDialog = false },
+              activityToDelete = activityToDelete,
+              tripsViewModel = tripsViewModel,
+              confirmButtonOnClick = {
+                showDialog = false
+                final = final.filter { it != activityToDelete }
+                drafts = drafts.filter { it != activityToDelete }
+              })
+        }
       })
 }
-

--- a/app/src/main/java/com/android/voyageur/ui/trip/activities/Activities.kt
+++ b/app/src/main/java/com/android/voyageur/ui/trip/activities/Activities.kt
@@ -30,7 +30,6 @@ import com.android.voyageur.model.user.UserViewModel
 import com.android.voyageur.ui.navigation.BottomNavigationMenu
 import com.android.voyageur.ui.navigation.LIST_TOP_LEVEL_DESTINATION
 import com.android.voyageur.ui.navigation.NavigationActions
-import com.android.voyageur.ui.navigation.Screen
 import com.google.firebase.Timestamp
 
 @SuppressLint("UnusedMaterial3ScaffoldPaddingParameter")
@@ -42,7 +41,7 @@ fun ActivitiesScreen(
     tripsViewModel: TripsViewModel
 ) {
 
-  val drafts =
+  var drafts =
       trip.activities.filter { activity ->
         activity.startTime == Timestamp(0, 0) || activity.endTime == Timestamp(0, 0)
       }
@@ -125,12 +124,3 @@ fun ActivitiesScreen(
       })
 }
 
-/** Composable that displays a button that navigates to the Add Activity screen. */
-@Composable
-fun AddActivityButton(navigationActions: NavigationActions) {
-  FloatingActionButton(
-      onClick = { navigationActions.navigateTo(Screen.ADD_ACTIVITY) },
-      modifier = Modifier.testTag("createActivityButton")) {
-        Icon(Icons.Outlined.Add, "Floating action button", modifier = Modifier.testTag("addIcon"))
-      }
-}

--- a/app/src/main/java/com/android/voyageur/ui/trip/activities/ActivityUtils.kt
+++ b/app/src/main/java/com/android/voyageur/ui/trip/activities/ActivityUtils.kt
@@ -1,12 +1,19 @@
 package com.android.voyageur.ui.trip.activities
 
+import android.util.Log
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.outlined.Add
+import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.FloatingActionButton
 import androidx.compose.material3.Icon
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.testTag
+import com.android.voyageur.model.activity.Activity
+import com.android.voyageur.model.trip.Trip
+import com.android.voyageur.model.trip.TripsViewModel
 import com.android.voyageur.ui.navigation.NavigationActions
 import com.android.voyageur.ui.navigation.Screen
 
@@ -18,4 +25,42 @@ fun AddActivityButton(navigationActions: NavigationActions) {
         modifier = Modifier.testTag("createActivityButton")) {
         Icon(Icons.Outlined.Add, "Floating action button", modifier = Modifier.testTag("addIcon"))
     }
+}
+@Composable
+fun DeleteActivityAlertDialog(
+    onDismissRequest: () -> Unit,
+    activityToDelete: Activity?,
+    tripsViewModel: TripsViewModel,
+    confirmButtonOnClick: () -> Unit,
+) {
+
+    AlertDialog(
+        onDismissRequest = onDismissRequest,
+        title = { Text("Delete Activity") },
+        text = { Text("Are you sure you want to delete this activity?") },
+        confirmButton = {
+            TextButton(
+                onClick = {
+                    confirmButtonOnClick()
+                    // Perform the deletion
+                    activityToDelete?.let { activity ->
+                        tripsViewModel.removeActivityFromTrip(activity)
+//                        tripsViewModel.selectTrip(Trip())
+//                        tripsViewModel.selectTrip(tripsViewModel.selectedTrip.value!!)
+                        Log.d(
+                            "ActivitiesScreen",
+                            "xxxx: ${tripsViewModel.selectedTrip.value!!.activities}"
+                        )
+                    }
+                }
+            ) {
+                Text("Delete")
+            }
+        },
+        dismissButton = {
+            TextButton(onClick = { onDismissRequest() }) {
+                Text("Cancel")
+            }
+        }
+    )
 }

--- a/app/src/main/java/com/android/voyageur/ui/trip/activities/ActivityUtils.kt
+++ b/app/src/main/java/com/android/voyageur/ui/trip/activities/ActivityUtils.kt
@@ -1,6 +1,5 @@
 package com.android.voyageur.ui.trip.activities
 
-import android.util.Log
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.outlined.Add
 import androidx.compose.material3.AlertDialog
@@ -12,20 +11,32 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.testTag
 import com.android.voyageur.model.activity.Activity
-import com.android.voyageur.model.trip.Trip
 import com.android.voyageur.model.trip.TripsViewModel
 import com.android.voyageur.ui.navigation.NavigationActions
 import com.android.voyageur.ui.navigation.Screen
 
-/** Composable that displays a button that navigates to the Add Activity screen. */
+/**
+ * Composable that displays a button that navigates to the Add Activity screen.
+ *
+ * @param navigationActions: The navigation actions.
+ */
 @Composable
 fun AddActivityButton(navigationActions: NavigationActions) {
-    FloatingActionButton(
-        onClick = { navigationActions.navigateTo(Screen.ADD_ACTIVITY) },
-        modifier = Modifier.testTag("createActivityButton")) {
+  FloatingActionButton(
+      onClick = { navigationActions.navigateTo(Screen.ADD_ACTIVITY) },
+      modifier = Modifier.testTag("createActivityButton")) {
         Icon(Icons.Outlined.Add, "Floating action button", modifier = Modifier.testTag("addIcon"))
-    }
+      }
 }
+
+/**
+ * Composable that displays an alert dialog to confirm the deletion of an activity.
+ *
+ * @param onDismissRequest: Callback to dismiss the dialog.
+ * @param activityToDelete: The activity to delete.
+ * @param tripsViewModel: The view model for the trips.
+ * @param confirmButtonOnClick: Callback to confirm the deletion.
+ */
 @Composable
 fun DeleteActivityAlertDialog(
     onDismissRequest: () -> Unit,
@@ -34,33 +45,21 @@ fun DeleteActivityAlertDialog(
     confirmButtonOnClick: () -> Unit,
 ) {
 
-    AlertDialog(
-        onDismissRequest = onDismissRequest,
-        title = { Text("Delete Activity") },
-        text = { Text("Are you sure you want to delete this activity?") },
-        confirmButton = {
-            TextButton(
-                onClick = {
-                    confirmButtonOnClick()
-                    // Perform the deletion
-                    activityToDelete?.let { activity ->
-                        tripsViewModel.removeActivityFromTrip(activity)
-//                        tripsViewModel.selectTrip(Trip())
-//                        tripsViewModel.selectTrip(tripsViewModel.selectedTrip.value!!)
-                        Log.d(
-                            "ActivitiesScreen",
-                            "xxxx: ${tripsViewModel.selectedTrip.value!!.activities}"
-                        )
-                    }
-                }
-            ) {
-                Text("Delete")
+  AlertDialog(
+      modifier = Modifier.testTag("deleteActivityAlertDialog"),
+      onDismissRequest = onDismissRequest,
+      title = { Text("Delete Activity") },
+      text = { Text("Are you sure you want to delete this activity?") },
+      confirmButton = {
+        TextButton(
+            modifier = Modifier.testTag("confirmDeleteButton"),
+            onClick = {
+              confirmButtonOnClick()
+              // Perform the deletion
+              activityToDelete?.let { activity -> tripsViewModel.removeActivityFromTrip(activity) }
+            }) {
+              Text("Delete")
             }
-        },
-        dismissButton = {
-            TextButton(onClick = { onDismissRequest() }) {
-                Text("Cancel")
-            }
-        }
-    )
+      },
+      dismissButton = { TextButton(onClick = { onDismissRequest() }) { Text("Cancel") } })
 }

--- a/app/src/main/java/com/android/voyageur/ui/trip/activities/ActivityUtils.kt
+++ b/app/src/main/java/com/android/voyageur/ui/trip/activities/ActivityUtils.kt
@@ -1,0 +1,21 @@
+package com.android.voyageur.ui.trip.activities
+
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.outlined.Add
+import androidx.compose.material3.FloatingActionButton
+import androidx.compose.material3.Icon
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
+import com.android.voyageur.ui.navigation.NavigationActions
+import com.android.voyageur.ui.navigation.Screen
+
+/** Composable that displays a button that navigates to the Add Activity screen. */
+@Composable
+fun AddActivityButton(navigationActions: NavigationActions) {
+    FloatingActionButton(
+        onClick = { navigationActions.navigateTo(Screen.ADD_ACTIVITY) },
+        modifier = Modifier.testTag("createActivityButton")) {
+        Icon(Icons.Outlined.Add, "Floating action button", modifier = Modifier.testTag("addIcon"))
+    }
+}

--- a/app/src/main/java/com/android/voyageur/ui/trip/schedule/ByDay.kt
+++ b/app/src/main/java/com/android/voyageur/ui/trip/schedule/ByDay.kt
@@ -1,5 +1,6 @@
 package com.android.voyageur.ui.trip.schedule
 
+import android.annotation.SuppressLint
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -42,6 +43,7 @@ import java.time.ZoneId
 import java.time.format.DateTimeFormatter
 import java.util.Locale
 
+@SuppressLint("StateFlowValueCalledInComposition")
 @Composable
 fun ByDayScreen(
     tripsViewModel: TripsViewModel,
@@ -60,7 +62,7 @@ fun ByDayScreen(
             userViewModel = userViewModel)
       },
       content = { pd ->
-        val tripActivities = trip.activities
+        val tripActivities = tripsViewModel.getActivitiesForSelectedTrip()
         val groupedActivities =
             groupActivitiesByDate(tripActivities)
                 .mapValues { (_, activities) ->

--- a/app/src/main/java/com/android/voyageur/ui/trip/schedule/WeeklyView.kt
+++ b/app/src/main/java/com/android/voyageur/ui/trip/schedule/WeeklyView.kt
@@ -73,7 +73,7 @@ fun WeeklyViewScreen(
                       trip = trip,
                       weekStart = weeks[weekIndex].first,
                       weekEnd = weeks[weekIndex].last,
-                      activities = trip.activities,
+                      activities = tripsViewModel.getActivitiesForSelectedTrip(),
                       weekIndex = weekIndex,
                       navigationActions = navigationActions)
                 }


### PR DESCRIPTION
## Summary

This new features enables users to delete an activity. To do this, users must be in the Activities screen or ActivitiesForOneDay screen, press on the expand icon for an activity and then press on the delete icon. This will put a pop up on screen, and the user has to confirm that they want to delete the activity.

## Changes

- **Models:** added getActivitiesForSelectedTrip and removeActivityFromTrip to tripsViewModel
- **Screens/UI:** the ActivityUtils file now has the Alert Dialog Composable for deleting an activity
- **Bug Fixes/Improvements:** when fetching activities, now the screens use tripsViewmodel for the activities instead of a trip parameter. This allows changes to be visible.

## Checklist

Ensure all / most of these are checked before the pull request is submitted.
- [x] This PR resolves #184  
- [x] Tests have been added for new functionality.
- [x] Screenshots or UI changes have been attached (if applicable).
- [x] Documentation has been updated (if applicable).

##  Testing

- **Manual Testing:**
    - [x] Tested on emulator / physical device.
- **Unit Tests**
    - [x] Added units tests for this

## Screenshots (if applicable)

Attach screenshots or screen recordings that show UI changes.

[delete activity.webm](https://github.com/user-attachments/assets/ef10fae2-3ddd-4a20-b122-21bf8b418027)
