### PR TITLE
feat: take interests into account when recommending activities with the assistant

### DIFF
--- a/app/src/androidTest/java/com/android/voyageur/ui/trip/assistant/AssistantTest.kt
+++ b/app/src/androidTest/java/com/android/voyageur/ui/trip/assistant/AssistantTest.kt
@@ -196,12 +196,7 @@ class AssistantScreenTest {
     // check the call to sendActivitiesPrompt happens with provideFinalActivities = true
     composeTestRule.onNodeWithTag("AIRequestButton").performClick()
     verify(mockTripsViewModel)
-        .sendActivitiesPrompt(
-            sampleTrip,
-            "",
-            listOf("hiking", "cycling"),
-            provideFinalActivities = true,
-            useInterests = false)
+        .sendActivitiesPrompt(sampleTrip, "", emptyList(), provideFinalActivities = true)
   }
 
   @Test
@@ -221,10 +216,6 @@ class AssistantScreenTest {
     composeTestRule.onNodeWithTag("AIRequestButton").performClick()
     verify(mockTripsViewModel)
         .sendActivitiesPrompt(
-            sampleTrip,
-            "",
-            listOf("hiking", "cycling"),
-            provideFinalActivities = false,
-            useInterests = true)
+            sampleTrip, "", listOf("hiking", "cycling"), provideFinalActivities = false)
   }
 }

--- a/app/src/main/java/com/android/voyageur/App.kt
+++ b/app/src/main/java/com/android/voyageur/App.kt
@@ -92,7 +92,9 @@ fun VoyageurApp(placesClient: PlacesClient) {
       composable(Screen.ACTIVITIES_FOR_ONE_DAY) {
         ActivitiesForOneDayScreen(tripsViewModel, navigationActions)
       }
-      composable(Screen.ASSISTANT) { AssistantScreen(tripsViewModel, navigationActions) }
+      composable(Screen.ASSISTANT) {
+        AssistantScreen(tripsViewModel, navigationActions, userViewModel)
+      }
       composable(Screen.EDIT_ACTIVITY) {
         EditActivityScreen(navigationActions, tripsViewModel, placesViewModel)
       }

--- a/app/src/main/java/com/android/voyageur/model/assistant/AssistantUtils.kt
+++ b/app/src/main/java/com/android/voyageur/model/assistant/AssistantUtils.kt
@@ -123,7 +123,6 @@ fun generatePrompt(
     userPrompt: String,
     interests: List<String>,
     provideFinalActivities: Boolean,
-    useInterests: Boolean
 ): String {
   val startDate = getYearMonthDay(trip.startDate)
   val endDate = getYearMonthDay(trip.endDate)
@@ -134,7 +133,7 @@ fun generatePrompt(
             """
           .trimIndent()
   val interestsPrompt =
-      if (useInterests && interests.isNotEmpty()) {
+      if (interests.isNotEmpty()) {
         "The activities should focus on the following interests (if applicable): ${interests.joinToString(", ")}."
       } else {
         ""

--- a/app/src/main/java/com/android/voyageur/model/assistant/AssistantUtils.kt
+++ b/app/src/main/java/com/android/voyageur/model/assistant/AssistantUtils.kt
@@ -115,7 +115,6 @@ val generativeModel =
  * @param provideFinalActivities whether to provide final activities with date and time or just
  *   draft activities. In the case of draft activities, the prompt is a bit different to avoid
  *   recommending a lunch for each day more or less the same.
- *     @param useInterests whether to use the interests in the prompt
  * @return the prompt to send to use with the generative model
  */
 fun generatePrompt(

--- a/app/src/main/java/com/android/voyageur/model/assistant/AssistantUtils.kt
+++ b/app/src/main/java/com/android/voyageur/model/assistant/AssistantUtils.kt
@@ -111,12 +111,20 @@ val generativeModel =
  *
  * @param trip the trip
  * @param userPrompt the prompt that the user provides in the app
+ * @param interests the interests to focus on
  * @param provideFinalActivities whether to provide final activities with date and time or just
  *   draft activities. In the case of draft activities, the prompt is a bit different to avoid
  *   recommending a lunch for each day more or less the same.
+ *     @param useInterests whether to use the interests in the prompt
  * @return the prompt to send to use with the generative model
  */
-fun generatePrompt(trip: Trip, userPrompt: String, provideFinalActivities: Boolean): String {
+fun generatePrompt(
+    trip: Trip,
+    userPrompt: String,
+    interests: List<String>,
+    provideFinalActivities: Boolean,
+    useInterests: Boolean
+): String {
   val startDate = getYearMonthDay(trip.startDate)
   val endDate = getYearMonthDay(trip.endDate)
   val datePrompt =
@@ -125,20 +133,27 @@ fun generatePrompt(trip: Trip, userPrompt: String, provideFinalActivities: Boole
           and the end date year ${endDate.first} month ${endDate.second + 1} day ${endDate.third}
             """
           .trimIndent()
+  val interestsPrompt =
+      if (useInterests && interests.isNotEmpty()) {
+        "The activities should focus on the following interests (if applicable): ${interests.joinToString(", ")}."
+      } else {
+        ""
+      }
   val prompt =
       if (provideFinalActivities) {
         """
     Make a full schedule by listing activities, including separate activities for eating, transport, etc.
-    The trip, called ${trip.name}, takes place $datePrompt with the following prompt: $userPrompt.
+    The trip, called ${trip.name}, takes place $datePrompt with the following prompt: $userPrompt. $interestsPrompt
     Recommend multiple activities for each day.
     """
             .trimIndent()
       } else {
         """
     List a lot of popular specific activities to do on a trip called ${trip.name}.
-    The trip takes place $datePrompt with the following prompt: $userPrompt.
+    The trip takes place $datePrompt with the following prompt: $userPrompt. $interestsPrompt
     """
             .trimIndent()
       }
+
   return prompt
 }

--- a/app/src/main/java/com/android/voyageur/model/trip/TripsViewModel.kt
+++ b/app/src/main/java/com/android/voyageur/model/trip/TripsViewModel.kt
@@ -191,14 +191,20 @@ open class TripsViewModel(
    * @param provideFinalActivities whether to provide final activities with date and time or just
    *   draft activities.
    */
-  open fun sendActivitiesPrompt(trip: Trip, userPrompt: String, provideFinalActivities: Boolean) {
+  open fun sendActivitiesPrompt(
+      trip: Trip,
+      userPrompt: String,
+      interests: List<String>,
+      provideFinalActivities: Boolean,
+      useInterests: Boolean
+  ) {
     _uiState.value = UiState.Loading
 
     viewModelScope.launch(Dispatchers.IO) {
       try {
         val response =
             generativeModel.generateContent(
-                generatePrompt(trip, userPrompt, provideFinalActivities))
+                generatePrompt(trip, userPrompt, interests, provideFinalActivities, useInterests))
         response.text?.let { outputContent -> _uiState.value = UiState.Success(outputContent) }
       } catch (e: Exception) {
         _uiState.value = UiState.Error(e.localizedMessage ?: "unknown error")

--- a/app/src/main/java/com/android/voyageur/model/trip/TripsViewModel.kt
+++ b/app/src/main/java/com/android/voyageur/model/trip/TripsViewModel.kt
@@ -194,9 +194,8 @@ open class TripsViewModel(
   open fun sendActivitiesPrompt(
       trip: Trip,
       userPrompt: String,
-      interests: List<String>,
+      interests: List<String> = emptyList(),
       provideFinalActivities: Boolean,
-      useInterests: Boolean
   ) {
     _uiState.value = UiState.Loading
 
@@ -204,7 +203,7 @@ open class TripsViewModel(
       try {
         val response =
             generativeModel.generateContent(
-                generatePrompt(trip, userPrompt, interests, provideFinalActivities, useInterests))
+                generatePrompt(trip, userPrompt, interests, provideFinalActivities))
         response.text?.let { outputContent -> _uiState.value = UiState.Success(outputContent) }
       } catch (e: Exception) {
         _uiState.value = UiState.Error(e.localizedMessage ?: "unknown error")

--- a/app/src/main/java/com/android/voyageur/model/trip/TripsViewModel.kt
+++ b/app/src/main/java/com/android/voyageur/model/trip/TripsViewModel.kt
@@ -188,6 +188,7 @@ open class TripsViewModel(
    *
    * @param trip the trip
    * @param userPrompt the prompt that the user provides in the app
+   * @param interests the interests to focus on
    * @param provideFinalActivities whether to provide final activities with date and time or just
    *   draft activities.
    */

--- a/app/src/main/java/com/android/voyageur/ui/trip/assistant/Assistant.kt
+++ b/app/src/main/java/com/android/voyageur/ui/trip/assistant/Assistant.kt
@@ -120,14 +120,22 @@ fun AssistantScreen(
                           keyboardController?.hide()
                           if (uiState !is UiState.Loading) {
                             tripsViewModel.sendActivitiesPrompt(
-                                trip, prompt, interests, provideFinalActivities, useInterests)
+                                trip = trip,
+                                userPrompt = prompt,
+                                interests = if (useInterests) interests else emptyList(),
+                                provideFinalActivities = provideFinalActivities,
+                            )
                           }
                         }),
                 singleLine = true)
             Button(
                 onClick = {
                   tripsViewModel.sendActivitiesPrompt(
-                      trip, prompt, interests, provideFinalActivities, useInterests)
+                      trip = trip,
+                      userPrompt = prompt,
+                      interests = if (useInterests) interests else emptyList(),
+                      provideFinalActivities = provideFinalActivities,
+                  )
                 },
                 enabled = uiState !is UiState.Loading, // Disable the button during loading
                 modifier = Modifier.testTag("AIRequestButton").align(Alignment.CenterVertically)) {

--- a/app/src/main/java/com/android/voyageur/ui/trip/assistant/Assistant.kt
+++ b/app/src/main/java/com/android/voyageur/ui/trip/assistant/Assistant.kt
@@ -1,7 +1,6 @@
 package com.android.voyageur.ui.trip.assistant
 
 import android.annotation.SuppressLint
-import android.util.Log
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -75,18 +74,18 @@ fun AssistantScreen(
     navigationActions: NavigationActions,
     userViewModel: UserViewModel
 ) {
+  // State
   var result by rememberSaveable { mutableStateOf("placeholderResult") }
   val uiState by tripsViewModel.uiState.collectAsState()
-  var prompt by rememberSaveable { mutableStateOf("") }
   var activities by remember { mutableStateOf(emptyList<Activity>()) }
-  Log.d("AssistantScreen", userViewModel.user.toString())
-  Log.d("AssistantScreen", userViewModel.user.collectAsState().toString())
-  Log.d("AssistantScreen", userViewModel.user.collectAsState().value.toString())
-  Log.d("AssistantScreen", userViewModel.user.collectAsState().value?.interests.toString())
 
+  // User related data
+  var prompt by rememberSaveable { mutableStateOf("") }
   val interests = userViewModel.user.collectAsState().value?.interests ?: emptyList()
+
   val keyboardController = LocalSoftwareKeyboardController.current
 
+  // Settings
   var showSettingsDialog by rememberSaveable { mutableStateOf(false) }
   var provideFinalActivities by rememberSaveable { mutableStateOf(false) }
   var useInterests by rememberSaveable { mutableStateOf(false) }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -28,6 +28,7 @@
     <string name="go">Go</string>
     <string name="settings">Settings</string>
     <string name="settings_subtitle">Remember to click on the \'go\' button after changing the settings</string>
-    <string name="provide_final_activities">"Provide final activities with date and time (recommended for trips shorter than a week)</string>
+    <string name="provide_final_activities">Provide final activities with date and time (recommended for trips shorter than a week)</string>
+    <string name="use_interests">Use your profile\'s interests to recommend activities</string>
     <string name="close">Close</string>
 </resources>

--- a/app/src/test/java/com/android/voyageur/model/assistant/AssistantUtilsTest.kt
+++ b/app/src/test/java/com/android/voyageur/model/assistant/AssistantUtilsTest.kt
@@ -3,13 +3,14 @@ package com.android.voyageur.model.assistant
 import com.android.voyageur.model.trip.Trip
 import com.google.firebase.Timestamp
 import java.util.Calendar
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Test
 
 class GeneratePromptTest {
 
   @Test
-  fun testGeneratePromptForFinalActivities() {
+  fun testGeneratePromptForFinalActivitiesWithoutInterests() {
     val trip =
         Trip(
             name = "Summer Adventure",
@@ -18,8 +19,10 @@ class GeneratePromptTest {
 
     val userPrompt = "Explore beaches and try local cuisine"
     val provideFinalActivities = true
+    val interests = listOf("hiking", "cycling")
+    val useInterests = false
 
-    val prompt = generatePrompt(trip, userPrompt, provideFinalActivities)
+    val prompt = generatePrompt(trip, userPrompt, interests, provideFinalActivities, useInterests)
     println(prompt)
 
     assertTrue(prompt.contains("Summer Adventure"))
@@ -27,10 +30,12 @@ class GeneratePromptTest {
     assertTrue(prompt.contains("end date year 2024 month 7 day 7"))
     assertTrue(prompt.contains("Make a full schedule by listing activities"))
     assertTrue(prompt.contains("Explore beaches and try local cuisine"))
+    assertFalse(prompt.contains("hiking"))
+    assertFalse(prompt.contains("cycling"))
   }
 
   @Test
-  fun testGeneratePromptForDraftActivities() {
+  fun testGeneratePromptForDraftActivitiesWithoutInterests() {
     val trip =
         Trip(
             name = "Winter Wonderland",
@@ -39,14 +44,66 @@ class GeneratePromptTest {
 
     val userPrompt = "Enjoy snowy landscapes and Christmas markets"
     val provideFinalActivities = false
+    val interests = listOf("hiking, cycling")
+    val useInterests = false
 
-    val prompt = generatePrompt(trip, userPrompt, provideFinalActivities)
+    val prompt = generatePrompt(trip, userPrompt, interests, provideFinalActivities, useInterests)
 
     assertTrue(prompt.contains("Winter Wonderland"))
     assertTrue(prompt.contains("start date year 2024 month 12 day 20"))
     assertTrue(prompt.contains("end date year 2024 month 12 day 27"))
     assertTrue(prompt.contains("List a lot of popular specific activities"))
     assertTrue(prompt.contains("Enjoy snowy landscapes and Christmas markets"))
+    assertFalse(prompt.contains("hiking"))
+    assertFalse(prompt.contains("cycling"))
+  }
+
+  @Test
+  fun testGeneratePromptWithInterests() {
+    val trip =
+        Trip(
+            name = "Spring Break",
+            startDate = createTimestamp(2024, 3, 1),
+            endDate = createTimestamp(2024, 3, 7))
+
+    val userPrompt = "Relax and have fun"
+    val provideFinalActivities = false
+    val interests = listOf("hiking", "cycling")
+    val useInterests = true
+
+    val prompt = generatePrompt(trip, userPrompt, interests, provideFinalActivities, useInterests)
+
+    assertTrue(prompt.contains("Spring Break"))
+    assertTrue(prompt.contains("start date year 2024 month 3 day 1"))
+    assertTrue(prompt.contains("end date year 2024 month 3 day 7"))
+    assertTrue(prompt.contains("List a lot of popular specific activities"))
+    assertTrue(prompt.contains("Relax and have fun"))
+    assertTrue(prompt.contains("hiking"))
+    assertTrue(prompt.contains("cycling"))
+  }
+
+  @Test
+  fun testGeneratePromptWithInterestsAndFinalActivities() {
+    val trip =
+        Trip(
+            name = "Spring Break",
+            startDate = createTimestamp(2024, 3, 1),
+            endDate = createTimestamp(2024, 3, 7))
+
+    val userPrompt = "Relax and have fun"
+    val provideFinalActivities = true
+    val interests = listOf("hiking", "cycling")
+    val useInterests = true
+
+    val prompt = generatePrompt(trip, userPrompt, interests, provideFinalActivities, useInterests)
+
+    assertTrue(prompt.contains("Spring Break"))
+    assertTrue(prompt.contains("start date year 2024 month 3 day 1"))
+    assertTrue(prompt.contains("end date year 2024 month 3 day 7"))
+    assertTrue(prompt.contains("Make a full schedule by listing activities"))
+    assertTrue(prompt.contains("Relax and have fun"))
+    assertTrue(prompt.contains("hiking"))
+    assertTrue(prompt.contains("cycling"))
   }
 
   // Helper function to create a Timestamp from year, month, and day

--- a/app/src/test/java/com/android/voyageur/model/assistant/AssistantUtilsTest.kt
+++ b/app/src/test/java/com/android/voyageur/model/assistant/AssistantUtilsTest.kt
@@ -19,10 +19,13 @@ class GeneratePromptTest {
 
     val userPrompt = "Explore beaches and try local cuisine"
     val provideFinalActivities = true
-    val interests = listOf("hiking", "cycling")
-    val useInterests = false
 
-    val prompt = generatePrompt(trip, userPrompt, interests, provideFinalActivities, useInterests)
+    val prompt =
+        generatePrompt(
+            trip = trip,
+            userPrompt = userPrompt,
+            interests = emptyList(),
+            provideFinalActivities = provideFinalActivities)
     println(prompt)
 
     assertTrue(prompt.contains("Summer Adventure"))
@@ -44,10 +47,13 @@ class GeneratePromptTest {
 
     val userPrompt = "Enjoy snowy landscapes and Christmas markets"
     val provideFinalActivities = false
-    val interests = listOf("hiking, cycling")
-    val useInterests = false
 
-    val prompt = generatePrompt(trip, userPrompt, interests, provideFinalActivities, useInterests)
+    val prompt =
+        generatePrompt(
+            trip = trip,
+            userPrompt = userPrompt,
+            interests = emptyList(),
+            provideFinalActivities = provideFinalActivities)
 
     assertTrue(prompt.contains("Winter Wonderland"))
     assertTrue(prompt.contains("start date year 2024 month 12 day 20"))
@@ -69,9 +75,8 @@ class GeneratePromptTest {
     val userPrompt = "Relax and have fun"
     val provideFinalActivities = false
     val interests = listOf("hiking", "cycling")
-    val useInterests = true
 
-    val prompt = generatePrompt(trip, userPrompt, interests, provideFinalActivities, useInterests)
+    val prompt = generatePrompt(trip, userPrompt, interests, provideFinalActivities)
 
     assertTrue(prompt.contains("Spring Break"))
     assertTrue(prompt.contains("start date year 2024 month 3 day 1"))
@@ -93,9 +98,8 @@ class GeneratePromptTest {
     val userPrompt = "Relax and have fun"
     val provideFinalActivities = true
     val interests = listOf("hiking", "cycling")
-    val useInterests = true
 
-    val prompt = generatePrompt(trip, userPrompt, interests, provideFinalActivities, useInterests)
+    val prompt = generatePrompt(trip, userPrompt, interests, provideFinalActivities)
 
     assertTrue(prompt.contains("Spring Break"))
     assertTrue(prompt.contains("start date year 2024 month 3 day 1"))

--- a/app/src/test/java/com/android/voyageur/model/trip/TripsViewModelTest.kt
+++ b/app/src/test/java/com/android/voyageur/model/trip/TripsViewModelTest.kt
@@ -328,7 +328,7 @@ class TripsViewModelTest {
     val userPrompt = "Generate activities for the trip"
     val provideFinalActivities = true
 
-    tripsViewModel.sendActivitiesPrompt(trip, userPrompt, provideFinalActivities)
+    tripsViewModel.sendActivitiesPrompt(trip, userPrompt, emptyList(), provideFinalActivities)
     advanceUntilIdle()
 
     val uiState = tripsViewModel.uiState.value


### PR DESCRIPTION
## Summary

This feature now allows the assistant to recommend activities taking into consideration the user's interests (the ones from their profile). This setting can be enabled or disabled by the user on the assistant screen.

## Changes

- **Screens/UI:** There is a new switch on the settings dialog of the AssistantScreen.

## Checklist

- [x] This PR resolves #263 
- [x] Tests have been added for new functionality.
- [x] Screenshots or UI changes have been attached (if applicable).
- [x] Documentation has been updated (if applicable).

##  Testing

- **Manual Testing:**
    - [x] Tested on emulator / physical device.
- **Unit Tests**
    - [x] Added units tests for this


## Screenshots (if applicable)

[interests.webm](https://github.com/user-attachments/assets/dffcb97d-ae41-4366-a9e6-88b800788c8c)
