### PR TITLE
[DRAFT] feat(ActivitiesForOneDay): add estimated price for activities by day

### DIFF
--- a/app/src/main/java/com/android/voyageur/ui/trip/activities/ActivitiesForOneDay.kt
+++ b/app/src/main/java/com/android/voyageur/ui/trip/activities/ActivitiesForOneDay.kt
@@ -1,5 +1,6 @@
 package com.android.voyageur.ui.trip.activities
 
+import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Spacer
@@ -8,9 +9,11 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -19,7 +22,11 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.android.voyageur.R
 import com.android.voyageur.model.activity.Activity
 import com.android.voyageur.model.trip.TripsViewModel
 import com.android.voyageur.ui.navigation.NavigationActions
@@ -61,6 +68,11 @@ fun ActivitiesForOneDayScreen(
   var showDialog by remember { mutableStateOf(false) }
   var activityToDelete by remember { mutableStateOf<Activity?>(null) }
 
+  var totalEstimatedPrice by remember { mutableStateOf(0.0) }
+
+  // Calculate the total estimated price whenever the activities change
+  LaunchedEffect(activities) { totalEstimatedPrice = activities.sumOf { it.estimatedPrice } }
+
   Scaffold(
       modifier = Modifier.testTag("activitiesForOneDayScreen"),
       topBar = {
@@ -96,6 +108,25 @@ fun ActivitiesForOneDayScreen(
                     tripsViewModel)
                 Spacer(modifier = Modifier.height(10.dp))
               }
+            }
+            item {
+              Box(
+                  modifier =
+                      Modifier.fillMaxWidth()
+                          .padding(16.dp)
+                          .background(
+                              color = MaterialTheme.colorScheme.secondary.copy(alpha = 0.1f),
+                              shape = androidx.compose.foundation.shape.RoundedCornerShape(8.dp))
+                          .padding(16.dp)
+                          .testTag("totalEstimatedPriceBox"),
+                  contentAlignment = Alignment.Center) {
+                    Text(
+                        text = stringResource(R.string.total_price, totalEstimatedPrice),
+                        fontSize = 20.sp,
+                        fontWeight = FontWeight.Medium,
+                        color = MaterialTheme.colorScheme.primary,
+                        modifier = Modifier.align(Alignment.Center))
+                  }
             }
           }
           if (showDialog) {


### PR DESCRIPTION
## Summary

Currently we can only see an estimated price for all  activities in a given trip. This PR adds an estimate for the total price for all activities in a given day.

## Changes

- **Screens/UI:** In the LazyColumn where final activities are displayed added another item with the total estimated price in the ActivitiesForOneDayScreen.

## Checklist

Ensure all / most of these are checked before the pull request is submitted.
- [ ] This PR resolves #278  (if applicable).
- [ ] Tests have been added for new functionality.
- [ ] Screenshots or UI changes have been attached (if applicable).

##  Testing

- **Manual Testing:**
    - [ ] Tested on emulator / physical device.
- **Unit Tests**
    - [ ] Added units tests for this

Manual testing was done to ensure feature works, also previous tests still pass.

##  Related Issues/Tickets

Closes #278.

## Screenshots (if applicable)

![image](https://github.com/user-attachments/assets/293c5d6c-8b62-4389-b01c-bb7a8c42ead8)



