### PR TITLE
Feat: assistant improvements

### DIFF
--- a/app/src/main/java/com/android/voyageur/model/assistant/AssistantUtils.kt
+++ b/app/src/main/java/com/android/voyageur/model/assistant/AssistantUtils.kt
@@ -161,8 +161,10 @@ fun generatePrompt(
       }
   val prompt =
       "$draftVsFinalPrompt The trip, called ${trip.name}, with description ${trip.description} " +
-              "and location ${trip.location.name}, takes place $datePrompt with the following prompt:"+
-          " $userPrompt. Descriptions should be detailed. "+ interestsPrompt +
-              alreadyPresentActivitiesPrompt + possibleEnumTypePrompt
+          "and location ${trip.location.name}, takes place $datePrompt with the following prompt:" +
+          " $userPrompt. Descriptions should be detailed. " +
+          interestsPrompt +
+          alreadyPresentActivitiesPrompt +
+          possibleEnumTypePrompt
   return prompt
 }

--- a/app/src/main/java/com/android/voyageur/model/assistant/AssistantUtils.kt
+++ b/app/src/main/java/com/android/voyageur/model/assistant/AssistantUtils.kt
@@ -117,7 +117,7 @@ val generativeModel =
  * @param provideFinalActivities whether to provide final activities with date and time or just
  *   draft activities. In the case of draft activities, the prompt is a bit different to avoid
  *   recommending a lunch for each day more or less the same.
- *     @param alreadyPresentActivities the activities that are already present in the trip
+ * @param alreadyPresentActivities the activities that are already present in the trip
  * @return the prompt to send to use with the generative model
  */
 fun generatePrompt(
@@ -127,8 +127,8 @@ fun generatePrompt(
     provideFinalActivities: Boolean,
     alreadyPresentActivities: List<String>
 ): String {
-    val possibleEnumTypePrompt = "The activity type can only be ${ActivityType.entries.joinToString { ", " }}"
-    Log.d("AssistantUtils", "possibleEnumTypePrompt: $possibleEnumTypePrompt")
+  val possibleEnumTypePrompt =
+      "The activity type can only be ${ActivityType.entries.joinToString(", ")}, but you can recommend any activity and set the type to OTHER."
   val startDate = getYearMonthDay(trip.startDate)
   val endDate = getYearMonthDay(trip.endDate)
   val datePrompt =
@@ -143,29 +143,23 @@ fun generatePrompt(
       } else {
         ""
       }
-  Log.d("AssistantUtils", "interestsPrompt: $interestsPrompt")
   val alreadyPresentActivitiesPrompt =
       if (alreadyPresentActivities.isNotEmpty()) {
         "The following activities are already present in the trip: ${alreadyPresentActivities.joinToString(", ")}. Please avoid them."
       } else {
         ""
       }
-  Log.d("AssistantUtils", "alreadyPresentActivitiesPrompt: $alreadyPresentActivitiesPrompt")
-  val prompt =
+  val draftVsFinalPrompt =
       if (provideFinalActivities) {
-        """
-    Make a full schedule by listing activities, including separate activities for eating, transport, etc.
-    The trip, called ${trip.name}, takes place $datePrompt with the following prompt: $userPrompt. $interestsPrompt $alreadyPresentActivitiesPrompt $possibleEnumTypePrompt
-    Recommend multiple activities for each day.
-    """
-            .trimIndent()
+        "Make a full schedule by listing activities, including separate activities for eating, transport, etc."
       } else {
-        """
-    List a lot of popular specific activities to do on a trip called ${trip.name}.
-    The trip takes place $datePrompt with the following prompt: $userPrompt. $interestsPrompt $alreadyPresentActivitiesPrompt $possibleEnumTypePrompt
-    """
-            .trimIndent()
+        "List a lot of popular specific activities to do on a trip."
       }
-
+  val prompt =
+      """
+    $draftVsFinalPrompt The trip, called ${trip.name}, takes place $datePrompt with the following prompt: $userPrompt. $interestsPrompt $alreadyPresentActivitiesPrompt $possibleEnumTypePrompt
+      
+    """
+          .trimIndent()
   return prompt
 }

--- a/app/src/main/java/com/android/voyageur/model/assistant/AssistantUtils.kt
+++ b/app/src/main/java/com/android/voyageur/model/assistant/AssistantUtils.kt
@@ -151,13 +151,13 @@ fun generatePrompt(
       }
   val draftVsFinalPrompt =
       if (provideFinalActivities) {
-        "Make a full schedule by listing activities, including separate activities for eating, transport, etc."
+        "Make a full schedule by listing specific activities, including separate activities for eating, transport, etc. Instead of travel from airport, say just arrival n Paris in the afternoon, unless otherwise specified by the user."
       } else {
         "List a lot of popular specific activities to do on a trip."
       }
   val prompt =
       """
-    $draftVsFinalPrompt The trip, called ${trip.name}, takes place $datePrompt with the following prompt: $userPrompt. $interestsPrompt $alreadyPresentActivitiesPrompt $possibleEnumTypePrompt
+    $draftVsFinalPrompt The trip, called ${trip.name}, takes place $datePrompt with the following prompt: $userPrompt. Descriptions should be detailed. $interestsPrompt $alreadyPresentActivitiesPrompt $possibleEnumTypePrompt
       
     """
           .trimIndent()

--- a/app/src/main/java/com/android/voyageur/model/assistant/AssistantUtils.kt
+++ b/app/src/main/java/com/android/voyageur/model/assistant/AssistantUtils.kt
@@ -2,6 +2,7 @@ package com.android.voyageur.model.assistant
 
 import android.util.Log
 import com.android.voyageur.BuildConfig
+import com.android.voyageur.model.activity.ActivityType
 import com.android.voyageur.model.trip.Trip
 import com.google.ai.client.generativeai.GenerativeModel
 import com.google.ai.client.generativeai.type.FunctionType
@@ -126,6 +127,8 @@ fun generatePrompt(
     provideFinalActivities: Boolean,
     alreadyPresentActivities: List<String>
 ): String {
+    val possibleEnumTypePrompt = "The activity type can only be ${ActivityType.entries.joinToString { ", " }}"
+    Log.d("AssistantUtils", "possibleEnumTypePrompt: $possibleEnumTypePrompt")
   val startDate = getYearMonthDay(trip.startDate)
   val endDate = getYearMonthDay(trip.endDate)
   val datePrompt =
@@ -152,14 +155,14 @@ fun generatePrompt(
       if (provideFinalActivities) {
         """
     Make a full schedule by listing activities, including separate activities for eating, transport, etc.
-    The trip, called ${trip.name}, takes place $datePrompt with the following prompt: $userPrompt. $interestsPrompt $alreadyPresentActivitiesPrompt
+    The trip, called ${trip.name}, takes place $datePrompt with the following prompt: $userPrompt. $interestsPrompt $alreadyPresentActivitiesPrompt $possibleEnumTypePrompt
     Recommend multiple activities for each day.
     """
             .trimIndent()
       } else {
         """
     List a lot of popular specific activities to do on a trip called ${trip.name}.
-    The trip takes place $datePrompt with the following prompt: $userPrompt. $interestsPrompt $alreadyPresentActivitiesPrompt
+    The trip takes place $datePrompt with the following prompt: $userPrompt. $interestsPrompt $alreadyPresentActivitiesPrompt $possibleEnumTypePrompt
     """
             .trimIndent()
       }

--- a/app/src/main/java/com/android/voyageur/model/assistant/AssistantUtils.kt
+++ b/app/src/main/java/com/android/voyageur/model/assistant/AssistantUtils.kt
@@ -160,11 +160,9 @@ fun generatePrompt(
         "List a lot of popular specific activities to do on a trip."
       }
   val prompt =
-      """
-          $draftVsFinalPrompt The trip, called ${trip.name}, with description ${trip.description}, 
-          takes place $datePrompt with the following prompt: $userPrompt. Descriptions should be 
-          detailed. $interestsPrompt $alreadyPresentActivitiesPrompt $possibleEnumTypePrompt
-      """
-          .trimIndent()
+      "$draftVsFinalPrompt The trip, called ${trip.name}, with description ${trip.description} " +
+              "and location ${trip.location.name}, takes place $datePrompt with the following prompt:"+
+          " $userPrompt. Descriptions should be detailed. "+ interestsPrompt +
+              alreadyPresentActivitiesPrompt + possibleEnumTypePrompt
   return prompt
 }

--- a/app/src/main/java/com/android/voyageur/model/assistant/AssistantUtils.kt
+++ b/app/src/main/java/com/android/voyageur/model/assistant/AssistantUtils.kt
@@ -126,17 +126,22 @@ fun generatePrompt(
     provideFinalActivities: Boolean,
     alreadyPresentActivities: List<String>
 ): String {
+  // specifies which enum types are possible
   val possibleEnumTypePrompt =
       "The activity type can only be ${ActivityType.entries.joinToString(", ")}, " +
           "but you can recommend any activity and set the type to OTHER."
+
   val startDate = getYearMonthDay(trip.startDate)
   val endDate = getYearMonthDay(trip.endDate)
+  // specifies the date range of the trip
   val datePrompt =
       """
           between the start date year ${startDate.first} month ${startDate.second + 1} day ${startDate.third} 
           and the end date year ${endDate.first} month ${endDate.second + 1} day ${endDate.third}
       """
           .trimIndent()
+
+  // specifies the interests of the user (if non-empty)
   val interestsPrompt =
       if (interests.isNotEmpty()) {
         "The activities should focus on the following interests (if applicable): " +
@@ -144,6 +149,8 @@ fun generatePrompt(
       } else {
         ""
       }
+
+  // specifies the titles of the activities that are already present in the trip
   val alreadyPresentActivitiesPrompt =
       if (alreadyPresentActivities.isNotEmpty()) {
         "The following activities are already present in the trip: " +
@@ -151,6 +158,8 @@ fun generatePrompt(
       } else {
         ""
       }
+
+  // specifies whether the prompt is for recommending draft or final activities
   val draftVsFinalPrompt =
       if (provideFinalActivities) {
         "Make a full schedule by listing specific activities, including separate activities " +
@@ -159,6 +168,9 @@ fun generatePrompt(
       } else {
         "List a lot of popular specific activities to do on a trip."
       }
+
+  // combines all the prompts into a single prompt and mentions the trip name, description, and
+  // location
   val prompt =
       "$draftVsFinalPrompt The trip, called ${trip.name}, with description ${trip.description} " +
           "and location ${trip.location.name}, takes place $datePrompt with the following prompt:" +

--- a/app/src/main/java/com/android/voyageur/model/assistant/AssistantUtils.kt
+++ b/app/src/main/java/com/android/voyageur/model/assistant/AssistantUtils.kt
@@ -1,6 +1,5 @@
 package com.android.voyageur.model.assistant
 
-import android.util.Log
 import com.android.voyageur.BuildConfig
 import com.android.voyageur.model.activity.ActivityType
 import com.android.voyageur.model.trip.Trip
@@ -128,38 +127,44 @@ fun generatePrompt(
     alreadyPresentActivities: List<String>
 ): String {
   val possibleEnumTypePrompt =
-      "The activity type can only be ${ActivityType.entries.joinToString(", ")}, but you can recommend any activity and set the type to OTHER."
+      "The activity type can only be ${ActivityType.entries.joinToString(", ")}, " +
+          "but you can recommend any activity and set the type to OTHER."
   val startDate = getYearMonthDay(trip.startDate)
   val endDate = getYearMonthDay(trip.endDate)
   val datePrompt =
       """
           between the start date year ${startDate.first} month ${startDate.second + 1} day ${startDate.third} 
           and the end date year ${endDate.first} month ${endDate.second + 1} day ${endDate.third}
-            """
+      """
           .trimIndent()
   val interestsPrompt =
       if (interests.isNotEmpty()) {
-        "The activities should focus on the following interests (if applicable): ${interests.joinToString(", ")}."
+        "The activities should focus on the following interests (if applicable): " +
+            "${interests.joinToString(", ")}."
       } else {
         ""
       }
   val alreadyPresentActivitiesPrompt =
       if (alreadyPresentActivities.isNotEmpty()) {
-        "The following activities are already present in the trip: ${alreadyPresentActivities.joinToString(", ")}. Please avoid them."
+        "The following activities are already present in the trip: " +
+            "${alreadyPresentActivities.joinToString(", ")}. Please avoid them."
       } else {
         ""
       }
   val draftVsFinalPrompt =
       if (provideFinalActivities) {
-        "Make a full schedule by listing specific activities, including separate activities for eating, transport, etc. Instead of travel from airport, say just arrival n Paris in the afternoon, unless otherwise specified by the user."
+        "Make a full schedule by listing specific activities, including separate activities " +
+            "for eating, transport, etc. Instead of travel from airport, say just arrival in Paris " +
+            "in the afternoon, unless otherwise specified by the user."
       } else {
         "List a lot of popular specific activities to do on a trip."
       }
   val prompt =
       """
-    $draftVsFinalPrompt The trip, called ${trip.name}, takes place $datePrompt with the following prompt: $userPrompt. Descriptions should be detailed. $interestsPrompt $alreadyPresentActivitiesPrompt $possibleEnumTypePrompt
-      
-    """
+          $draftVsFinalPrompt The trip, called ${trip.name}, with description ${trip.description}, 
+          takes place $datePrompt with the following prompt: $userPrompt. Descriptions should be 
+          detailed. $interestsPrompt $alreadyPresentActivitiesPrompt $possibleEnumTypePrompt
+      """
           .trimIndent()
   return prompt
 }

--- a/app/src/main/java/com/android/voyageur/model/assistant/AssistantUtils.kt
+++ b/app/src/main/java/com/android/voyageur/model/assistant/AssistantUtils.kt
@@ -1,5 +1,6 @@
 package com.android.voyageur.model.assistant
 
+import android.util.Log
 import com.android.voyageur.BuildConfig
 import com.android.voyageur.model.trip.Trip
 import com.google.ai.client.generativeai.GenerativeModel
@@ -115,6 +116,7 @@ val generativeModel =
  * @param provideFinalActivities whether to provide final activities with date and time or just
  *   draft activities. In the case of draft activities, the prompt is a bit different to avoid
  *   recommending a lunch for each day more or less the same.
+ *     @param alreadyPresentActivities the activities that are already present in the trip
  * @return the prompt to send to use with the generative model
  */
 fun generatePrompt(
@@ -122,6 +124,7 @@ fun generatePrompt(
     userPrompt: String,
     interests: List<String>,
     provideFinalActivities: Boolean,
+    alreadyPresentActivities: List<String>
 ): String {
   val startDate = getYearMonthDay(trip.startDate)
   val endDate = getYearMonthDay(trip.endDate)
@@ -137,18 +140,26 @@ fun generatePrompt(
       } else {
         ""
       }
+  Log.d("AssistantUtils", "interestsPrompt: $interestsPrompt")
+  val alreadyPresentActivitiesPrompt =
+      if (alreadyPresentActivities.isNotEmpty()) {
+        "The following activities are already present in the trip: ${alreadyPresentActivities.joinToString(", ")}. Please avoid them."
+      } else {
+        ""
+      }
+  Log.d("AssistantUtils", "alreadyPresentActivitiesPrompt: $alreadyPresentActivitiesPrompt")
   val prompt =
       if (provideFinalActivities) {
         """
     Make a full schedule by listing activities, including separate activities for eating, transport, etc.
-    The trip, called ${trip.name}, takes place $datePrompt with the following prompt: $userPrompt. $interestsPrompt
+    The trip, called ${trip.name}, takes place $datePrompt with the following prompt: $userPrompt. $interestsPrompt $alreadyPresentActivitiesPrompt
     Recommend multiple activities for each day.
     """
             .trimIndent()
       } else {
         """
     List a lot of popular specific activities to do on a trip called ${trip.name}.
-    The trip takes place $datePrompt with the following prompt: $userPrompt. $interestsPrompt
+    The trip takes place $datePrompt with the following prompt: $userPrompt. $interestsPrompt $alreadyPresentActivitiesPrompt
     """
             .trimIndent()
       }

--- a/app/src/main/java/com/android/voyageur/model/trip/TripsViewModel.kt
+++ b/app/src/main/java/com/android/voyageur/model/trip/TripsViewModel.kt
@@ -204,7 +204,12 @@ open class TripsViewModel(
       try {
         val response =
             generativeModel.generateContent(
-                generatePrompt(trip, userPrompt, interests, provideFinalActivities))
+                generatePrompt(
+                    trip,
+                    userPrompt,
+                    interests,
+                    provideFinalActivities,
+                    getActivitiesForSelectedTrip().map { it.title }))
         response.text?.let { outputContent -> _uiState.value = UiState.Success(outputContent) }
       } catch (e: Exception) {
         _uiState.value = UiState.Error(e.localizedMessage ?: "unknown error")

--- a/app/src/test/java/com/android/voyageur/model/assistant/AssistantUtilsTest.kt
+++ b/app/src/test/java/com/android/voyageur/model/assistant/AssistantUtilsTest.kt
@@ -25,16 +25,19 @@ class GeneratePromptTest {
             trip = trip,
             userPrompt = userPrompt,
             interests = emptyList(),
-            provideFinalActivities = provideFinalActivities)
+            provideFinalActivities = provideFinalActivities,
+            alreadyPresentActivities = listOf("Explore beaches", "try local cuisine"))
     println(prompt)
 
     assertTrue(prompt.contains("Summer Adventure"))
     assertTrue(prompt.contains("start date year 2024 month 7 day 1"))
     assertTrue(prompt.contains("end date year 2024 month 7 day 7"))
     assertTrue(prompt.contains("Make a full schedule by listing activities"))
-    assertTrue(prompt.contains("Explore beaches and try local cuisine"))
+    assertTrue(prompt.contains("Explore beaches", "try local cuisine"))
     assertFalse(prompt.contains("hiking"))
     assertFalse(prompt.contains("cycling"))
+    assertFalse(prompt.contains("Explore beaches"))
+    assertFalse(prompt.contains("try local cuisine"))
   }
 
   @Test
@@ -53,7 +56,8 @@ class GeneratePromptTest {
             trip = trip,
             userPrompt = userPrompt,
             interests = emptyList(),
-            provideFinalActivities = provideFinalActivities)
+            provideFinalActivities = provideFinalActivities,
+            alreadyPresentActivities = listOf("Walk", "Visit museum"))
 
     assertTrue(prompt.contains("Winter Wonderland"))
     assertTrue(prompt.contains("start date year 2024 month 12 day 20"))
@@ -62,6 +66,9 @@ class GeneratePromptTest {
     assertTrue(prompt.contains("Enjoy snowy landscapes and Christmas markets"))
     assertFalse(prompt.contains("hiking"))
     assertFalse(prompt.contains("cycling"))
+    assertTrue(prompt.contains("Walk"))
+    assertTrue(prompt.contains("Visit museum"))
+
   }
 
   @Test
@@ -76,7 +83,7 @@ class GeneratePromptTest {
     val provideFinalActivities = false
     val interests = listOf("hiking", "cycling")
 
-    val prompt = generatePrompt(trip, userPrompt, interests, provideFinalActivities)
+    val prompt = generatePrompt(trip, userPrompt, interests, provideFinalActivities, listOf("Walk"))
 
     assertTrue(prompt.contains("Spring Break"))
     assertTrue(prompt.contains("start date year 2024 month 3 day 1"))
@@ -99,7 +106,7 @@ class GeneratePromptTest {
     val provideFinalActivities = true
     val interests = listOf("hiking", "cycling")
 
-    val prompt = generatePrompt(trip, userPrompt, interests, provideFinalActivities)
+    val prompt = generatePrompt(trip, userPrompt, interests, provideFinalActivities, listOf("Swimming"))
 
     assertTrue(prompt.contains("Spring Break"))
     assertTrue(prompt.contains("start date year 2024 month 3 day 1"))

--- a/app/src/test/java/com/android/voyageur/model/assistant/AssistantUtilsTest.kt
+++ b/app/src/test/java/com/android/voyageur/model/assistant/AssistantUtilsTest.kt
@@ -1,5 +1,6 @@
 package com.android.voyageur.model.assistant
 
+import com.android.voyageur.model.location.Location
 import com.android.voyageur.model.trip.Trip
 import com.google.firebase.Timestamp
 import java.util.Calendar
@@ -168,11 +169,12 @@ class GeneratePromptTest {
   }
 
   @Test
-  fun testTripTitleAndDescriptionAreIncluded() {
+  fun testTripDetailsAreIncluded() {
     val trip =
         Trip(
             name = "Trip Name",
             description = "Trip Description",
+            location = Location(id = "", name ="Location Name"),
             startDate = createTimestamp(2024, 7, 1),
             endDate = createTimestamp(2024, 7, 7))
 
@@ -184,8 +186,31 @@ class GeneratePromptTest {
             provideFinalActivities = false,
             alreadyPresentActivities = emptyList())
 
-    assertTrue(prompt.contains("The trip, called Trip Name, with description Trip Description"))
+    assertTrue(prompt.contains("The trip, called Trip Name"))
+            assertTrue(prompt.contains("description Trip Description"))
+            assertTrue(prompt.contains("location Location Name"))
   }
+
+    @Test
+    fun testUserPromptIsIncluded() {
+        val trip =
+            Trip(
+                name = "Trip Name",
+                startDate = createTimestamp(2024, 7, 1),
+                endDate = createTimestamp(2024, 7, 7)
+            )
+
+        val prompt =
+            generatePrompt(
+                trip = trip,
+                userPrompt = "User Prompt",
+                interests = emptyList(),
+                provideFinalActivities = false,
+                alreadyPresentActivities = emptyList()
+            )
+
+        assertTrue(prompt.contains("with the following prompt: User Prompt"))
+    }
 
   // Helper function to create a Timestamp from year, month, and day
   private fun createTimestamp(year: Int, month: Int, day: Int): Timestamp {

--- a/app/src/test/java/com/android/voyageur/model/assistant/AssistantUtilsTest.kt
+++ b/app/src/test/java/com/android/voyageur/model/assistant/AssistantUtilsTest.kt
@@ -10,111 +10,181 @@ import org.junit.Test
 class GeneratePromptTest {
 
   @Test
-  fun testGeneratePromptForFinalActivitiesWithoutInterests() {
+  fun testDatePromptGeneratesCorrectly() {
     val trip =
         Trip(
-            name = "Summer Adventure",
+            name = "Trip Name",
             startDate = createTimestamp(2024, 7, 1),
             endDate = createTimestamp(2024, 7, 7))
 
-    val userPrompt = "Explore beaches and try local cuisine"
-    val provideFinalActivities = true
-
     val prompt =
         generatePrompt(
             trip = trip,
-            userPrompt = userPrompt,
+            userPrompt = "",
             interests = emptyList(),
-            provideFinalActivities = provideFinalActivities,
-            alreadyPresentActivities = listOf("Explore beaches", "try local cuisine"))
-    println(prompt)
+            provideFinalActivities = false,
+            alreadyPresentActivities = emptyList())
 
-    assertTrue(prompt.contains("Summer Adventure"))
     assertTrue(prompt.contains("start date year 2024 month 7 day 1"))
     assertTrue(prompt.contains("end date year 2024 month 7 day 7"))
-    assertTrue(prompt.contains("Make a full schedule by listing activities"))
-    assertTrue(prompt.contains("Explore beaches", "try local cuisine"))
-    assertFalse(prompt.contains("hiking"))
-    assertFalse(prompt.contains("cycling"))
-    assertFalse(prompt.contains("Explore beaches"))
-    assertFalse(prompt.contains("try local cuisine"))
   }
 
   @Test
-  fun testGeneratePromptForDraftActivitiesWithoutInterests() {
+  fun testInterestsPromptGeneratesCorrectly() {
     val trip =
         Trip(
-            name = "Winter Wonderland",
-            startDate = createTimestamp(2024, 12, 20),
-            endDate = createTimestamp(2024, 12, 27))
-
-    val userPrompt = "Enjoy snowy landscapes and Christmas markets"
-    val provideFinalActivities = false
+            name = "Trip Name",
+            startDate = createTimestamp(2024, 7, 1),
+            endDate = createTimestamp(2024, 7, 7))
 
     val prompt =
         generatePrompt(
             trip = trip,
-            userPrompt = userPrompt,
+            userPrompt = "",
+            interests = listOf("hiking", "cycling"),
+            provideFinalActivities = false,
+            alreadyPresentActivities = emptyList())
+
+    assertTrue(
+        prompt.contains(
+            "The activities should focus on the following interests (if applicable): hiking, cycling."))
+  }
+
+  @Test
+  fun testEmptyInterestsIsNotGenerated() {
+    val trip =
+        Trip(
+            name = "Trip Name",
+            startDate = createTimestamp(2024, 7, 1),
+            endDate = createTimestamp(2024, 7, 7))
+
+    val prompt =
+        generatePrompt(
+            trip = trip,
+            userPrompt = "",
             interests = emptyList(),
-            provideFinalActivities = provideFinalActivities,
-            alreadyPresentActivities = listOf("Walk", "Visit museum"))
+            provideFinalActivities = false,
+            alreadyPresentActivities = emptyList())
 
-    assertTrue(prompt.contains("Winter Wonderland"))
-    assertTrue(prompt.contains("start date year 2024 month 12 day 20"))
-    assertTrue(prompt.contains("end date year 2024 month 12 day 27"))
-    assertTrue(prompt.contains("List a lot of popular specific activities"))
-    assertTrue(prompt.contains("Enjoy snowy landscapes and Christmas markets"))
-    assertFalse(prompt.contains("hiking"))
-    assertFalse(prompt.contains("cycling"))
-    assertTrue(prompt.contains("Walk"))
-    assertTrue(prompt.contains("Visit museum"))
-
+    assertFalse(
+        prompt.contains("The activities should focus on the following interests (if applicable):"))
   }
 
   @Test
-  fun testGeneratePromptWithInterests() {
+  fun testEnumTypePromptGeneratesCorrectly() {
     val trip =
         Trip(
-            name = "Spring Break",
-            startDate = createTimestamp(2024, 3, 1),
-            endDate = createTimestamp(2024, 3, 7))
+            name = "Trip Name",
+            startDate = createTimestamp(2024, 7, 1),
+            endDate = createTimestamp(2024, 7, 7))
 
-    val userPrompt = "Relax and have fun"
-    val provideFinalActivities = false
-    val interests = listOf("hiking", "cycling")
+    val prompt =
+        generatePrompt(
+            trip = trip,
+            userPrompt = "",
+            interests = emptyList(),
+            provideFinalActivities = false,
+            alreadyPresentActivities = emptyList())
 
-    val prompt = generatePrompt(trip, userPrompt, interests, provideFinalActivities, listOf("Walk"))
-
-    assertTrue(prompt.contains("Spring Break"))
-    assertTrue(prompt.contains("start date year 2024 month 3 day 1"))
-    assertTrue(prompt.contains("end date year 2024 month 3 day 7"))
-    assertTrue(prompt.contains("List a lot of popular specific activities"))
-    assertTrue(prompt.contains("Relax and have fun"))
-    assertTrue(prompt.contains("hiking"))
-    assertTrue(prompt.contains("cycling"))
+    assertTrue(prompt.contains("The activity type can only be"))
   }
 
   @Test
-  fun testGeneratePromptWithInterestsAndFinalActivities() {
+  fun testAlreadyPresentActivitiesPromptGeneratesCorrectly() {
     val trip =
         Trip(
-            name = "Spring Break",
-            startDate = createTimestamp(2024, 3, 1),
-            endDate = createTimestamp(2024, 3, 7))
+            name = "Trip Name",
+            startDate = createTimestamp(2024, 7, 1),
+            endDate = createTimestamp(2024, 7, 7))
 
-    val userPrompt = "Relax and have fun"
-    val provideFinalActivities = true
-    val interests = listOf("hiking", "cycling")
+    val prompt =
+        generatePrompt(
+            trip = trip,
+            userPrompt = "",
+            interests = emptyList(),
+            provideFinalActivities = false,
+            alreadyPresentActivities = listOf("activity1", "activity2"))
 
-    val prompt = generatePrompt(trip, userPrompt, interests, provideFinalActivities, listOf("Swimming"))
+    assertTrue(
+        prompt.contains(
+            "The following activities are already present in the trip: activity1, activity2. Please avoid them."))
+  }
 
-    assertTrue(prompt.contains("Spring Break"))
-    assertTrue(prompt.contains("start date year 2024 month 3 day 1"))
-    assertTrue(prompt.contains("end date year 2024 month 3 day 7"))
-    assertTrue(prompt.contains("Make a full schedule by listing activities"))
-    assertTrue(prompt.contains("Relax and have fun"))
-    assertTrue(prompt.contains("hiking"))
-    assertTrue(prompt.contains("cycling"))
+  @Test
+  fun testEmptyAlreadyPresentActivitiesIsNotGenerated() {
+    val trip =
+        Trip(
+            name = "Trip Name",
+            startDate = createTimestamp(2024, 7, 1),
+            endDate = createTimestamp(2024, 7, 7))
+
+    val prompt =
+        generatePrompt(
+            trip = trip,
+            userPrompt = "",
+            interests = emptyList(),
+            provideFinalActivities = false,
+            alreadyPresentActivities = emptyList())
+
+    assertFalse(prompt.contains("The following activities are already present in the trip:"))
+  }
+
+  @Test
+  fun testDraftActivitiesPromptGeneratesCorrectly() {
+    val trip =
+        Trip(
+            name = "Trip Name",
+            startDate = createTimestamp(2024, 7, 1),
+            endDate = createTimestamp(2024, 7, 7))
+
+    val prompt =
+        generatePrompt(
+            trip = trip,
+            userPrompt = "",
+            interests = emptyList(),
+            provideFinalActivities = false,
+            alreadyPresentActivities = emptyList())
+
+    assertTrue(prompt.contains("List a lot of popular specific activities"))
+  }
+
+  @Test
+  fun testFinalActivitiesPromptGeneratesCorrectly() {
+    val trip =
+        Trip(
+            name = "Trip Name",
+            startDate = createTimestamp(2024, 7, 1),
+            endDate = createTimestamp(2024, 7, 7))
+
+    val prompt =
+        generatePrompt(
+            trip = trip,
+            userPrompt = "",
+            interests = emptyList(),
+            provideFinalActivities = true,
+            alreadyPresentActivities = emptyList())
+
+    assertTrue(prompt.contains("Make a full schedule by listing specific activities"))
+  }
+
+  @Test
+  fun testTripTitleAndDescriptionAreIncluded() {
+    val trip =
+        Trip(
+            name = "Trip Name",
+            description = "Trip Description",
+            startDate = createTimestamp(2024, 7, 1),
+            endDate = createTimestamp(2024, 7, 7))
+
+    val prompt =
+        generatePrompt(
+            trip = trip,
+            userPrompt = "",
+            interests = emptyList(),
+            provideFinalActivities = false,
+            alreadyPresentActivities = emptyList())
+
+    assertTrue(prompt.contains("The trip, called Trip Name, with description Trip Description"))
   }
 
   // Helper function to create a Timestamp from year, month, and day

--- a/app/src/test/java/com/android/voyageur/model/assistant/AssistantUtilsTest.kt
+++ b/app/src/test/java/com/android/voyageur/model/assistant/AssistantUtilsTest.kt
@@ -174,7 +174,7 @@ class GeneratePromptTest {
         Trip(
             name = "Trip Name",
             description = "Trip Description",
-            location = Location(id = "", name ="Location Name"),
+            location = Location(id = "", name = "Location Name"),
             startDate = createTimestamp(2024, 7, 1),
             endDate = createTimestamp(2024, 7, 7))
 
@@ -187,30 +187,28 @@ class GeneratePromptTest {
             alreadyPresentActivities = emptyList())
 
     assertTrue(prompt.contains("The trip, called Trip Name"))
-            assertTrue(prompt.contains("description Trip Description"))
-            assertTrue(prompt.contains("location Location Name"))
+    assertTrue(prompt.contains("description Trip Description"))
+    assertTrue(prompt.contains("location Location Name"))
   }
 
-    @Test
-    fun testUserPromptIsIncluded() {
-        val trip =
-            Trip(
-                name = "Trip Name",
-                startDate = createTimestamp(2024, 7, 1),
-                endDate = createTimestamp(2024, 7, 7)
-            )
+  @Test
+  fun testUserPromptIsIncluded() {
+    val trip =
+        Trip(
+            name = "Trip Name",
+            startDate = createTimestamp(2024, 7, 1),
+            endDate = createTimestamp(2024, 7, 7))
 
-        val prompt =
-            generatePrompt(
-                trip = trip,
-                userPrompt = "User Prompt",
-                interests = emptyList(),
-                provideFinalActivities = false,
-                alreadyPresentActivities = emptyList()
-            )
+    val prompt =
+        generatePrompt(
+            trip = trip,
+            userPrompt = "User Prompt",
+            interests = emptyList(),
+            provideFinalActivities = false,
+            alreadyPresentActivities = emptyList())
 
-        assertTrue(prompt.contains("with the following prompt: User Prompt"))
-    }
+    assertTrue(prompt.contains("with the following prompt: User Prompt"))
+  }
 
   // Helper function to create a Timestamp from year, month, and day
   private fun createTimestamp(year: Int, month: Int, day: Int): Timestamp {


### PR DESCRIPTION
## Summary

Following tis change the assistant won't recommend activities that already exist in the trip to the user. Also, now the assistant takes into account the trip description and location as well when making recommendations.

## Changes

Most of the changes live in `AssistantUtils.kt` where the prompt is generated. I also added more granular tests for the `generatePrompt` method.

## Checklist

- [x] This PR resolves #262 
- [x] Tests have been added for new functionality.
- [x] Screenshots or UI changes have been attached (if applicable).
- [x] Documentation has been updated (if applicable).

##  Testing

Explain how this feature was tested and what kind of testing (unit, integration, UI) has been done. Mention platforms or configurations used for testing.
- **Manual Testing:**
    - [x] Tested on emulator / physical device.
- **Unit Tests**
    - [x] Added units tests for this

## Screenshots (if applicable)

This video demonstrates how the assistant takes into consideration the description(surfing) and the location (Ericeira). Also, once the surfing lesson is added to the trip, the assistant doesn't recommend it anymore.

https://github.com/user-attachments/assets/6e3f3a8e-3bfe-4cd0-a2ce-a6bc536f30bd

