### PR TITLE
Feat: Add button to filter activities by type.

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -171,6 +171,10 @@ dependencies {
     implementation(libs.play.services.auth)
     implementation(libs.places)
 
+    // Icons
+    implementation (libs.androidx.material.icons.core)
+    implementation (libs.androidx.material.icons.extended)
+
     // Firebase
     implementation(libs.firebase.database.ktx)
     implementation(libs.firebase.firestore)

--- a/app/src/androidTest/java/com/android/voyageur/ui/trip/activities/ActivitiesScreenTest.kt
+++ b/app/src/androidTest/java/com/android/voyageur/ui/trip/activities/ActivitiesScreenTest.kt
@@ -176,4 +176,65 @@ class ActivitiesScreenTest {
         .assertIsNotDisplayed()
     verify(mockTripsViewModel).removeActivityFromTrip(sampleTrip.activities[1])
   }
+
+  @Test
+  fun clickingFilterButton_displaysFilterDialog() {
+    `when`(mockTripsViewModel.getActivitiesForSelectedTrip()).thenReturn(sampleTrip.activities)
+    composeTestRule.setContent {
+      ActivitiesScreen(navigationActions, userViewModel, mockTripsViewModel)
+    }
+    // Click the filter button
+    composeTestRule.onNodeWithTag("filterButton").performClick()
+    composeTestRule.onNodeWithTag("filterActivityAlertDialog").assertIsDisplayed()
+  }
+
+  @Test
+  fun selectingFilter_updatesDisplayedActivities() {
+    `when`(mockTripsViewModel.getActivitiesForSelectedTrip()).thenReturn(sampleTrip.activities)
+    composeTestRule.setContent {
+      ActivitiesScreen(navigationActions, userViewModel, mockTripsViewModel)
+    }
+
+    composeTestRule.onNodeWithTag("filterButton").performClick()
+    // Select the "WALK" filter
+    composeTestRule.onNodeWithTag("typeCheckBox_WALK").performClick()
+    composeTestRule.onNodeWithTag("confirmButtonDialog").performClick()
+
+    // Verify that only WALK activities are displayed
+    composeTestRule.onNodeWithTag("cardItem_${sampleTrip.activities[0].title}").assertIsDisplayed()
+    composeTestRule.onNodeWithTag("cardItem_${sampleTrip.activities[1].title}").assertDoesNotExist()
+    composeTestRule.onNodeWithTag("cardItem_${sampleTrip.activities[2].title}").assertDoesNotExist()
+  }
+
+  @Test
+  fun clearingFilter_displaysAllActivities() {
+    `when`(mockTripsViewModel.getActivitiesForSelectedTrip()).thenReturn(sampleTrip.activities)
+    composeTestRule.setContent {
+      ActivitiesScreen(navigationActions, userViewModel, mockTripsViewModel)
+    }
+
+    composeTestRule.onNodeWithTag("filterButton").performClick()
+    // Select the "RESTAURANT" filter using the updated test tag
+    composeTestRule.onNodeWithTag("typeCheckBox_RESTAURANT").performClick()
+    composeTestRule.onNodeWithTag("confirmButtonDialog").performClick()
+
+    // Verify that only RESTAURANT activities are displayed
+    composeTestRule.onNodeWithTag("cardItem_Final Activity With Description").assertIsDisplayed()
+    composeTestRule.onNodeWithTag("cardItem_Draft Activity").assertDoesNotExist()
+    composeTestRule
+        .onNodeWithTag("cardItem_Final Activity Without Description")
+        .assertDoesNotExist()
+
+    // Open the filter dialog again
+    composeTestRule.onNodeWithTag("filterButton").performClick()
+
+    // Deselect the "RESTAURANT" filter using the updated test tag
+    composeTestRule.onNodeWithTag("typeCheckBox_RESTAURANT").performClick()
+    composeTestRule.onNodeWithTag("confirmButtonDialog").performClick()
+
+    // Verify all activities are displayed
+    composeTestRule.onNodeWithTag("cardItem_Draft Activity").assertIsDisplayed()
+    composeTestRule.onNodeWithTag("cardItem_Final Activity With Description").assertIsDisplayed()
+    composeTestRule.onNodeWithTag("cardItem_Final Activity Without Description").assertIsDisplayed()
+  }
 }

--- a/app/src/androidTest/java/com/android/voyageur/ui/trip/activities/ActivitiesScreenTest.kt
+++ b/app/src/androidTest/java/com/android/voyageur/ui/trip/activities/ActivitiesScreenTest.kt
@@ -2,6 +2,7 @@ package com.android.voyageur.ui.trip.activities
 
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.assertIsNotDisplayed
+import androidx.compose.ui.test.assertIsOn
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
@@ -186,6 +187,9 @@ class ActivitiesScreenTest {
     // Click the filter button
     composeTestRule.onNodeWithTag("filterButton").performClick()
     composeTestRule.onNodeWithTag("filterActivityAlertDialog").assertIsDisplayed()
+    composeTestRule.onNodeWithTag("typeCheckBox_WALK").assertExists()
+    composeTestRule.onNodeWithTag("confirmButtonDialog").performClick()
+    composeTestRule.onNodeWithTag("filterActivityAlertDialog").assertDoesNotExist()
   }
 
   @Test
@@ -198,6 +202,9 @@ class ActivitiesScreenTest {
     composeTestRule.onNodeWithTag("filterButton").performClick()
     // Select the "WALK" filter
     composeTestRule.onNodeWithTag("typeCheckBox_WALK").performClick()
+    composeTestRule
+        .onNodeWithTag("typeCheckBox_WALK")
+        .assertIsOn() // Verify the checkbox is checked
     composeTestRule.onNodeWithTag("confirmButtonDialog").performClick()
 
     // Verify that only WALK activities are displayed
@@ -216,6 +223,7 @@ class ActivitiesScreenTest {
     composeTestRule.onNodeWithTag("filterButton").performClick()
     // Select the "RESTAURANT" filter using the updated test tag
     composeTestRule.onNodeWithTag("typeCheckBox_RESTAURANT").performClick()
+
     composeTestRule.onNodeWithTag("confirmButtonDialog").performClick()
 
     // Verify that only RESTAURANT activities are displayed

--- a/app/src/main/java/com/android/voyageur/ui/trip/activities/Activities.kt
+++ b/app/src/main/java/com/android/voyageur/ui/trip/activities/Activities.kt
@@ -99,7 +99,7 @@ fun ActivitiesScreen(
             actions = {
               IconButton(
                   modifier = Modifier.testTag("filterButton"),
-                  onClick = { showFilterMenu = !showFilterMenu },
+                  onClick = { showFilterMenu = true },
                   content = {
                     Icon(
                         imageVector = Icons.Outlined.FilterAlt,

--- a/app/src/main/java/com/android/voyageur/ui/trip/activities/Activities.kt
+++ b/app/src/main/java/com/android/voyageur/ui/trip/activities/Activities.kt
@@ -7,8 +7,15 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.outlined.FilterAlt
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -17,10 +24,13 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import com.android.voyageur.R
 import com.android.voyageur.model.activity.Activity
+import com.android.voyageur.model.activity.ActivityType
 import com.android.voyageur.model.trip.TripsViewModel
 import com.android.voyageur.model.user.UserViewModel
 import com.android.voyageur.ui.navigation.BottomNavigationMenu
@@ -28,13 +38,26 @@ import com.android.voyageur.ui.navigation.LIST_TOP_LEVEL_DESTINATION
 import com.android.voyageur.ui.navigation.NavigationActions
 import com.google.firebase.Timestamp
 
+@OptIn(ExperimentalMaterial3Api::class)
 @SuppressLint("UnusedMaterial3ScaffoldPaddingParameter")
 @Composable
+/**
+ * The main screen for managing and displaying activities in a trip. It provides two categorized
+ * lists: drafts and final activities. The screen includes filtering by type, navigation, and and
+ * options to edit and delete activities.
+ *
+ * @param navigationActions Provides actions for navigating between screens.
+ * @param userViewModel The [UserViewModel] instance for managing user-related data.
+ * @param tripsViewModel The [TripsViewModel] instance for accessing trip and activity data.
+ */
 fun ActivitiesScreen(
     navigationActions: NavigationActions,
     userViewModel: UserViewModel,
     tripsViewModel: TripsViewModel
 ) {
+  // States for filtering
+  var selectedFilters by remember { mutableStateOf(setOf<ActivityType>()) }
+  var showFilterMenu by remember { mutableStateOf(false) }
 
   var drafts by remember {
     mutableStateOf(
@@ -60,7 +83,6 @@ fun ActivitiesScreen(
   var activityToDelete by remember { mutableStateOf<Activity?>(null) }
 
   Scaffold(
-      // TODO: Search Bar
       modifier = Modifier.testTag("activitiesScreen"),
       bottomBar = {
         BottomNavigationMenu(
@@ -68,6 +90,24 @@ fun ActivitiesScreen(
             tabList = LIST_TOP_LEVEL_DESTINATION,
             selectedItem = navigationActions.currentRoute(),
             userViewModel = userViewModel)
+      },
+      topBar = { // TODO: include the Search in TopAppBar
+        TopAppBar(
+            title = {
+              Text("Activities bar")
+            }, // This is a hardcoded string, as it should be replaced by the search bar
+            actions = {
+              IconButton(
+                  modifier = Modifier.testTag("filterButton"),
+                  onClick = { showFilterMenu = !showFilterMenu },
+                  content = {
+                    Icon(
+                        imageVector = Icons.Outlined.FilterAlt,
+                        contentDescription = stringResource(R.string.filter_activities),
+                        tint = MaterialTheme.colorScheme.primary,
+                    )
+                  })
+            })
       },
       floatingActionButton = { AddActivityButton(navigationActions) },
       content = { pd ->
@@ -78,46 +118,50 @@ fun ActivitiesScreen(
         ) {
           item {
             Text(
-                text = "Drafts",
+                text = stringResource(R.string.drafts),
                 fontSize = 24.sp,
                 fontWeight = FontWeight.Bold,
                 modifier = Modifier.padding(start = 10.dp))
           }
           drafts.forEach { activity ->
             item {
-              ActivityItem(
-                  activity,
-                  true,
-                  onClickButton = {
-                    activityToDelete = activity
-                    showDialog = true
-                  },
-                  ButtonType.DELETE,
-                  navigationActions,
-                  tripsViewModel)
-              Spacer(modifier = Modifier.height(10.dp))
+              if (selectedFilters.isEmpty() || activity.activityType in selectedFilters) {
+                ActivityItem(
+                    activity,
+                    true,
+                    onClickButton = {
+                      activityToDelete = activity
+                      showDialog = true
+                    },
+                    ButtonType.DELETE,
+                    navigationActions,
+                    tripsViewModel)
+                Spacer(modifier = Modifier.height(10.dp))
+              }
             }
           }
           item {
             Text(
-                text = "Final",
+                text = stringResource(R.string.final_activities),
                 fontSize = 24.sp,
                 fontWeight = FontWeight.Bold,
                 modifier = Modifier.padding(start = 10.dp))
           }
           final.forEach { activity ->
             item {
-              ActivityItem(
-                  activity,
-                  true,
-                  onClickButton = {
-                    activityToDelete = activity
-                    showDialog = true
-                  },
-                  ButtonType.DELETE,
-                  navigationActions,
-                  tripsViewModel)
-              Spacer(modifier = Modifier.height(10.dp))
+              if (selectedFilters.isEmpty() || activity.activityType in selectedFilters) {
+                ActivityItem(
+                    activity,
+                    true,
+                    onClickButton = {
+                      activityToDelete = activity
+                      showDialog = true
+                    },
+                    ButtonType.DELETE,
+                    navigationActions,
+                    tripsViewModel)
+                Spacer(modifier = Modifier.height(10.dp))
+              }
             }
           }
         }
@@ -132,6 +176,20 @@ fun ActivitiesScreen(
                 final = final.filter { it != activityToDelete }
                 drafts = drafts.filter { it != activityToDelete }
               })
+        }
+        // Opens the filter menu dialog
+        if (showFilterMenu) {
+          FilterDialog(
+              selectedFilters = selectedFilters,
+              onFilterChanged = { filter, isSelected ->
+                selectedFilters =
+                    if (isSelected) {
+                      selectedFilters + filter
+                    } else {
+                      selectedFilters - filter
+                    }
+              },
+              onDismiss = { showFilterMenu = false })
         }
       })
 }

--- a/app/src/main/java/com/android/voyageur/ui/trip/activities/ActivityUtils.kt
+++ b/app/src/main/java/com/android/voyageur/ui/trip/activities/ActivityUtils.kt
@@ -98,7 +98,7 @@ fun FilterDialog(
       },
       text = {
         Column(
-            modifier = Modifier.fillMaxWidth(), verticalArrangement = Arrangement.spacedBy(10.dp)) {
+            modifier = Modifier.fillMaxWidth(), verticalArrangement = Arrangement.spacedBy(3.dp)) {
               ActivityType.entries.forEach { type ->
                 // A row represents the activity type and a checkbox to validate the filter
                 Row(
@@ -106,7 +106,7 @@ fun FilterDialog(
                     verticalAlignment = Alignment.CenterVertically,
                     horizontalArrangement = Arrangement.SpaceBetween) {
                       Text(
-                          text = type.name,
+                          text = type.name.lowercase().replaceFirstChar { it.uppercase() },
                       )
                       Checkbox(
                           modifier = Modifier.testTag("typeCheckBox_${type.name}"),

--- a/app/src/main/java/com/android/voyageur/ui/trip/activities/ActivityUtils.kt
+++ b/app/src/main/java/com/android/voyageur/ui/trip/activities/ActivityUtils.kt
@@ -1,16 +1,27 @@
 package com.android.voyageur.ui.trip.activities
 
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.outlined.Add
 import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.Checkbox
 import androidx.compose.material3.FloatingActionButton
 import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import com.android.voyageur.R
 import com.android.voyageur.model.activity.Activity
+import com.android.voyageur.model.activity.ActivityType
 import com.android.voyageur.model.trip.TripsViewModel
 import com.android.voyageur.ui.navigation.NavigationActions
 import com.android.voyageur.ui.navigation.Screen
@@ -62,4 +73,53 @@ fun DeleteActivityAlertDialog(
             }
       },
       dismissButton = { TextButton(onClick = { onDismissRequest() }) { Text("Cancel") } })
+}
+/**
+ * A dialog for filtering activities by type. Displays a list of available activity types with
+ * checkboxes to toggle filters.
+ *
+ * @param selectedFilters A set of currently selected [ActivityType] filters.
+ * @param onFilterChanged Callback invoked when a filter checkbox is checked or unchecked.
+ * @param onDismiss Callback invoked to close the dialog.
+ */
+@Composable
+fun FilterDialog(
+    selectedFilters: Set<ActivityType>,
+    onFilterChanged: (ActivityType, Boolean) -> Unit,
+    onDismiss: () -> Unit
+) {
+  AlertDialog(
+      onDismissRequest = { onDismiss() },
+      modifier = Modifier.testTag("filterActivityAlertDialog"),
+      title = {
+        Text(
+            text = stringResource(R.string.filter_activity_type),
+            style = MaterialTheme.typography.titleMedium)
+      },
+      text = {
+        Column(
+            modifier = Modifier.fillMaxWidth(), verticalArrangement = Arrangement.spacedBy(10.dp)) {
+              ActivityType.entries.forEach { type ->
+                // A row represents the activity type and a checkbox to validate the filter
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    verticalAlignment = Alignment.CenterVertically,
+                    horizontalArrangement = Arrangement.SpaceBetween) {
+                      Text(
+                          text = type.name,
+                      )
+                      Checkbox(
+                          modifier = Modifier.testTag("typeCheckBox_${type.name}"),
+                          checked = selectedFilters.contains(type),
+                          onCheckedChange = { isChecked -> onFilterChanged(type, isChecked) })
+                    }
+              }
+            }
+      },
+      // Confirm button which closes the dialog
+      confirmButton = {
+        TextButton(onClick = { onDismiss() }, modifier = Modifier.testTag("confirmButtonDialog")) {
+          Text(stringResource(R.string.confirm_text))
+        }
+      })
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -3,4 +3,9 @@
     <string name="title_activity_main">MainActivity</string>
     <string name="title_activity_second">SecondActivity</string>
     <string name="default_web_client_id">386260395468-2n5ilio1go0tnvq1pddj087e0gekcmei.apps.googleusercontent.com</string>
+    <string name="confirm_text">Confirm</string>
+    <string name="filter_activities">Filter Activities</string>
+    <string name="drafts">Drafts</string>
+    <string name="final_activities">Final</string>
+    <string name="filter_activity_type">Filter activities by type</string>
 </resources>

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -4,6 +4,7 @@ accompanistPermissions = "0.35.0-alpha"
 activityKtx = "1.9.3"
 coilCompose = "2.4.0"
 fragmentKtxVersion = "1.6.1"
+materialIconsCore = "<latest_version>"
 places = "4.0.0"
 robolectricVersion = "4.10"
 sonar = "4.4.1.3373"
@@ -98,6 +99,8 @@ androidx-fragment-ktx-v161 = { module = "androidx.fragment:fragment-ktx", versio
 androidx-junit = { module = "androidx.test.ext:junit", version.ref = "junitVersion" }
 androidx-lifecycle-runtime-ktx = { module = "androidx.lifecycle:lifecycle-runtime-ktx", version.ref = "lifecycleRuntimeKtx" }
 androidx-material = { module = "androidx.compose.material:material", version.ref = "material" }
+androidx-material-icons-core = { module = "androidx.compose.material:material-icons-core", version.ref = "materialIconsCore" }
+androidx-material-icons-extended = { module = "androidx.compose.material:material-icons-extended", version.ref = "materialIconsCore" }
 androidx-material3 = { module = "androidx.compose.material3:material3", version.ref = "material3" }
 androidx-navigation-compose = { module = "androidx.navigation:navigation-compose", version.ref = "navigationCompose" }
 androidx-navigation-fragment-ktx = { module = "androidx.navigation:navigation-fragment-ktx", version.ref = "navigationCompose" }


### PR DESCRIPTION
## Summary

This PR introduces a button in the ActivitiesScreen, which when pressed, opens a dialog allowing the user to select one or more Activity types to filter the Activities displayed. When pressed confirm, dialog closes and only the filtered trips are displayed. The user is also able to de-select one or more filters previously selected.
Moreover, documentation has been updated for the ActivitiesScreen Composable.

## Changes

- **Screens/UI:** Filter button appears now in ActiviesScreen, a Dialog Composable has been implemented in ActivityUtils and is displayed in ActivitiesScreen by pressing the button.

## Checklist

Ensure all / most of these are checked before the pull request is submitted.
- [X] This PR resolves #229.
- [X] Tests have been added for new functionality.
- [X] Screenshots or UI changes have been attached (if applicable).
- [X] Documentation has been updated (if applicable).

##  Testing

- **Manual Testing:**
    - [X] Tested on emulator / physical device.
- **Unit Tests**
    - [X] Added units tests for this

##  Related Issues/Tickets

Closes #229.

## Screenshots (if applicable)


https://github.com/user-attachments/assets/b5e13ddb-d829-4700-884b-4bd028406f87



## 💡 Additional Context

The filter button has been added in a Top bar. In the same Top bar should appear the Search for Activities. For the moment, the Title of the Top bar is "Activities bar", but it should be replaced by the Search.
