### PR TITLE
Feat/Add trips to google calendar.

### DIFF
--- a/app/src/androidTest/java/com/android/voyageur/ui/overview/OverviewScreenTest.kt
+++ b/app/src/androidTest/java/com/android/voyageur/ui/overview/OverviewScreenTest.kt
@@ -312,15 +312,16 @@ class OverviewScreenTest {
     assertEquals(CalendarContract.Events.CONTENT_URI, capturedIntent.data)
     assertEquals(mockTrip.name, capturedIntent.getStringExtra(CalendarContract.Events.TITLE))
     assertEquals(
+        mockTrip.startDate.toDate().time,
+        capturedIntent.getLongExtra(CalendarContract.EXTRA_EVENT_BEGIN_TIME, -1))
+    assertEquals(
         mockTrip.description, capturedIntent.getStringExtra(CalendarContract.Events.DESCRIPTION))
-    // Check startDate if it's added
-    val expectedStartTime = mockTrip.startDate.toDate().time
     assertEquals(
-        expectedStartTime, capturedIntent.getLongExtra(CalendarContract.EXTRA_EVENT_BEGIN_TIME, -1))
-    // Check endDate if it's added
-    val expectedEndTime = mockTrip.endDate.toDate().time
+        mockTrip.startDate.toDate().time,
+        capturedIntent.getLongExtra(CalendarContract.EXTRA_EVENT_BEGIN_TIME, -1))
     assertEquals(
-        expectedEndTime, capturedIntent.getLongExtra(CalendarContract.EXTRA_EVENT_END_TIME, -1))
+        mockTrip.endDate.toDate().time,
+        capturedIntent.getLongExtra(CalendarContract.EXTRA_EVENT_END_TIME, -1))
     assertEquals(
         TimeZone.getDefault().id,
         capturedIntent.getStringExtra(CalendarContract.Events.EVENT_TIMEZONE))

--- a/app/src/androidTest/java/com/android/voyageur/ui/overview/OverviewScreenTest.kt
+++ b/app/src/androidTest/java/com/android/voyageur/ui/overview/OverviewScreenTest.kt
@@ -313,16 +313,14 @@ class OverviewScreenTest {
     assertEquals(mockTrip.name, capturedIntent.getStringExtra(CalendarContract.Events.TITLE))
     assertEquals(
         mockTrip.description, capturedIntent.getStringExtra(CalendarContract.Events.DESCRIPTION))
+    // Check startDate if it's added
+    val expectedStartTime = mockTrip.startDate.toDate().time
     assertEquals(
-        mockTrip.startDate.toDate().time,
-        capturedIntent.getLongExtra(
-            CalendarContract.EXTRA_EVENT_BEGIN_TIME,
-            -1)) // -1 is default value in case begin time is not found
+        expectedStartTime, capturedIntent.getLongExtra(CalendarContract.EXTRA_EVENT_BEGIN_TIME, -1))
+    // Check endDate if it's added
+    val expectedEndTime = mockTrip.endDate.toDate().time
     assertEquals(
-        mockTrip.endDate.toDate().time,
-        capturedIntent.getLongExtra(
-            CalendarContract.EXTRA_EVENT_END_TIME,
-            -1)) // -1 is default value in case end time is not found
+        expectedEndTime, capturedIntent.getLongExtra(CalendarContract.EXTRA_EVENT_END_TIME, -1))
     assertEquals(
         TimeZone.getDefault().id,
         capturedIntent.getStringExtra(CalendarContract.Events.EVENT_TIMEZONE))

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -18,29 +18,33 @@
     <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
     <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
 
-    <application
-        android:allowBackup="true"
-        android:dataExtractionRules="@xml/data_extraction_rules"
-        android:fullBackupContent="@xml/backup_rules"
-        android:icon="@mipmap/ic_launcher"
-        android:label="@string/app_name"
-        android:roundIcon="@mipmap/ic_launcher_round"
-        android:supportsRtl="true"
-        android:theme="@style/Theme.Voyageur"
-        tools:targetApi="31">
-        <activity
-            android:name="com.android.voyageur.MainActivity"
-            android:exported="true"
-            android:label="@string/app_name"
-            android:theme="@style/Theme.Voyageur">
-            <intent-filter>
-                <action android:name="android.intent.action.MAIN" />
-                <category android:name="android.intent.category.LAUNCHER" />
-            </intent-filter>
-        </activity>
-        <meta-data
-            android:name="com.google.android.geo.API_KEY"
-            android:value="${PLACES_API_KEY}" />
-    </application>
+    <!-- To handle reading/writing in google calendar -->
+   <uses-permission android:name="android.permission.WRITE_CALENDAR" />
+   <uses-permission android:name="android.permission.READ_CALENDAR" />
+
+   <application
+       android:allowBackup="true"
+       android:dataExtractionRules="@xml/data_extraction_rules"
+       android:fullBackupContent="@xml/backup_rules"
+       android:icon="@mipmap/ic_launcher"
+       android:label="@string/app_name"
+       android:roundIcon="@mipmap/ic_launcher_round"
+       android:supportsRtl="true"
+       android:theme="@style/Theme.Voyageur"
+       tools:targetApi="31">
+       <activity
+           android:name="com.android.voyageur.MainActivity"
+           android:exported="true"
+           android:label="@string/app_name"
+           android:theme="@style/Theme.Voyageur">
+           <intent-filter>
+               <action android:name="android.intent.action.MAIN" />
+               <category android:name="android.intent.category.LAUNCHER" />
+           </intent-filter>
+       </activity>
+       <meta-data
+           android:name="com.google.android.geo.API_KEY"
+           android:value="${PLACES_API_KEY}" />
+   </application>
 
 </manifest>

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -20,7 +20,6 @@
 
     <!-- To handle reading/writing in google calendar -->
    <uses-permission android:name="android.permission.WRITE_CALENDAR" />
-   <uses-permission android:name="android.permission.READ_CALENDAR" />
 
    <application
        android:allowBackup="true"

--- a/app/src/main/java/com/android/voyageur/ui/overview/AddTrip.kt
+++ b/app/src/main/java/com/android/voyageur/ui/overview/AddTrip.kt
@@ -1,13 +1,7 @@
 package com.android.voyageur.ui.overview
 
-import android.Manifest
 import android.annotation.SuppressLint
-import android.app.Activity
-import android.content.ContentValues
-import android.content.Context
-import android.content.pm.PackageManager
 import android.net.Uri
-import android.provider.CalendarContract
 import android.util.Log
 import android.widget.Toast
 import androidx.compose.foundation.Image
@@ -24,7 +18,6 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.KeyboardActions
@@ -33,7 +26,6 @@ import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.outlined.ArrowBack
 import androidx.compose.material3.Button
-import androidx.compose.material3.Checkbox
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
@@ -65,8 +57,6 @@ import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.input.TextFieldValue
 import androidx.compose.ui.unit.dp
-import androidx.core.app.ActivityCompat
-import androidx.core.content.ContextCompat
 import androidx.lifecycle.viewmodel.compose.viewModel
 import coil.compose.rememberAsyncImagePainter
 import com.android.voyageur.R
@@ -159,11 +149,6 @@ fun AddTripScreen(
       //      userList.clear()
     }
   }
-  LaunchedEffect(Unit) {
-    if (!checkAndRequestCalendarPermissions(context, context as Activity)) {
-      Toast.makeText(context, "Calendar permissions are required", Toast.LENGTH_SHORT).show()
-    }
-  }
 
   fun createTripWithImage(imageUrl: String) {
     if (isSaving) return // Prevent duplicate saves
@@ -236,9 +221,6 @@ fun AddTripScreen(
           onSuccess = {
             isSaving = false
             Toast.makeText(context, "Trip created successfully!", Toast.LENGTH_SHORT).show()
-            if (addToCalendar) {
-              addEventToGoogleCalendar(context, trip)
-            }
           },
           onFailure = { error ->
             isSaving = false
@@ -418,7 +400,7 @@ fun AddTripScreen(
 
                 Spacer(modifier = Modifier.height(4.dp))
                 // Add the checkbox
-                Row(
+                /*Row(
                     verticalAlignment = Alignment.CenterVertically,
                     modifier = Modifier.fillMaxWidth().padding(vertical = 8.dp)) {
                       Checkbox(
@@ -428,7 +410,7 @@ fun AddTripScreen(
                       Spacer(modifier = Modifier.width(8.dp))
                       Text("Add to Google Calendar")
                     }
-
+                */
                 Row(
                     modifier = Modifier.fillMaxWidth(),
                     horizontalArrangement = Arrangement.Center,
@@ -487,104 +469,7 @@ fun AddTripScreen(
       }
 }
 
-private fun logAvailableCalendars(context: Context) {
-  val projection =
-      arrayOf(
-          CalendarContract.Calendars._ID,
-          CalendarContract.Calendars.ACCOUNT_NAME,
-          CalendarContract.Calendars.CALENDAR_DISPLAY_NAME)
-
-  context.contentResolver
-      .query(
-          CalendarContract.Calendars.CONTENT_URI,
-          projection,
-          null, // No selection, so it queries all calendars
-          null,
-          null)
-      ?.use { cursor ->
-        while (cursor.moveToNext()) {
-          val id = cursor.getLong(cursor.getColumnIndexOrThrow(CalendarContract.Calendars._ID))
-          val accountName =
-              cursor.getString(
-                  cursor.getColumnIndexOrThrow(CalendarContract.Calendars.ACCOUNT_NAME))
-          val displayName =
-              cursor.getString(
-                  cursor.getColumnIndexOrThrow(CalendarContract.Calendars.CALENDAR_DISPLAY_NAME))
-          Log.d(
-              "AvailableCalendar", "ID: $id, AccountName: $accountName, DisplayName: $displayName")
-        }
-      }
-}
-
 enum class DateField {
   START,
   END
-}
-
-fun addEventToGoogleCalendar(context: Context, trip: Trip) {
-
-  val calendarId = getGoogleCalendarId(context)
-  if (calendarId == null) {
-    Toast.makeText(context, "No Google Calendar found", Toast.LENGTH_SHORT).show()
-    return
-  }
-
-  val values =
-      ContentValues().apply {
-        put(CalendarContract.Events.CALENDAR_ID, calendarId) // Use the Google Calendar ID
-        put(CalendarContract.Events.TITLE, trip.name)
-        put(CalendarContract.Events.DESCRIPTION, trip.description)
-        put(CalendarContract.Events.DTSTART, trip.startDate.toDate().time)
-        put(CalendarContract.Events.DTEND, trip.endDate.toDate().time)
-        put(CalendarContract.Events.EVENT_TIMEZONE, TimeZone.getDefault().id)
-      }
-
-  try {
-    val uri = context.contentResolver.insert(CalendarContract.Events.CONTENT_URI, values)
-    if (uri != null) {
-      Toast.makeText(context, "Event added to Google Calendar", Toast.LENGTH_SHORT).show()
-    } else {
-      Toast.makeText(context, "Failed to add event to calendar", Toast.LENGTH_SHORT).show()
-    }
-  } catch (e: Exception) {
-    Log.e("AddToCalendar", "Error adding event", e)
-    Toast.makeText(context, "Error adding event: ${e.message}", Toast.LENGTH_SHORT).show()
-  }
-}
-
-private fun getGoogleCalendarId(context: Context): Long? {
-  val projection =
-      arrayOf(
-          CalendarContract.Calendars._ID,
-          CalendarContract.Calendars.ACCOUNT_NAME,
-          CalendarContract.Calendars.IS_PRIMARY)
-
-  val selection =
-      "${CalendarContract.Calendars.ACCOUNT_NAME} LIKE ? AND ${CalendarContract.Calendars.IS_PRIMARY} = 1"
-  val selectionArgs = arrayOf("%@gmail.com") // Match Google accounts
-
-  context.contentResolver
-      .query(CalendarContract.Calendars.CONTENT_URI, projection, selection, selectionArgs, null)
-      ?.use { cursor ->
-        if (cursor.moveToFirst()) {
-          return cursor.getLong(cursor.getColumnIndexOrThrow(CalendarContract.Calendars._ID))
-        }
-      }
-
-  return null
-}
-
-fun checkAndRequestCalendarPermissions(context: Context, activity: Activity): Boolean {
-  val permissions = arrayOf(Manifest.permission.READ_CALENDAR, Manifest.permission.WRITE_CALENDAR)
-
-  val permissionsGranted =
-      permissions.all {
-        ContextCompat.checkSelfPermission(context, it) == PackageManager.PERMISSION_GRANTED
-      }
-
-  if (!permissionsGranted) {
-    ActivityCompat.requestPermissions(activity, permissions, 100)
-  }
-
-  return permissionsGranted
 }

--- a/app/src/main/java/com/android/voyageur/ui/overview/AddTrip.kt
+++ b/app/src/main/java/com/android/voyageur/ui/overview/AddTrip.kt
@@ -1,7 +1,11 @@
 package com.android.voyageur.ui.overview
 
 import android.annotation.SuppressLint
+import android.app.Activity
+import android.content.ContentValues
+import android.content.Context
 import android.net.Uri
+import android.provider.CalendarContract
 import android.util.Log
 import android.widget.Toast
 import androidx.compose.foundation.Image
@@ -18,6 +22,7 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.KeyboardActions
@@ -26,6 +31,7 @@ import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.outlined.ArrowBack
 import androidx.compose.material3.Button
+import androidx.compose.material3.Checkbox
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
@@ -57,8 +63,12 @@ import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.input.TextFieldValue
 import androidx.compose.ui.unit.dp
+import androidx.core.app.ActivityCompat
+import androidx.core.content.ContextCompat
 import androidx.lifecycle.viewmodel.compose.viewModel
 import coil.compose.rememberAsyncImagePainter
+import android.Manifest
+import android.content.pm.PackageManager
 import com.android.voyageur.R
 import com.android.voyageur.model.location.Location
 import com.android.voyageur.model.place.PlacesViewModel
@@ -78,6 +88,7 @@ import java.text.SimpleDateFormat
 import java.util.Calendar
 import java.util.Date
 import java.util.Locale
+import java.util.TimeZone
 
 @SuppressLint("StateFlowValueCalledInComposition", "UnrememberedMutableState")
 @OptIn(ExperimentalMaterial3Api::class, ExperimentalLayoutApi::class)
@@ -100,6 +111,8 @@ fun AddTripScreen(
   var endDate by remember { mutableStateOf<Long?>(null) }
   var tripType by remember { mutableStateOf(TripType.BUSINESS) }
   var imageUri by remember { mutableStateOf("") }
+    // Existing state variables
+    var addToCalendar by remember { mutableStateOf(false) }
 
   val contactsAndUsers by userViewModel.contacts.collectAsState()
   val userList =
@@ -146,6 +159,11 @@ fun AddTripScreen(
       //      userList.clear()
     }
   }
+    LaunchedEffect(Unit) {
+        if (!checkAndRequestCalendarPermissions(context, context as Activity)) {
+            Toast.makeText(context, "Calendar permissions are required", Toast.LENGTH_SHORT).show()
+        }
+    }
 
   fun createTripWithImage(imageUrl: String) {
     if (isSaving) return // Prevent duplicate saves
@@ -159,13 +177,14 @@ fun AddTripScreen(
     val endTimestamp = Timestamp(Date(endDate!!))
     fun normalizeToMidnight(date: Date): Date {
       val calendar =
-          Calendar.getInstance().apply {
+          Calendar.getInstance(TimeZone.getTimeZone("UTC")).apply {
             time = date
             set(Calendar.HOUR_OF_DAY, 0)
             set(Calendar.MINUTE, 0)
             set(Calendar.SECOND, 0)
             set(Calendar.MILLISECOND, 0)
           }
+
       return calendar.time
     }
 
@@ -217,6 +236,9 @@ fun AddTripScreen(
           onSuccess = {
             isSaving = false
             Toast.makeText(context, "Trip created successfully!", Toast.LENGTH_SHORT).show()
+              if (addToCalendar) {
+                  addEventToGoogleCalendar(context, trip)
+              }
           },
           onFailure = { error ->
             isSaving = false
@@ -394,7 +416,20 @@ fun AddTripScreen(
                           })
                 }
 
-                Spacer(modifier = Modifier.height(16.dp))
+                Spacer(modifier = Modifier.height(4.dp))
+              // Add the checkbox
+              Row(
+                  verticalAlignment = Alignment.CenterVertically,
+                  modifier = Modifier.fillMaxWidth().padding(vertical = 8.dp)
+              ) {
+                  Checkbox(
+                      checked = addToCalendar,
+                      onCheckedChange = { addToCalendar = it },
+                      modifier = Modifier.testTag("addToCalendarCheckbox")
+                  )
+                  Spacer(modifier = Modifier.width(8.dp))
+                  Text("Add to Google Calendar")
+              }
 
                 Row(
                     modifier = Modifier.fillMaxWidth(),
@@ -453,8 +488,104 @@ fun AddTripScreen(
         }
       }
 }
+private fun logAvailableCalendars(context: Context) {
+    val projection = arrayOf(
+        CalendarContract.Calendars._ID,
+        CalendarContract.Calendars.ACCOUNT_NAME,
+        CalendarContract.Calendars.CALENDAR_DISPLAY_NAME
+    )
+
+    context.contentResolver.query(
+        CalendarContract.Calendars.CONTENT_URI,
+        projection,
+        null, // No selection, so it queries all calendars
+        null,
+        null
+    )?.use { cursor ->
+        while (cursor.moveToNext()) {
+            val id = cursor.getLong(cursor.getColumnIndexOrThrow(CalendarContract.Calendars._ID))
+            val accountName = cursor.getString(cursor.getColumnIndexOrThrow(CalendarContract.Calendars.ACCOUNT_NAME))
+            val displayName = cursor.getString(cursor.getColumnIndexOrThrow(CalendarContract.Calendars.CALENDAR_DISPLAY_NAME))
+            Log.d("AvailableCalendar", "ID: $id, AccountName: $accountName, DisplayName: $displayName")
+        }
+    }
+}
 
 enum class DateField {
   START,
   END
 }
+
+fun addEventToGoogleCalendar(context: Context, trip: Trip) {
+
+    val calendarId = getGoogleCalendarId(context)
+    if (calendarId == null) {
+        Toast.makeText(context, "No Google Calendar found", Toast.LENGTH_SHORT).show()
+        return
+    }
+
+    val values = ContentValues().apply {
+        put(CalendarContract.Events.CALENDAR_ID, calendarId) // Use the Google Calendar ID
+        put(CalendarContract.Events.TITLE, trip.name)
+        put(CalendarContract.Events.DESCRIPTION, trip.description)
+        put(CalendarContract.Events.DTSTART, trip.startDate.toDate().time)
+        put(CalendarContract.Events.DTEND, trip.endDate.toDate().time)
+        put(CalendarContract.Events.EVENT_TIMEZONE, TimeZone.getDefault().id)
+    }
+
+    try {
+        val uri = context.contentResolver.insert(CalendarContract.Events.CONTENT_URI, values)
+        if (uri != null) {
+            Toast.makeText(context, "Event added to Google Calendar", Toast.LENGTH_SHORT).show()
+        } else {
+            Toast.makeText(context, "Failed to add event to calendar", Toast.LENGTH_SHORT).show()
+        }
+    } catch (e: Exception) {
+        Log.e("AddToCalendar", "Error adding event", e)
+        Toast.makeText(context, "Error adding event: ${e.message}", Toast.LENGTH_SHORT).show()
+
+
+    }
+}
+private fun getGoogleCalendarId(context: Context): Long? {
+    val projection = arrayOf(
+        CalendarContract.Calendars._ID,
+        CalendarContract.Calendars.ACCOUNT_NAME,
+        CalendarContract.Calendars.IS_PRIMARY
+    )
+
+    val selection = "${CalendarContract.Calendars.ACCOUNT_NAME} LIKE ? AND ${CalendarContract.Calendars.IS_PRIMARY} = 1"
+    val selectionArgs = arrayOf("%@gmail.com") // Match Google accounts
+
+    context.contentResolver.query(
+        CalendarContract.Calendars.CONTENT_URI,
+        projection,
+        selection,
+        selectionArgs,
+        null
+    )?.use { cursor ->
+        if (cursor.moveToFirst()) {
+            return cursor.getLong(cursor.getColumnIndexOrThrow(CalendarContract.Calendars._ID))
+        }
+    }
+
+    return null
+}
+fun checkAndRequestCalendarPermissions(context: Context, activity: Activity): Boolean {
+    val permissions = arrayOf(
+        Manifest.permission.READ_CALENDAR,
+        Manifest.permission.WRITE_CALENDAR
+    )
+
+    val permissionsGranted = permissions.all {
+        ContextCompat.checkSelfPermission(context, it) == PackageManager.PERMISSION_GRANTED
+    }
+
+    if (!permissionsGranted) {
+        ActivityCompat.requestPermissions(activity, permissions, 100)
+    }
+
+    return permissionsGranted
+}
+
+

--- a/app/src/main/java/com/android/voyageur/ui/overview/AddTrip.kt
+++ b/app/src/main/java/com/android/voyageur/ui/overview/AddTrip.kt
@@ -101,8 +101,6 @@ fun AddTripScreen(
   var endDate by remember { mutableStateOf<Long?>(null) }
   var tripType by remember { mutableStateOf(TripType.BUSINESS) }
   var imageUri by remember { mutableStateOf("") }
-  // Existing state variables
-  var addToCalendar by remember { mutableStateOf(false) }
 
   val contactsAndUsers by userViewModel.contacts.collectAsState()
   val userList =
@@ -399,18 +397,6 @@ fun AddTripScreen(
                 }
 
                 Spacer(modifier = Modifier.height(4.dp))
-                // Add the checkbox
-                /*Row(
-                    verticalAlignment = Alignment.CenterVertically,
-                    modifier = Modifier.fillMaxWidth().padding(vertical = 8.dp)) {
-                      Checkbox(
-                          checked = addToCalendar,
-                          onCheckedChange = { addToCalendar = it },
-                          modifier = Modifier.testTag("addToCalendarCheckbox"))
-                      Spacer(modifier = Modifier.width(8.dp))
-                      Text("Add to Google Calendar")
-                    }
-                */
                 Row(
                     modifier = Modifier.fillMaxWidth(),
                     horizontalArrangement = Arrangement.Center,

--- a/app/src/main/java/com/android/voyageur/ui/overview/Overview.kt
+++ b/app/src/main/java/com/android/voyageur/ui/overview/Overview.kt
@@ -443,12 +443,28 @@ internal fun openGoogleCalendar(context: Context, trip: Trip) {
           .setData(CalendarContract.Events.CONTENT_URI)
           .putExtra(CalendarContract.Events.TITLE, trip.name)
           .putExtra(CalendarContract.Events.DESCRIPTION, trip.description)
-          .putExtra(CalendarContract.EXTRA_EVENT_BEGIN_TIME, trip.startDate.toDate().time)
-          .putExtra(CalendarContract.EXTRA_EVENT_END_TIME, trip.endDate.toDate().time)
-          .putExtra(CalendarContract.Events.EVENT_LOCATION, trip.location.name)
-          .putExtra(CalendarContract.Events.EVENT_TIMEZONE, TimeZone.getDefault().id)
 
-  // Launch the calendar or throw toast if no app compatible
+  // Handle endDate in try-catch safely
+  try {
+    val startTime = trip.startDate.toDate().time
+    intent.putExtra(CalendarContract.EXTRA_EVENT_BEGIN_TIME, startTime)
+  } catch (e: Exception) {
+    // Handle conversion exception gracefully
+    Toast.makeText(context, "startDate is not valid.", Toast.LENGTH_LONG).show()
+  }
+  // Handle endDate in try-catch safely
+  try {
+    val endTime = trip.endDate.toDate().time
+    intent.putExtra(CalendarContract.EXTRA_EVENT_BEGIN_TIME, endTime)
+  } catch (e: Exception) {
+    // Handle conversion exception gracefully
+    Toast.makeText(context, "endDate is not valid.", Toast.LENGTH_LONG).show()
+  }
+  // Add location and timezone to intent
+  intent.putExtra(CalendarContract.Events.EVENT_LOCATION, trip.location.name)
+  intent.putExtra(CalendarContract.Events.EVENT_TIMEZONE, TimeZone.getDefault().id)
+
+  // Launch the calendar intent or handle exceptions
   try {
     context.startActivity(intent)
   } catch (e: ActivityNotFoundException) {

--- a/app/src/main/java/com/android/voyageur/ui/overview/Overview.kt
+++ b/app/src/main/java/com/android/voyageur/ui/overview/Overview.kt
@@ -437,34 +437,17 @@ fun generateParticipantString(numberOfParticipants: Int): String {
  * @param trip The trip data used to populate the calendar event details.
  */
 internal fun openGoogleCalendar(context: Context, trip: Trip) {
-  // Create intent to open calendar app
   val intent =
       Intent(Intent.ACTION_INSERT)
           .setData(CalendarContract.Events.CONTENT_URI)
           .putExtra(CalendarContract.Events.TITLE, trip.name)
           .putExtra(CalendarContract.Events.DESCRIPTION, trip.description)
+          .putExtra(CalendarContract.EXTRA_EVENT_BEGIN_TIME, trip.startDate.toDate().time)
+          .putExtra(CalendarContract.EXTRA_EVENT_END_TIME, trip.endDate.toDate().time)
+          .putExtra(CalendarContract.Events.EVENT_LOCATION, trip.location.name)
+          .putExtra(CalendarContract.Events.EVENT_TIMEZONE, TimeZone.getDefault().id)
 
-  // Handle endDate in try-catch safely
-  try {
-    val startTime = trip.startDate.toDate().time
-    intent.putExtra(CalendarContract.EXTRA_EVENT_BEGIN_TIME, startTime)
-  } catch (e: Exception) {
-    // Handle conversion exception gracefully
-    Toast.makeText(context, "startDate is not valid.", Toast.LENGTH_LONG).show()
-  }
-  // Handle endDate in try-catch safely
-  try {
-    val endTime = trip.endDate.toDate().time
-    intent.putExtra(CalendarContract.EXTRA_EVENT_END_TIME, endTime)
-  } catch (e: Exception) {
-    // Handle conversion exception gracefully
-    Toast.makeText(context, "endDate is not valid.", Toast.LENGTH_LONG).show()
-  }
-  // Add location and timezone to intent
-  intent.putExtra(CalendarContract.Events.EVENT_LOCATION, trip.location.name)
-  intent.putExtra(CalendarContract.Events.EVENT_TIMEZONE, TimeZone.getDefault().id)
-
-  // Launch the calendar intent or handle exceptions
+  // Handle ActivityNotFoundException
   try {
     context.startActivity(intent)
   } catch (e: ActivityNotFoundException) {

--- a/app/src/main/java/com/android/voyageur/ui/overview/Overview.kt
+++ b/app/src/main/java/com/android/voyageur/ui/overview/Overview.kt
@@ -455,7 +455,7 @@ internal fun openGoogleCalendar(context: Context, trip: Trip) {
   // Handle endDate in try-catch safely
   try {
     val endTime = trip.endDate.toDate().time
-    intent.putExtra(CalendarContract.EXTRA_EVENT_BEGIN_TIME, endTime)
+    intent.putExtra(CalendarContract.EXTRA_EVENT_END_TIME, endTime)
   } catch (e: Exception) {
     // Handle conversion exception gracefully
     Toast.makeText(context, "endDate is not valid.", Toast.LENGTH_LONG).show()

--- a/app/src/main/java/com/android/voyageur/ui/overview/Overview.kt
+++ b/app/src/main/java/com/android/voyageur/ui/overview/Overview.kt
@@ -2,6 +2,7 @@ package com.android.voyageur.ui.overview
 
 import android.Manifest
 import android.annotation.SuppressLint
+import android.content.ActivityNotFoundException
 import android.content.Context
 import android.content.Intent
 import android.content.pm.PackageManager
@@ -436,7 +437,7 @@ fun generateParticipantString(numberOfParticipants: Int): String {
  * @param trip The trip data used to populate the calendar event details.
  */
 internal fun openGoogleCalendar(context: Context, trip: Trip) {
-  // Create an intent to insert into the calendar app
+  // Create intent to open calendar app
   val intent =
       Intent(Intent.ACTION_INSERT)
           .setData(CalendarContract.Events.CONTENT_URI)
@@ -444,7 +445,13 @@ internal fun openGoogleCalendar(context: Context, trip: Trip) {
           .putExtra(CalendarContract.Events.DESCRIPTION, trip.description)
           .putExtra(CalendarContract.EXTRA_EVENT_BEGIN_TIME, trip.startDate.toDate().time)
           .putExtra(CalendarContract.EXTRA_EVENT_END_TIME, trip.endDate.toDate().time)
+          .putExtra(CalendarContract.Events.EVENT_LOCATION, trip.location.name)
           .putExtra(CalendarContract.Events.EVENT_TIMEZONE, TimeZone.getDefault().id)
-  // Start Activity and open calendar
-  context.startActivity(intent)
+
+  // Launch the calendar or throw toast if no app compatible
+  try {
+    context.startActivity(intent)
+  } catch (e: ActivityNotFoundException) {
+    Toast.makeText(context, R.string.no_compatible_calendar, Toast.LENGTH_LONG).show()
+  }
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -52,6 +52,7 @@
     <string name="deleted_trip_text">Trip successfully deleted</string>
     <string name="additional_participants">and %1$d more</string>
     <string name="participants_count">%1$d Participants:</string>
+    <string name="no_compatible_calendar">No compatible calendar app found.</string>
 
 
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -30,4 +30,28 @@
     <string name="settings_subtitle">Remember to click on the \'go\' button after changing the settings</string>
     <string name="provide_final_activities">"Provide final activities with date and time (recommended for trips shorter than a week)</string>
     <string name="close">Close</string>
+
+    <!-- OVERVIEW SCREEN -->
+    <string name="your_trips_text">Your trips</string>
+    <string name="floating_button">Floating button action</string>
+    <string name="empty_trip_prompt">You have no trips yet.</string>
+    <string name="denied_calendar_permission">Permission denied. Cannot open calendar.</string>
+    <string name="selected_image_description">Selected image</string>
+    <string name="trip_image_overview_description">Trip image overview</string>
+    <string name="collapse_text">Collapse</string>
+    <string name="expand_text">Expand</string>
+    <string name="delete_text">Delete</string>
+    <string name="add_to_calendar_text">Add to calendar</string>
+    <string name="remove_trip_text">Remove Trip</string>
+    <string name="cancel_text">Cancel</string>
+    <string name="remove_text">Remove</string>
+    <string name="no_participants_text">No participants.</string>
+    <string name="one_participant_text">1 Participant:</string>
+    <string name="remove_trip_confirmation">Are you sure you want to remove %1$s from your trips?</string>
+    <string name="deleted_trip_text">Trip successfully deleted</string>
+    <string name="additional_participants">and %1$d more</string>
+    <string name="participants_count">%1$d Participants:</string>
+
+
+
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -34,7 +34,7 @@
 
     <!-- OVERVIEW SCREEN -->
     <string name="your_trips_text">Your trips</string>
-    <string name="floating_button">Floating button action</string>
+    <string name="floating_button">"Floating action button"</string>
     <string name="empty_trip_prompt">You have no trips yet.</string>
     <string name="denied_calendar_permission">Permission denied. Cannot open calendar.</string>
     <string name="selected_image_description">Selected image</string>
@@ -52,7 +52,6 @@
     <string name="deleted_trip_text">Trip successfully deleted</string>
     <string name="additional_participants">and %1$d more</string>
     <string name="participants_count">%1$d Participants:</string>
-
 
 
 </resources>


### PR DESCRIPTION
## Summary

This PR introduces the possibility to add a trip to google calendar by pressing the icon button at the top right of a trip and selecting "Add to calendar".  It opens an intent and redirects the user to the calendar app, where they  have pre-filled fields such as the name of the trip, description and start and end dates. Then, the user has the possibility to add the trip to their calendar or not.
Moreover, this feature comes with permission support for the calendar app, which if denied shows a toast to the user, and if accepted, redirects the user to the calendar app.
It also adds documentation for the Overview Screen and replacement of hardcoded strings with string resources.

## Changes

- **Screens/UI:** A new DropDownMenuItem has been introduced to the DropDownMenu in the OverviewScreen.
- **Bug Fixes/Improvements:** Addresses #247.

## Checklist

- [X] This PR resolves #247 .
- [X] Tests have been added for new functionality.
- [X] Screenshots or UI changes have been attached.
- [X] Documentation has been updated.

##  Testing

- **Manual Testing:**
    - [X] Tested on emulator / physical device.
- **Unit Tests**
    - [X] Added units tests for this


##  Related Issues/Tickets

Closes #247.

## Screenshots (if applicable)


https://github.com/user-attachments/assets/919ac327-a068-4cf3-986c-90b28ea8dc80

![Screenshot 2024-12-05 at 22 01 14](https://github.com/user-attachments/assets/0d512cfa-0ed5-42a1-9b03-83033367e392)


## 💡 Additional Context

While I managed to test the intent and the DropDownMenuItem, permissions are hard to test.
