### PR TITLE
Refactor: Improve friend requests.

### DIFF
--- a/app/src/androidTest/java/com/android/voyageur/ui/profile/ProfileScreenTest.kt
+++ b/app/src/androidTest/java/com/android/voyageur/ui/profile/ProfileScreenTest.kt
@@ -3,10 +3,8 @@ package com.android.voyageur.ui.profile
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.ui.test.assertCountEquals
 import androidx.compose.ui.test.assertIsDisplayed
-import androidx.compose.ui.test.assertTextContains
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onAllNodesWithTag
-import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
@@ -70,6 +68,7 @@ class ProfileScreenTest {
 
     // Create the UserViewModel with the mocked userRepository and firebaseAuth
     userViewModel = UserViewModel(userRepository, firebaseAuth, friendRequestRepository)
+
     userViewModel.shouldFetch = false
     // Mocking initial navigation state
     `when`(navigationActions.currentRoute()).thenReturn(Route.PROFILE)
@@ -208,6 +207,7 @@ class ProfileScreenTest {
     // Assert: Check that the "No interests added yet" message is displayed
     composeTestRule.onNodeWithTag("noInterests").assertIsDisplayed()
   }
+
   @Test
   fun displaysNoRequestsTextWhenFriendRequestsAreEmpty() {
     // Arrange: Set empty friendRequests
@@ -217,35 +217,28 @@ class ProfileScreenTest {
     composeTestRule.onNodeWithTag("noRequestsBox").assertIsDisplayed()
     composeTestRule.onNodeWithText("You're all caught up! No pending requests.").assertIsDisplayed()
   }
+
   @Test
   fun displaysFriendRequestWhenListIsNotEmpty() {
     // Arrange: Set friendRequests with some data
-    val mockFriendRequests = listOf(
-      FriendRequest(from = "user1", to = "user2")
-    )
+    val mockFriendRequests = listOf(FriendRequest(from = "user1", to = "user2"))
     friendRequests.value = mockFriendRequests
-    notificationUsers.value = listOf(
-      User(id = "user1", name = "User One", profilePicture = "http://example.com/pic.jpg")
-    )
+    notificationUsers.value =
+        listOf(User(id = "user1", name = "User One", profilePicture = "http://example.com/pic.jpg"))
     composeTestRule.waitForIdle()
 
     // Assert: Check that the LazyColumn is displayed
     composeTestRule.onNodeWithTag("friendRequestLazyColumn").assertIsDisplayed()
 
-    // Assert: Check that the specific friend request item is displayed
-    composeTestRule.onAllNodesWithTag("friendRequest", useUnmergedTree = true)
-      .assertCountEquals(1)
-    // Assert: Check the profile picture is displayed
-    composeTestRule.onNodeWithTag("profilePicture", useUnmergedTree = true).assertIsDisplayed()
+    // Assert: Check that the specific friend request item has count one
+    composeTestRule.onAllNodesWithTag("friendRequest", useUnmergedTree = true).assertCountEquals(1)
 
-    // Assert: Check the name is displayed
+    // Assert: Check the profile picture and name are displayed
+    composeTestRule.onNodeWithTag("profilePicture", useUnmergedTree = true).assertIsDisplayed()
     composeTestRule.onNodeWithText("User One", useUnmergedTree = true).assertIsDisplayed()
 
-    // Assert: Check the accept icon is displayed
+    // Assert: Check the accept and deny buttons are displayed
     composeTestRule.onNodeWithTag("acceptButton", useUnmergedTree = true).assertIsDisplayed()
-
-    // Assert: Check the deny icon is displayed
     composeTestRule.onNodeWithTag("denyButton", useUnmergedTree = true).assertIsDisplayed()
   }
-
 }

--- a/app/src/main/java/com/android/voyageur/model/user/UserViewModel.kt
+++ b/app/src/main/java/com/android/voyageur/model/user/UserViewModel.kt
@@ -335,7 +335,11 @@ open class UserViewModel(
     userRepository.getContacts(
         Firebase.auth.uid ?: "", onSuccess, { Log.e("USER_VIEW_MODEL", it.message.orEmpty()) })
   }
-
+    /**
+     * Deletes friend request with the corresponding request ID
+     *
+     * @param reqId the request ID of the friend request to delete
+     */
   fun deleteFriendRequest(reqId: String) {
     friendRequestRepository.deleteRequest(
         reqId = reqId,

--- a/app/src/main/java/com/android/voyageur/model/user/UserViewModel.kt
+++ b/app/src/main/java/com/android/voyageur/model/user/UserViewModel.kt
@@ -358,11 +358,11 @@ open class UserViewModel(
     userRepository.getContacts(
         Firebase.auth.uid ?: "", onSuccess, { Log.e("USER_VIEW_MODEL", it.message.orEmpty()) })
   }
-    /**
-     * Deletes friend request with the corresponding request ID
-     *
-     * @param reqId the request ID of the friend request to delete
-     */
+  /**
+   * Deletes friend request with the corresponding request ID
+   *
+   * @param reqId the request ID of the friend request to delete
+   */
   fun deleteFriendRequest(reqId: String) {
     friendRequestRepository.deleteRequest(
         reqId = reqId,

--- a/app/src/main/java/com/android/voyageur/ui/profile/ProfileScreen.kt
+++ b/app/src/main/java/com/android/voyageur/ui/profile/ProfileScreen.kt
@@ -2,20 +2,17 @@ package com.android.voyageur.ui.profile
 
 import UserProfileContent
 import androidx.compose.foundation.Image
-import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.layout.wrapContentHeight
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.rememberScrollState
@@ -24,8 +21,6 @@ import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Check
 import androidx.compose.material.icons.filled.Close
-import androidx.compose.material.icons.filled.KeyboardArrowDown
-import androidx.compose.material.icons.filled.KeyboardArrowUp
 import androidx.compose.material3.Card
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.Icon
@@ -45,10 +40,11 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import androidx.compose.ui.window.Dialog
 import coil.compose.rememberAsyncImagePainter
+import com.android.voyageur.R
 import com.android.voyageur.model.notifications.FriendRequest
 import com.android.voyageur.model.user.User
 import com.android.voyageur.model.user.UserViewModel
@@ -57,6 +53,13 @@ import com.android.voyageur.ui.navigation.LIST_TOP_LEVEL_DESTINATION
 import com.android.voyageur.ui.navigation.NavigationActions
 import com.android.voyageur.ui.navigation.Route
 
+/**
+ * Composable function that represents the profile screen. Displays user information, handles
+ * navigation, and manages sign-out logic.
+ *
+ * @param userViewModel The [UserViewModel] instance used to observe user state and actions.
+ * @param navigationActions The [NavigationActions] instance for navigating between screens.
+ */
 @Composable
 fun ProfileScreen(userViewModel: UserViewModel, navigationActions: NavigationActions) {
   // Observe user and loading state from UserViewModel
@@ -89,11 +92,10 @@ fun ProfileScreen(userViewModel: UserViewModel, navigationActions: NavigationAct
       }) { padding ->
         Box(
             modifier =
-            Modifier
-                .fillMaxSize()
-                .padding(padding)
-                .verticalScroll(rememberScrollState())
-                .testTag("profileScreenContent"),
+                Modifier.fillMaxSize()
+                    .padding(padding)
+                    .verticalScroll(rememberScrollState())
+                    .testTag("profileScreenContent"),
             contentAlignment = Alignment.Center) {
               when {
                 isSigningOut -> {
@@ -111,13 +113,24 @@ fun ProfileScreen(userViewModel: UserViewModel, navigationActions: NavigationAct
                       onEdit = { navigationActions.navigateTo(Route.EDIT_PROFILE) })
                 }
                 else -> {
-                  Text("No user data available", modifier = Modifier.testTag("noUserData"))
+                  Text(
+                      stringResource(R.string.no_user_data),
+                      modifier = Modifier.testTag("noUserData"))
                 }
               }
             }
       }
 }
-
+/**
+ * Composable function that displays detailed user profile information and interaction options.
+ * Includes profile editing and friend request management.
+ *
+ * @param userData The [User] object representing the signed-in user's data.
+ * @param signedInUserId The ID of the currently signed-in user.
+ * @param onSignOut A lambda function triggered when the user chooses to sign out.
+ * @param userViewModel The [UserViewModel] instance for managing user-related actions.
+ * @param onEdit A lambda function triggered to navigate to the edit profile screen.
+ */
 @Composable
 fun ProfileContent(
     userData: User,
@@ -129,9 +142,7 @@ fun ProfileContent(
   val friendRequests by userViewModel.friendRequests.collectAsState()
   val notificationUsers by userViewModel.notificationUsers.collectAsState()
   Column(
-      modifier = Modifier
-          .fillMaxSize()
-          .padding(top = 16.dp), // Space for profile content
+      modifier = Modifier.fillMaxSize().padding(top = 16.dp), // Space for profile content
       horizontalAlignment = Alignment.CenterHorizontally) {
         UserProfileContent(
             userData = userData,
@@ -161,64 +172,56 @@ fun FriendReqMenu(
     notificationUsers: List<User>,
     userViewModel: UserViewModel,
 ) {
-    // Parent Card containing the scrollable box
-    Card(
-        shape = RoundedCornerShape(12.dp),
-        modifier = Modifier
-            .fillMaxWidth(0.80f)
-            .padding(horizontal = 10.dp, vertical = 8.dp)
-            .testTag("friendRequestCard")
-    ) {
+  // Parent Card containing the scrollable box
+  Card(
+      shape = RoundedCornerShape(12.dp),
+      modifier =
+          Modifier.fillMaxWidth(0.80f)
+              .padding(horizontal = 10.dp, vertical = 8.dp)
+              .testTag("friendRequestCard")) {
         Column(modifier = Modifier.padding(12.dp)) {
-            Text(
-                text = "${friendRequests.size} Pending Friend Requests",
-                color = MaterialTheme.colorScheme.onSurface,
-            )
+          Text(
+              text = stringResource(R.string.pending_friend_requests, friendRequests.size),
+              color = MaterialTheme.colorScheme.onSurface,
+          )
 
-            // Scrollable List inside a fixed-height box
-            Card(
-                shape = RoundedCornerShape(8.dp),
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .heightIn(max = 180.dp)// Set the height to restrict the scrollable area
-                    .padding(top = 8.dp)
-                    .testTag("friendRequestBox")
-            ) {
+          // Scrollable List inside a fixed-height box
+          Card(
+              shape = RoundedCornerShape(8.dp),
+              modifier =
+                  Modifier.fillMaxWidth()
+                      .heightIn(max = 180.dp) // Set the height to restrict the scrollable area
+                      .padding(top = 8.dp)
+                      .testTag("friendRequestBox")) {
                 if (friendRequests.isEmpty()) {
-                    // Display message if no friend requests
-                    Box(
-                        modifier = Modifier.fillMaxSize().testTag("noRequestsBox"),
-                        contentAlignment = Alignment.Center
-                    ) {
+                  // Display message if no friend requests
+                  Box(
+                      modifier = Modifier.fillMaxSize().testTag("noRequestsBox"),
+                      contentAlignment = Alignment.Center) {
                         Text(
-                            text = "You're all caught up! No pending requests.",
+                            text = stringResource(R.string.no_pending_requests),
                             fontSize = 12.sp,
-                            color = MaterialTheme.colorScheme.onSurfaceVariant
-                        )
-                    }
+                            color = MaterialTheme.colorScheme.onSurfaceVariant)
+                      }
                 } else {
-                    // Display Lazy Column with the friend requests
-                    LazyColumn(
-                        modifier = Modifier
-                            .fillMaxSize()
-                            .padding(8.dp)
-                            .testTag("friendRequestLazyColumn")
-                    ) {
+                  // Display Lazy Column with the friend requests
+                  LazyColumn(
+                      modifier =
+                          Modifier.fillMaxSize().padding(8.dp).testTag("friendRequestLazyColumn")) {
                         items(friendRequests) { request ->
-                            val fromUser = notificationUsers.find { it.id == request.from }
-                            fromUser?.let {
-                                FriendRequestItem(
-                                    friendRequest = request,
-                                    fromUser = fromUser,
-                                    userViewModel = userViewModel
-                                )
-                            }
+                          val fromUser = notificationUsers.find { it.id == request.from }
+                          fromUser?.let {
+                            FriendRequestItem(
+                                friendRequest = request,
+                                fromUser = fromUser,
+                                userViewModel = userViewModel)
+                          }
                         }
-                    }
+                      }
                 }
-            }
+              }
         }
-    }
+      }
 }
 /**
  * A composable function that displays a single friend request item. The item shows the user's
@@ -232,27 +235,19 @@ fun FriendReqMenu(
 @Composable
 fun FriendRequestItem(friendRequest: FriendRequest, fromUser: User, userViewModel: UserViewModel) {
   Row(
-      modifier = Modifier
-          .fillMaxWidth()
-          .padding(8.dp)
-          .testTag("friendRequest"),
+      modifier = Modifier.fillMaxWidth().padding(8.dp).testTag("friendRequest"),
       verticalAlignment = Alignment.CenterVertically,
       horizontalArrangement = Arrangement.SpaceBetween) {
         // Display the Profile Picture of the user from which you have a request
         Image(
             painter = rememberAsyncImagePainter(fromUser.profilePicture),
-            contentDescription = "Profile Picture",
+            contentDescription = stringResource(R.string.profile_picture),
             modifier =
-            Modifier
-                .size(40.dp)
-                .clip(RoundedCornerShape(20.dp))
-                .testTag("profilePicture"))
+                Modifier.size(40.dp).clip(RoundedCornerShape(20.dp)).testTag("profilePicture"))
 
         Text(
             text = fromUser.name,
-            modifier = Modifier
-                .padding(start = 8.dp)
-                .weight(1f) // Take remaining space
+            modifier = Modifier.padding(start = 8.dp).weight(1f) // Take remaining space
             )
 
         // Accept and Reject Icons
@@ -265,7 +260,7 @@ fun FriendRequestItem(friendRequest: FriendRequest, fromUser: User, userViewMode
               }) {
                 Icon(
                     imageVector = Icons.Default.Check,
-                    contentDescription = "Accept",
+                    contentDescription = stringResource(R.string.accept),
                     tint = Color.Green)
               }
 
@@ -277,7 +272,7 @@ fun FriendRequestItem(friendRequest: FriendRequest, fromUser: User, userViewMode
               }) {
                 Icon(
                     imageVector = Icons.Default.Close,
-                    contentDescription = "Reject",
+                    contentDescription = stringResource(R.string.reject),
                     tint = Color.Red)
               }
         }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -3,4 +3,10 @@
     <string name="title_activity_main">MainActivity</string>
     <string name="title_activity_second">SecondActivity</string>
     <string name="default_web_client_id">386260395468-2n5ilio1go0tnvq1pddj087e0gekcmei.apps.googleusercontent.com</string>
+    <string name="no_user_data">No user data available</string>
+    <string name="no_pending_requests">You\'re all caught up! No pending requests.</string>
+    <string name="pending_friend_requests">%1$d Pending Friend Requests</string>
+    <string name="profile_picture">Profile Picture</string>
+    <string name="accept">Accept</string>
+    <string name="reject">Reject</string>
 </resources>


### PR DESCRIPTION
## Summary

This PR fixes the issue in which, after the user accepts a friend request, the dialog closed and they would have to open it again to visualize the friend requests. Now, the user views a list, which if empty displays a text saying there are no pending requests, otherwise displaying the requests. After approving a request, the request disappears but the list still stays open. If there are more than 3 friend requests, the user can scroll below to approve/deny them.
Moreover, documentation has been updated for the  ProfileScreen and UserViewModel.

## Changes

- **Screens/UI:** Changes to the friend request list in ProfileScreen.
- **Bug Fixes/Improvements:** Improves user experience and addresses #215 .

## Checklist

Ensure all / most of these are checked before the pull request is submitted.
- [X] This PR resolves #215.
- [X] Tests have been added for new functionality.
- [X] Screenshots or UI changes have been attached (if applicable).
- [X] Documentation has been updated (if applicable).

##  Testing

Explain how this feature was tested and what kind of testing (unit, integration, UI) has been done. Mention platforms or configurations used for testing.
- **Manual Testing:**
    - [X] Tested on emulator / physical device.
- **Unit Tests**
    - [X] Added units tests for this

If you haven't added tests, please create a new issue and assign it.

##  Related Issues/Tickets

Closes #215.

## Screenshots (if applicable)

![Screenshot 2024-11-26 at 16 32 57](https://github.com/user-attachments/assets/85251cc0-28b9-4c1e-a15e-3a3a3537999b)
![Screenshot 2024-11-26 at 16 33 20](https://github.com/user-attachments/assets/2d8fb5e4-c327-4bb0-be1e-0ea459ad8e59)
