### PR TITLE
Feat: generate dates with assistant

### DIFF
--- a/app/src/main/java/com/android/voyageur/model/activity/Activity.kt
+++ b/app/src/main/java/com/android/voyageur/model/activity/Activity.kt
@@ -2,7 +2,6 @@ package com.android.voyageur.model.activity
 
 import com.android.voyageur.model.location.Location
 import com.google.firebase.Timestamp
-import kotlinx.serialization.Serializable
 
 data class Activity(
     val title: String = "",

--- a/app/src/main/java/com/android/voyageur/model/activity/Activity.kt
+++ b/app/src/main/java/com/android/voyageur/model/activity/Activity.kt
@@ -1,11 +1,7 @@
 package com.android.voyageur.model.activity
 
-import android.util.Log
 import com.android.voyageur.model.location.Location
 import com.google.firebase.Timestamp
-import com.google.gson.Gson
-import com.google.gson.reflect.TypeToken
-import java.time.ZoneId
 import kotlinx.serialization.Serializable
 
 @Serializable
@@ -16,7 +12,7 @@ data class Activity(
     val startTime: Timestamp = Timestamp(0, 0),
     val endTime: Timestamp = Timestamp(0, 0),
     val estimatedPrice: Double = 0.0,
-    val activityType: ActivityType = ActivityType.WALK,
+    val activityType: ActivityType = ActivityType.OTHER,
 )
 
 enum class ActivityType {
@@ -29,25 +25,6 @@ enum class ActivityType {
   OTHER,
 }
 
-/**
- * We need a separate class for the JSON that the assistant generates since the assistant can
- * confuse the TimeStamp format. This class is used to store the data in a format that the assistant
- * can understand.
- */
-data class ActivityForAssistant(
-    val title: String = "",
-    val description: String = "",
-    val year: Int = 0,
-    val month: Int = 0,
-    val day: Int = 0,
-    val startTimeHour: Int = 0,
-    val startTimeMinute: Int = 0,
-    val endTimeHour: Int = 0,
-    val endTimeMinute: Int = 0,
-    val estimatedPrice: Double = 0.0,
-    val activityType: String = ""
-)
-
 fun Activity.hasDescription() = description != ""
 
 fun Activity.hasStartTime() = startTime != Timestamp(0, 0)
@@ -55,61 +32,3 @@ fun Activity.hasStartTime() = startTime != Timestamp(0, 0)
 fun Activity.hasEndDate() = endTime != Timestamp(0, 0)
 
 fun Activity.isDraft() = !(hasStartTime() && hasEndDate())
-
-fun extractActivitiesFromJson(jsonString: String): MutableList<Activity> {
-  val gson = Gson()
-  val activityListType = object : TypeToken<List<Activity>>() {}.type
-  return gson.fromJson(jsonString, activityListType)
-}
-
-fun extractActivitiesForAssistantFromJson(jsonString: String): MutableList<ActivityForAssistant> {
-  val gson = Gson()
-  val activityListType = object : TypeToken<List<ActivityForAssistant>>() {}.type
-  return gson.fromJson(jsonString, activityListType)
-}
-
-fun convertActivityForAssistantToActivity(activityForAssistant: ActivityForAssistant): Activity {
-  return Activity(
-      title = activityForAssistant.title,
-      description = activityForAssistant.description,
-      startTime =
-          Timestamp(
-              java.util.Date.from(
-                  java.time.LocalDateTime.of(
-                          activityForAssistant.year,
-                          activityForAssistant.month,
-                          activityForAssistant.day,
-                          activityForAssistant.startTimeHour,
-                          activityForAssistant.startTimeMinute)
-                      .atZone(ZoneId.systemDefault())
-                      .toInstant())),
-      endTime =
-          Timestamp(
-              java.util.Date.from(
-                  java.time.LocalDateTime.of(
-                          activityForAssistant.year,
-                          activityForAssistant.month,
-                          activityForAssistant.day,
-                          activityForAssistant.endTimeHour,
-                          activityForAssistant.endTimeMinute)
-                      .atZone(ZoneId.systemDefault())
-                      .toInstant())),
-      estimatedPrice = activityForAssistant.estimatedPrice,
-      activityType =
-          try {
-            ActivityType.valueOf(activityForAssistant.activityType)
-          } catch (e: IllegalArgumentException) {
-            Log.e("GeminiTest", "Activity type not found: ${activityForAssistant.activityType}")
-            ActivityType.OTHER
-          })
-}
-
-fun getYearMonthDay(timestamp: Timestamp): Triple<Int, Int, Int> {
-  val date = timestamp.toDate()
-  val calendar = java.util.Calendar.getInstance()
-  calendar.time = date
-  return Triple(
-      calendar.get(java.util.Calendar.YEAR),
-      calendar.get(java.util.Calendar.MONTH),
-      calendar.get(java.util.Calendar.DAY_OF_MONTH))
-}

--- a/app/src/main/java/com/android/voyageur/model/activity/Activity.kt
+++ b/app/src/main/java/com/android/voyageur/model/activity/Activity.kt
@@ -1,9 +1,11 @@
 package com.android.voyageur.model.activity
 
+import android.util.Log
 import com.android.voyageur.model.location.Location
 import com.google.firebase.Timestamp
 import com.google.gson.Gson
 import com.google.gson.reflect.TypeToken
+import java.time.ZoneId
 import kotlinx.serialization.Serializable
 
 @Serializable
@@ -27,6 +29,25 @@ enum class ActivityType {
   OTHER,
 }
 
+/**
+ * We need a separate class for the JSON that the assistant generates since the assistant can
+ * confuse the TimeStamp format. This class is used to store the data in a format that the assistant
+ * can understand.
+ */
+data class ActivityForAssistant(
+    val title: String = "",
+    val description: String = "",
+    val year: Int = 0,
+    val month: Int = 0,
+    val day: Int = 0,
+    val startTimeHour: Int = 0,
+    val startTimeMinute: Int = 0,
+    val endTimeHour: Int = 0,
+    val endTimeMinute: Int = 0,
+    val estimatedPrice: Double = 0.0,
+    val activityType: String = ""
+)
+
 fun Activity.hasDescription() = description != ""
 
 fun Activity.hasStartTime() = startTime != Timestamp(0, 0)
@@ -39,4 +60,56 @@ fun extractActivitiesFromJson(jsonString: String): MutableList<Activity> {
   val gson = Gson()
   val activityListType = object : TypeToken<List<Activity>>() {}.type
   return gson.fromJson(jsonString, activityListType)
+}
+
+fun extractActivitiesForAssistantFromJson(jsonString: String): MutableList<ActivityForAssistant> {
+  val gson = Gson()
+  val activityListType = object : TypeToken<List<ActivityForAssistant>>() {}.type
+  return gson.fromJson(jsonString, activityListType)
+}
+
+fun convertActivityForAssistantToActivity(activityForAssistant: ActivityForAssistant): Activity {
+  return Activity(
+      title = activityForAssistant.title,
+      description = activityForAssistant.description,
+      startTime =
+          Timestamp(
+              java.util.Date.from(
+                  java.time.LocalDateTime.of(
+                          activityForAssistant.year,
+                          activityForAssistant.month,
+                          activityForAssistant.day,
+                          activityForAssistant.startTimeHour,
+                          activityForAssistant.startTimeMinute)
+                      .atZone(ZoneId.systemDefault())
+                      .toInstant())),
+      endTime =
+          Timestamp(
+              java.util.Date.from(
+                  java.time.LocalDateTime.of(
+                          activityForAssistant.year,
+                          activityForAssistant.month,
+                          activityForAssistant.day,
+                          activityForAssistant.endTimeHour,
+                          activityForAssistant.endTimeMinute)
+                      .atZone(ZoneId.systemDefault())
+                      .toInstant())),
+      estimatedPrice = activityForAssistant.estimatedPrice,
+      activityType =
+          try {
+            ActivityType.valueOf(activityForAssistant.activityType)
+          } catch (e: IllegalArgumentException) {
+            Log.e("GeminiTest", "Activity type not found: ${activityForAssistant.activityType}")
+            ActivityType.OTHER
+          })
+}
+
+fun getYearMonthDay(timestamp: Timestamp): Triple<Int, Int, Int> {
+  val date = timestamp.toDate()
+  val calendar = java.util.Calendar.getInstance()
+  calendar.time = date
+  return Triple(
+      calendar.get(java.util.Calendar.YEAR),
+      calendar.get(java.util.Calendar.MONTH),
+      calendar.get(java.util.Calendar.DAY_OF_MONTH))
 }

--- a/app/src/main/java/com/android/voyageur/model/activity/Activity.kt
+++ b/app/src/main/java/com/android/voyageur/model/activity/Activity.kt
@@ -4,7 +4,6 @@ import com.android.voyageur.model.location.Location
 import com.google.firebase.Timestamp
 import kotlinx.serialization.Serializable
 
-@Serializable
 data class Activity(
     val title: String = "",
     val description: String = "",

--- a/app/src/main/java/com/android/voyageur/model/assistant/ActivityFromAssistant.kt
+++ b/app/src/main/java/com/android/voyageur/model/assistant/ActivityFromAssistant.kt
@@ -1,0 +1,94 @@
+package com.android.voyageur.model.assistant
+
+import android.util.Log
+import com.android.voyageur.model.activity.Activity
+import com.android.voyageur.model.activity.ActivityType
+import com.google.firebase.Timestamp
+import com.google.gson.Gson
+import com.google.gson.reflect.TypeToken
+import java.time.ZoneId
+
+/**
+ * We need a separate class for the JSON that the assistant generates since the assistant can
+ * confuse the TimeStamp format (it's less error prone to generate dates and times in a readable .
+ * This class is used to store the data in a format that the assistant can understand.
+ */
+data class ActivityFromAssistant(
+    val title: String = "",
+    val description: String = "",
+    val year: Int = 0,
+    val month: Int = 0,
+    val day: Int = 0,
+    val startTimeHour: Int = 0,
+    val startTimeMinute: Int = 0,
+    val endTimeHour: Int = 0,
+    val endTimeMinute: Int = 0,
+    val estimatedPrice: Double = 0.0,
+    val activityType: String = "" // it's a string because the generativeModel can't generate enums
+)
+
+/**
+ * Extracts activities that the assistant generated from a JSON string.
+ *
+ * @param jsonString the JSON string
+ * @return the list of activities
+ */
+fun extractActivitiesFromAssistantFromJson(jsonString: String): MutableList<ActivityFromAssistant> {
+  val gson = Gson()
+  val activityListType = object : TypeToken<List<ActivityFromAssistant>>() {}.type
+  return gson.fromJson(jsonString, activityListType)
+}
+
+/**
+ * Converts an activity from the assistant to an activity that can be used in the app.
+ *
+ * @param activityFromAssistant the activity from the assistant
+ * @return the activity that can be used in the app
+ */
+fun convertActivityFromAssistantToActivity(activityFromAssistant: ActivityFromAssistant): Activity {
+  return Activity(
+      title = activityFromAssistant.title,
+      description = activityFromAssistant.description,
+      startTime =
+          Timestamp(
+              java.util.Date.from(
+                  java.time.LocalDateTime.of(
+                          activityFromAssistant.year,
+                          activityFromAssistant.month,
+                          activityFromAssistant.day,
+                          activityFromAssistant.startTimeHour,
+                          activityFromAssistant.startTimeMinute)
+                      .atZone(ZoneId.systemDefault())
+                      .toInstant())),
+      endTime =
+          Timestamp(
+              java.util.Date.from(
+                  java.time.LocalDateTime.of(
+                          activityFromAssistant.year,
+                          activityFromAssistant.month,
+                          activityFromAssistant.day,
+                          activityFromAssistant.endTimeHour,
+                          activityFromAssistant.endTimeMinute)
+                      .atZone(ZoneId.systemDefault())
+                      .toInstant())),
+      estimatedPrice = activityFromAssistant.estimatedPrice,
+      activityType =
+          try {
+            ActivityType.valueOf(activityFromAssistant.activityType)
+          } catch (e: IllegalArgumentException) {
+            Log.e(
+                "ActivityFromAssistant",
+                "Activity type not found: ${activityFromAssistant.activityType}")
+            ActivityType.OTHER
+          })
+}
+
+fun getYearMonthDay(timestamp: Timestamp): Triple<Int, Int, Int> {
+  val date = timestamp.toDate()
+  val calendar = java.util.Calendar.getInstance()
+  calendar.time = date
+  return Triple(
+      calendar.get(java.util.Calendar.YEAR),
+      calendar.get(java.util.Calendar.MONTH),
+      calendar.get(java.util.Calendar.DAY_OF_MONTH))
+}

--- a/app/src/main/java/com/android/voyageur/model/assistant/ActivityFromAssistant.kt
+++ b/app/src/main/java/com/android/voyageur/model/assistant/ActivityFromAssistant.kt
@@ -5,6 +5,7 @@ import com.android.voyageur.model.activity.Activity
 import com.android.voyageur.model.activity.ActivityType
 import com.google.firebase.Timestamp
 import com.google.gson.Gson
+import com.google.gson.JsonSyntaxException
 import com.google.gson.reflect.TypeToken
 import java.time.ZoneId
 
@@ -36,7 +37,15 @@ data class ActivityFromAssistant(
 fun extractActivitiesFromAssistantFromJson(jsonString: String): MutableList<ActivityFromAssistant> {
   val gson = Gson()
   val activityListType = object : TypeToken<List<ActivityFromAssistant>>() {}.type
-  return gson.fromJson(jsonString, activityListType)
+    return try {
+        gson.fromJson(jsonString, activityListType)
+    } catch (e: JsonSyntaxException) {
+        Log.e("ActivityFromAssistant", "Error parsing JSON: ${e.message}")
+        mutableListOf() // Return an empty list if parsing fails
+    } catch (e: Exception) {
+        Log.e("ActivityFromAssistant", "Unexpected error: ${e.message}")
+        mutableListOf() // Handle any other unexpected exceptions
+    }
 }
 
 /**

--- a/app/src/main/java/com/android/voyageur/model/assistant/ActivityFromAssistant.kt
+++ b/app/src/main/java/com/android/voyageur/model/assistant/ActivityFromAssistant.kt
@@ -37,15 +37,15 @@ data class ActivityFromAssistant(
 fun extractActivitiesFromAssistantFromJson(jsonString: String): MutableList<ActivityFromAssistant> {
   val gson = Gson()
   val activityListType = object : TypeToken<List<ActivityFromAssistant>>() {}.type
-    return try {
-        gson.fromJson(jsonString, activityListType)
-    } catch (e: JsonSyntaxException) {
-        Log.e("ActivityFromAssistant", "Error parsing JSON: ${e.message}")
-        mutableListOf() // Return an empty list if parsing fails
-    } catch (e: Exception) {
-        Log.e("ActivityFromAssistant", "Unexpected error: ${e.message}")
-        mutableListOf() // Handle any other unexpected exceptions
-    }
+  return try {
+    gson.fromJson(jsonString, activityListType)
+  } catch (e: JsonSyntaxException) {
+    Log.e("ActivityFromAssistant", "Error parsing JSON: ${e.message}")
+    mutableListOf() // Return an empty list if parsing fails
+  } catch (e: Exception) {
+    Log.e("ActivityFromAssistant", "Unexpected error: ${e.message}")
+    mutableListOf() // Handle any other unexpected exceptions
+  }
 }
 
 /**

--- a/app/src/main/java/com/android/voyageur/model/assistant/AssistantUtils.kt
+++ b/app/src/main/java/com/android/voyageur/model/assistant/AssistantUtils.kt
@@ -1,0 +1,110 @@
+package com.android.voyageur.model.assistant
+
+import com.android.voyageur.BuildConfig
+import com.android.voyageur.model.activity.getYearMonthDay
+import com.android.voyageur.model.trip.Trip
+import com.google.ai.client.generativeai.GenerativeModel
+import com.google.ai.client.generativeai.type.FunctionType
+import com.google.ai.client.generativeai.type.Schema
+import com.google.ai.client.generativeai.type.generationConfig
+
+val generativeModel =
+    GenerativeModel(
+        modelName = "gemini-1.5-flash",
+        apiKey = BuildConfig.GEMINI_API_KEY,
+        generationConfig =
+            generationConfig {
+              responseMimeType = "application/json"
+              responseSchema =
+                  Schema(
+                      name = "activities",
+                      description = "List of activities",
+                      type = FunctionType.ARRAY,
+                      items =
+                          Schema(
+                              name = "activity",
+                              description = "An activity",
+                              type = FunctionType.OBJECT,
+                              properties =
+                                  mapOf(
+                                      "title" to
+                                          Schema(
+                                              name = "title",
+                                              description = "Title of the activity",
+                                              type = FunctionType.STRING),
+                                      "description" to
+                                          Schema(
+                                              name = "description",
+                                              description = "Description of the activity",
+                                              type = FunctionType.STRING),
+                                      "year" to
+                                          Schema(
+                                              name = "year",
+                                              description = "Year of the activity",
+                                              type = FunctionType.INTEGER),
+                                      "month" to
+                                          Schema(
+                                              name = "month",
+                                              description = "Month of the activity",
+                                              type = FunctionType.INTEGER),
+                                      "day" to
+                                          Schema(
+                                              name = "day",
+                                              description = "Day of the activity",
+                                              type = FunctionType.INTEGER),
+                                      "startTimeHour" to
+                                          Schema(
+                                              name = "startTimeHour",
+                                              description = "Start time hour of the activity",
+                                              type = FunctionType.INTEGER),
+                                      "startTimeMinute" to
+                                          Schema(
+                                              name = "startTimeMinute",
+                                              description = "Start time minute of the activity",
+                                              type = FunctionType.INTEGER),
+                                      "endTimeHour" to
+                                          Schema(
+                                              name = "endTimeHour",
+                                              description = "End time hour of the activity",
+                                              type = FunctionType.INTEGER),
+                                      "endTimeMinute" to
+                                          Schema(
+                                              name = "endTimeMinute",
+                                              description = "End time minute of the activity",
+                                              type = FunctionType.INTEGER),
+                                      "estimatedPrice" to
+                                          Schema(
+                                              name = "estimatedPrice",
+                                              description = "Estimated price of the activity",
+                                              type = FunctionType.NUMBER),
+                                      "activityType" to
+                                          Schema(
+                                              name = "activityType",
+                                              description =
+                                                  "Type of the activity. can only be WALK, RESTAURANT, MUSEUM, SPORTS, OUTDOORS, TRANSPORT, OTHER",
+                                              type = FunctionType.STRING),
+                                  ),
+                              required =
+                                  listOf(
+                                      "title",
+                                      "description",
+                                      "year",
+                                      "month",
+                                      "day",
+                                      "startTimeHour",
+                                      "startTimeMinute",
+                                      "endTimeHour",
+                                      "endTimeMinute",
+                                      "estimatedPrice",
+                                      "activityType")))
+            })
+
+fun generatePrompt(trip: Trip, userPrompt: String) : String {
+    val startDate = getYearMonthDay(trip.startDate)
+    val endDate = getYearMonthDay(trip.endDate)
+    val datePrompt =
+        "between the start date year ${startDate.first} month ${startDate.second + 1} day ${startDate.third} and the end date year ${endDate.first} month ${endDate.second + 1} day ${endDate.third}"
+   val prompt = "Make a full schedule by listing activities including separate activities for each separate activity, e.g. eating, transport, basically i want suggestions for every day spent on a trip called ${trip.name} that takes place $datePrompt" +
+                    " and with the following prompt: $userPrompt. You should recommend multiple activities for each day."
+      return prompt
+}

--- a/app/src/main/java/com/android/voyageur/model/trip/TripsViewModel.kt
+++ b/app/src/main/java/com/android/voyageur/model/trip/TripsViewModel.kt
@@ -185,7 +185,6 @@ open class TripsViewModel(
         val response =
             generativeModel.generateContent(
                 generatePrompt(trip, userPrompt, provideFinalActivities))
-        Log.d("GeminiTest", "response: ${response.text}")
         response.text?.let { outputContent -> _uiState.value = UiState.Success(outputContent) }
       } catch (e: Exception) {
         _uiState.value = UiState.Error(e.localizedMessage ?: "unknown error")

--- a/app/src/main/java/com/android/voyageur/model/trip/TripsViewModel.kt
+++ b/app/src/main/java/com/android/voyageur/model/trip/TripsViewModel.kt
@@ -6,7 +6,6 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.viewModelScope
 import com.android.voyageur.model.activity.Activity
-import com.android.voyageur.model.activity.getYearMonthDay
 import com.android.voyageur.model.assistant.generatePrompt
 import com.android.voyageur.model.assistant.generativeModel
 import com.google.firebase.Firebase
@@ -169,12 +168,23 @@ open class TripsViewModel(
   // AI assistant
   // ****************************************************************************************************
 
-  fun sendActivitiesPrompt(trip: Trip, userPrompt: String) {
+  /**
+   * Sends a prompt to the AI assistant to generate activities for a trip. The result changes the UI
+   * state.
+   *
+   * @param trip the trip
+   * @param userPrompt the prompt that the user provides in the app
+   * @param provideFinalActivities whether to provide final activities with date and time or just
+   *   draft activities.
+   */
+  open fun sendActivitiesPrompt(trip: Trip, userPrompt: String, provideFinalActivities: Boolean) {
     _uiState.value = UiState.Loading
 
     viewModelScope.launch(Dispatchers.IO) {
       try {
-        val response = generativeModel.generateContent(generatePrompt(trip, userPrompt))
+        val response =
+            generativeModel.generateContent(
+                generatePrompt(trip, userPrompt, provideFinalActivities))
         Log.d("GeminiTest", "response: ${response.text}")
         response.text?.let { outputContent -> _uiState.value = UiState.Success(outputContent) }
       } catch (e: Exception) {
@@ -183,6 +193,7 @@ open class TripsViewModel(
     }
   }
 
+  /** Sets the initial UI state to [UiState.Initial]. */
   open fun setInitialUiState() {
     _uiState.value = UiState.Initial
   }

--- a/app/src/main/java/com/android/voyageur/ui/trip/assistant/Assistant.kt
+++ b/app/src/main/java/com/android/voyageur/ui/trip/assistant/Assistant.kt
@@ -16,10 +16,16 @@ import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Settings
+import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Button
 import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextField
 import androidx.compose.runtime.Composable
@@ -37,8 +43,8 @@ import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import com.android.voyageur.model.activity.Activity
-import com.android.voyageur.model.activity.convertActivityForAssistantToActivity
-import com.android.voyageur.model.activity.extractActivitiesForAssistantFromJson
+import com.android.voyageur.model.assistant.convertActivityFromAssistantToActivity
+import com.android.voyageur.model.assistant.extractActivitiesFromAssistantFromJson
 import com.android.voyageur.model.trip.TripsViewModel
 import com.android.voyageur.model.trip.UiState
 import com.android.voyageur.ui.navigation.NavigationActions
@@ -46,16 +52,19 @@ import com.android.voyageur.ui.navigation.Screen
 import com.android.voyageur.ui.trip.activities.ActivityItem
 import com.android.voyageur.ui.trip.activities.ButtonType
 import com.android.voyageur.ui.trip.schedule.TopBarWithImageAndText
+import com.google.firebase.Timestamp
 
-@SuppressLint("StateFlowValueCalledInComposition")
+@SuppressLint("StateFlowValueCalledInComposition", "UnrememberedMutableState")
 @Composable
 fun AssistantScreen(tripsViewModel: TripsViewModel, navigationActions: NavigationActions) {
   var result by rememberSaveable { mutableStateOf("placeholderResult") }
   val uiState by tripsViewModel.uiState.collectAsState()
   var prompt by rememberSaveable { mutableStateOf("") }
   var activities by remember { mutableStateOf(emptyList<Activity>()) }
-
   val keyboardController = LocalSoftwareKeyboardController.current
+
+  var showSettingsDialog by rememberSaveable { mutableStateOf(false) }
+  var provideFinalActivities by rememberSaveable { mutableStateOf(false) }
 
   val trip = tripsViewModel.selectedTrip.value
   if (trip == null) {
@@ -84,15 +93,23 @@ fun AssistantScreen(tripsViewModel: TripsViewModel, navigationActions: Navigatio
                         onDone = {
                           keyboardController?.hide()
                           if (uiState !is UiState.Loading) {
-                            tripsViewModel.sendActivitiesPrompt(trip, prompt)
+                            tripsViewModel.sendActivitiesPrompt(
+                                trip, prompt, provideFinalActivities)
                           }
                         }),
                 singleLine = true)
             Button(
-                onClick = { tripsViewModel.sendActivitiesPrompt(trip, prompt) },
+                onClick = {
+                  tripsViewModel.sendActivitiesPrompt(trip, prompt, provideFinalActivities)
+                },
                 enabled = uiState !is UiState.Loading, // Disable the button during loading
                 modifier = Modifier.testTag("AIRequestButton").align(Alignment.CenterVertically)) {
                   Text(text = "go")
+                }
+            IconButton(
+                onClick = { showSettingsDialog = true },
+                modifier = Modifier.testTag("settingsButton")) {
+                  Icon(imageVector = Icons.Default.Settings, contentDescription = "Settings")
                 }
           }
 
@@ -116,8 +133,16 @@ fun AssistantScreen(tripsViewModel: TripsViewModel, navigationActions: Navigatio
                           .verticalScroll(scrollState))
             } else if (uiState is UiState.Success) {
               result = (uiState as UiState.Success).outputText
-              val activitiesForAssistant = extractActivitiesForAssistantFromJson(result)
-              activities = activitiesForAssistant.map { convertActivityForAssistantToActivity(it) }
+              val activitiesFromAssistant = extractActivitiesFromAssistantFromJson(result)
+              activities =
+                  activitiesFromAssistant.map {
+                    val activity = convertActivityFromAssistantToActivity(it)
+                    if (!provideFinalActivities) {
+                      activity.copy(startTime = Timestamp(0, 0), endTime = Timestamp(0, 0))
+                    } else {
+                      activity
+                    }
+                  }
               LazyColumn(
                   modifier =
                       Modifier.padding(pd)
@@ -144,6 +169,58 @@ fun AssistantScreen(tripsViewModel: TripsViewModel, navigationActions: Navigatio
               }
             }
           }
+        }
+        if (showSettingsDialog) {
+          SettingsDialog(
+              onDismiss = { showSettingsDialog = false },
+              provideDraftActivities = provideFinalActivities,
+              onProvideFinalActivitiesChanged = { provideFinalActivities = it })
+        }
+      })
+}
+
+/**
+ * Dialog for the settings
+ *
+ * @param onDismiss the function to dismiss the dialog
+ * @param provideDraftActivities whether to provide final activities with date and time or just
+ *   draft activities
+ * @param onProvideFinalActivitiesChanged the function to change the setting
+ */
+@Composable
+fun SettingsDialog(
+    onDismiss: () -> Unit,
+    provideDraftActivities: Boolean,
+    onProvideFinalActivitiesChanged: (Boolean) -> Unit,
+) {
+  AlertDialog(
+      modifier = Modifier.testTag("settingsDialog"),
+      onDismissRequest = onDismiss,
+      title = { Text(text = "Settings") },
+      text = {
+        Column {
+          Row(verticalAlignment = Alignment.CenterVertically) {
+            Text(
+                "Remember to click on the 'go' button after changing the settings",
+                modifier = Modifier.weight(1f),
+                style = MaterialTheme.typography.bodyLarge)
+          }
+          Spacer(modifier = Modifier.height(16.dp)) // Add a spacer for some vertical space
+
+          Row(verticalAlignment = Alignment.CenterVertically) {
+            Text(
+                "Provide final activities with date and time (recommended for trips shorter than a week)",
+                modifier = Modifier.weight(1f))
+            Switch(
+                checked = provideDraftActivities,
+                onCheckedChange = onProvideFinalActivitiesChanged,
+                modifier = Modifier.testTag("provideFinalActivitiesSwitch"))
+          }
+        }
+      },
+      confirmButton = {
+        Button(onClick = onDismiss, modifier = Modifier.testTag("closeDialogButton")) {
+          Text("Close")
         }
       })
 }

--- a/app/src/main/java/com/android/voyageur/ui/trip/assistant/Assistant.kt
+++ b/app/src/main/java/com/android/voyageur/ui/trip/assistant/Assistant.kt
@@ -37,7 +37,8 @@ import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import com.android.voyageur.model.activity.Activity
-import com.android.voyageur.model.activity.extractActivitiesFromJson
+import com.android.voyageur.model.activity.convertActivityForAssistantToActivity
+import com.android.voyageur.model.activity.extractActivitiesForAssistantFromJson
 import com.android.voyageur.model.trip.TripsViewModel
 import com.android.voyageur.model.trip.UiState
 import com.android.voyageur.ui.navigation.NavigationActions
@@ -115,7 +116,8 @@ fun AssistantScreen(tripsViewModel: TripsViewModel, navigationActions: Navigatio
                           .verticalScroll(scrollState))
             } else if (uiState is UiState.Success) {
               result = (uiState as UiState.Success).outputText
-              activities = extractActivitiesFromJson(result)
+              val activitiesForAssistant = extractActivitiesForAssistantFromJson(result)
+              activities = activitiesForAssistant.map { convertActivityForAssistantToActivity(it) }
               LazyColumn(
                   modifier =
                       Modifier.padding(pd)

--- a/app/src/test/java/com/android/voyageur/model/activity/ActivityFromAssistantTest.kt
+++ b/app/src/test/java/com/android/voyageur/model/activity/ActivityFromAssistantTest.kt
@@ -1,0 +1,115 @@
+package com.android.voyageur.model.activity
+
+import com.android.voyageur.model.assistant.ActivityFromAssistant
+import com.android.voyageur.model.assistant.convertActivityFromAssistantToActivity
+import com.android.voyageur.model.assistant.extractActivitiesFromAssistantFromJson
+import com.android.voyageur.model.assistant.getYearMonthDay
+import com.google.firebase.Timestamp
+import java.util.Calendar
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class ActivityFromAssistantTest {
+
+  @Test
+  fun testExtractActivitiesFromAssistantFromJson() {
+    val jsonString =
+        """
+            [
+                {
+                    "title": "Hiking",
+                    "description": "A scenic mountain hike.",
+                    "year": 2024,
+                    "month": 5,
+                    "day": 20,
+                    "startTimeHour": 9,
+                    "startTimeMinute": 30,
+                    "endTimeHour": 15,
+                    "endTimeMinute": 0,
+                    "estimatedPrice": 50.0,
+                    "activityType": "OUTDOORS"
+                },
+                {
+                    "title": "Dinner",
+                    "description": "Dinner at a fancy restaurant.",
+                    "year": 2024,
+                    "month": 5,
+                    "day": 20,
+                    "startTimeHour": 19,
+                    "startTimeMinute": 0,
+                    "endTimeHour": 21,
+                    "endTimeMinute": 30,
+                    "estimatedPrice": 150.0,
+                    "activityType": "WALK"
+                }
+            ]
+        """
+
+    val activities = extractActivitiesFromAssistantFromJson(jsonString)
+    assertEquals(2, activities.size)
+
+    val firstActivity = activities[0]
+    assertEquals("Hiking", firstActivity.title)
+    assertEquals(2024, firstActivity.year)
+    assertEquals(5, firstActivity.month)
+    assertEquals(50.0, firstActivity.estimatedPrice, 0.0)
+  }
+
+  @Test
+  fun testConvertActivityFromAssistantToActivity() {
+    val assistantActivity =
+        ActivityFromAssistant(
+            title = "Cycling",
+            description = "Cycling around the city.",
+            year = 2024,
+            month = 6,
+            day = 15,
+            startTimeHour = 10,
+            startTimeMinute = 0,
+            endTimeHour = 12,
+            endTimeMinute = 0,
+            estimatedPrice = 20.0,
+            activityType = "OUTDOORS")
+
+    val convertedActivity = convertActivityFromAssistantToActivity(assistantActivity)
+
+    assertEquals("Cycling", convertedActivity.title)
+    assertEquals("Cycling around the city.", convertedActivity.description)
+    assertEquals(ActivityType.OUTDOORS, convertedActivity.activityType)
+
+    val startCalendar = Calendar.getInstance().apply { time = convertedActivity.startTime.toDate() }
+    assertEquals(2024, startCalendar.get(Calendar.YEAR))
+    assertEquals(6, startCalendar.get(Calendar.MONTH) + 1) // Months are 0-indexed
+    assertEquals(15, startCalendar.get(Calendar.DAY_OF_MONTH))
+  }
+
+  @Test
+  fun testInvalidActivityType() {
+    val assistantActivity =
+        ActivityFromAssistant(
+            title = "Mystery Event",
+            description = "An unknown activity type.",
+            year = 2024,
+            month = 12,
+            day = 25,
+            startTimeHour = 14,
+            startTimeMinute = 0,
+            endTimeHour = 16,
+            endTimeMinute = 0,
+            estimatedPrice = 100.0,
+            activityType = "UNKNOWN_TYPE")
+
+    val convertedActivity = convertActivityFromAssistantToActivity(assistantActivity)
+    assertEquals(ActivityType.OTHER, convertedActivity.activityType)
+  }
+
+  @Test
+  fun testGetYearMonthDay() {
+    val timestamp = Timestamp(1735689600, 0) // January 1, 2025
+    val (year, month, day) = getYearMonthDay(timestamp)
+
+    assertEquals(2025, year)
+    assertEquals(0, month) // January
+    assertEquals(1, day)
+  }
+}

--- a/app/src/test/java/com/android/voyageur/model/assistant/AssistantUtilsTest.kt
+++ b/app/src/test/java/com/android/voyageur/model/assistant/AssistantUtilsTest.kt
@@ -1,0 +1,58 @@
+package com.android.voyageur.model.assistant
+
+import com.android.voyageur.model.trip.Trip
+import com.google.firebase.Timestamp
+import java.util.Calendar
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class GeneratePromptTest {
+
+  @Test
+  fun testGeneratePromptForFinalActivities() {
+    val trip =
+        Trip(
+            name = "Summer Adventure",
+            startDate = createTimestamp(2024, 7, 1),
+            endDate = createTimestamp(2024, 7, 7))
+
+    val userPrompt = "Explore beaches and try local cuisine"
+    val provideFinalActivities = true
+
+    val prompt = generatePrompt(trip, userPrompt, provideFinalActivities)
+    println(prompt)
+
+    assertTrue(prompt.contains("Summer Adventure"))
+    assertTrue(prompt.contains("start date year 2024 month 7 day 1"))
+    assertTrue(prompt.contains("end date year 2024 month 7 day 7"))
+    assertTrue(prompt.contains("Make a full schedule by listing activities"))
+    assertTrue(prompt.contains("Explore beaches and try local cuisine"))
+  }
+
+  @Test
+  fun testGeneratePromptForDraftActivities() {
+    val trip =
+        Trip(
+            name = "Winter Wonderland",
+            startDate = createTimestamp(2024, 12, 20),
+            endDate = createTimestamp(2024, 12, 27))
+
+    val userPrompt = "Enjoy snowy landscapes and Christmas markets"
+    val provideFinalActivities = false
+
+    val prompt = generatePrompt(trip, userPrompt, provideFinalActivities)
+
+    assertTrue(prompt.contains("Winter Wonderland"))
+    assertTrue(prompt.contains("start date year 2024 month 12 day 20"))
+    assertTrue(prompt.contains("end date year 2024 month 12 day 27"))
+    assertTrue(prompt.contains("List a lot of popular specific activities"))
+    assertTrue(prompt.contains("Enjoy snowy landscapes and Christmas markets"))
+  }
+
+  // Helper function to create a Timestamp from year, month, and day
+  private fun createTimestamp(year: Int, month: Int, day: Int): Timestamp {
+    val calendar = Calendar.getInstance()
+    calendar.set(year, month - 1, day, 0, 0, 0) // Month is 0-indexed
+    return Timestamp(calendar.time)
+  }
+}


### PR DESCRIPTION
## Summary

This feature focuses on the AI assistant use. Now users can get recommended activities with a date and time attached as well, more like a schedule. To activate this, the user must click on the settings button, and toggle on the switch responsible for this. 

## Changes

- **Models:** Added a new data class `ActivityFromAssistant`. The difference between this class and the Activity class is that it has the explicit integers for year, month, day, hour, minutes instead of a timestamp, because it is more difficult for the AI assistant to make mistakes this way. This class is used to generate the Activities.
- **Screens/UI:** Now the `AssistantScreen` has a settings button where users can toggle on or off whether they want to receive draft or final activities.

## Checklist

Ensure all / most of these are checked before the pull request is submitted.
- [x] This PR resolves #231 
- [x] Tests have been added for new functionality.
- [x] Screenshots or UI changes have been attached (if applicable).
- [x] Documentation has been updated (if applicable).

##  Testing

- **Manual Testing:**
    - [x] Tested on emulator / physical device.
- **Unit Tests**
    - [x] Added units tests for this

## Screenshots (if applicable)


[activitiesWithDate.webm](https://github.com/user-attachments/assets/6bce1815-643b-4989-949b-9058ddd43cd0)
