### PR TITLE
remove deprecated creator field and update tests

### DIFF
--- a/app/src/androidTest/java/com/android/voyageur/ui/overview/AddTripTest.kt
+++ b/app/src/androidTest/java/com/android/voyageur/ui/overview/AddTripTest.kt
@@ -192,7 +192,6 @@ class AddTripScreenTest {
     val expectedTrip =
         Trip(
             id = "mockTripId",
-            creator = "mockUserId",
             description = "Description for trip with unknown location",
             name = "Trip with Unknown Location",
             location = Location(name = "Big Ben Cafe"),
@@ -232,7 +231,6 @@ class AddTripScreenTest {
     val trip =
         Trip(
             id = "editTripId",
-            creator = "mockUserId",
             description = "Existing trip",
             name = "Existing Trip",
             location = Location(name = "Big Ben Cafe"),
@@ -258,7 +256,6 @@ class AddTripScreenTest {
     val trip =
         Trip(
             id = "editTripId",
-            creator = "mockUserId",
             description = "Existing trip",
             name = "Existing Trip",
             location = Location(name = "Big Ben Cafe"),

--- a/app/src/androidTest/java/com/android/voyageur/ui/overview/OverviewScreenTest.kt
+++ b/app/src/androidTest/java/com/android/voyageur/ui/overview/OverviewScreenTest.kt
@@ -91,7 +91,6 @@ class OverviewScreenTest {
         listOf(
             Trip(
                 id = "1",
-                creator = "Andreea",
                 participants = listOf("Alex", "Mihai", "Ioana", "Andrei", "Maria", "Matei"),
                 name = "Paris Trip"))
     `when`(tripRepository.getTrips(any(), any(), any())).then {
@@ -109,9 +108,7 @@ class OverviewScreenTest {
 
   @Test
   fun noParticipantsDisplaysNoAvatars() {
-    val mockTrips =
-        listOf(
-            Trip(id = "23", creator = "Andreea", participants = emptyList(), name = "Paris Trip"))
+    val mockTrips = listOf(Trip(id = "23", participants = emptyList(), name = "Paris Trip"))
     `when`(tripRepository.getTrips(any(), any(), any())).then {
       it.getArgument<(List<Trip>) -> Unit>(1)(mockTrips)
     }
@@ -124,12 +121,7 @@ class OverviewScreenTest {
 
   @Test
   fun clickingTripCardNavigatesToTripDetails() {
-    val mockTrip =
-        Trip(
-            id = "1",
-            creator = "Andreea",
-            participants = listOf("Alex", "Mihai"),
-            name = "Paris Trip")
+    val mockTrip = Trip(id = "1", participants = listOf("Alex", "Mihai"), name = "Paris Trip")
     val mockTrips = listOf(mockTrip)
 
     `when`(tripRepository.getTrips(any(), any(), any())).then {
@@ -145,12 +137,7 @@ class OverviewScreenTest {
 
   @Test
   fun clickingTripCardUpdatesNavigationState() {
-    val mockTrip =
-        Trip(
-            id = "1",
-            creator = "Andreea",
-            participants = listOf("Alex", "Mihai"),
-            name = "Paris Trip")
+    val mockTrip = Trip(id = "1", participants = listOf("Alex", "Mihai"), name = "Paris Trip")
     val mockTrips = listOf(mockTrip)
 
     // Simulate getting the mock trip from the repository
@@ -196,7 +183,6 @@ class OverviewScreenTest {
     val mockTrip =
         Trip(
             id = "1",
-            creator = "Andreea",
             participants = listOf("Alex"),
             name = "Paris Trip",
             imageUri = "https://example.com/image.jpg",
@@ -216,7 +202,6 @@ class OverviewScreenTest {
     val mockTrip =
         Trip(
             id = "1",
-            creator = "Andreea",
             participants = listOf("Alex"),
             name = "Paris Trip",
             imageUri = "",
@@ -236,7 +221,6 @@ class OverviewScreenTest {
     val mockTrip =
         Trip(
             id = "1",
-            creator = "Andreea",
             participants = listOf("Alex"),
             name = "Paris Trip",
             imageUri = "",

--- a/app/src/androidTest/java/com/android/voyageur/ui/trip/AddActivityTest.kt
+++ b/app/src/androidTest/java/com/android/voyageur/ui/trip/AddActivityTest.kt
@@ -307,7 +307,6 @@ class AddActivityScreenTest {
     val trip =
         Trip(
             id = "editTripId",
-            creator = "mockUserId",
             description = "Existing trip",
             name = "Existing Trip",
             location = Location(name = "Paris"),

--- a/app/src/androidTest/java/com/android/voyageur/ui/trip/TripTest.kt
+++ b/app/src/androidTest/java/com/android/voyageur/ui/trip/TripTest.kt
@@ -17,7 +17,6 @@ class TripTest {
     val trip1 =
         Trip(
             id = "1",
-            creator = "creator1",
             participants = participants,
             description = "Trip Description",
             name = "Trip Name",
@@ -31,7 +30,6 @@ class TripTest {
     val trip2 =
         Trip(
             id = "1",
-            creator = "creator1",
             participants = participants,
             description = "Trip Description",
             name = "Trip Name",
@@ -47,15 +45,9 @@ class TripTest {
 
   @Test
   fun tripInstancesWithDifferentFieldsShouldNotBeEqual() {
-    val trip1 =
-        Trip(id = "1", creator = "creator1", description = "Trip Description", name = "Trip Name")
+    val trip1 = Trip(id = "1", description = "Trip Description", name = "Trip Name")
 
-    val trip2 =
-        Trip(
-            id = "2",
-            creator = "creator2",
-            description = "Different Description",
-            name = "Different Name")
+    val trip2 = Trip(id = "2", description = "Different Description", name = "Different Name")
 
     assert(!trip1.equals(trip2))
   }
@@ -68,15 +60,14 @@ class TripTest {
 
   @Test
   fun equalsShouldHandleNullAndDifferentObjectTypes() {
-    val trip = Trip(id = "1", creator = "creator1")
+    val trip = Trip(id = "1")
 
     assert(!trip.equals(null))
   }
 
   @Test
   fun hashCodeShouldBeConsistentForTheSameObject() {
-    val trip =
-        Trip(id = "1", creator = "creator1", description = "Trip Description", name = "Trip Name")
+    val trip = Trip(id = "1", description = "Trip Description", name = "Trip Name")
 
     val initialHashCode = trip.hashCode()
     assert(trip.hashCode() == initialHashCode)
@@ -87,7 +78,6 @@ class TripTest {
     val trip = Trip()
 
     assert(trip.id.isEmpty())
-    assert(trip.creator.isEmpty())
     assert(trip.participants.isEmpty())
     assert(trip.description.isEmpty())
     assert(trip.name.isEmpty())

--- a/app/src/main/java/com/android/voyageur/model/trip/Trip.kt
+++ b/app/src/main/java/com/android/voyageur/model/trip/Trip.kt
@@ -23,7 +23,6 @@ import com.google.firebase.firestore.Exclude
  */
 data class Trip(
     val id: String = "",
-    val creator: String = "",
     val participants: List<String> = emptyList(),
     val description: String = "",
     val name: String = "",
@@ -55,7 +54,6 @@ data class Trip(
     if (other !is Trip) return false
 
     return id == other.id &&
-        creator == other.creator &&
         participants == other.participants &&
         description == other.description &&
         name == other.name &&
@@ -75,7 +73,6 @@ data class Trip(
    */
   override fun hashCode(): Int {
     var result = id.hashCode()
-    result = 31 * result + creator.hashCode()
     result = 31 * result + participants.hashCode()
     result = 31 * result + description.hashCode()
     result = 31 * result + name.hashCode()

--- a/app/src/main/java/com/android/voyageur/model/trip/TripRepositoryFirebase.kt
+++ b/app/src/main/java/com/android/voyageur/model/trip/TripRepositoryFirebase.kt
@@ -83,7 +83,7 @@ class TripRepositoryFirebase(private val db: FirebaseFirestore) : TripRepository
           val trips =
               result
                   .map { document -> document.toObject(Trip::class.java) }
-                  .filter { it.creator != userId && !it.participants.contains(userId) }
+                  .filter { !it.participants.contains(userId) }
           onSuccess(trips)
         }
         .addOnFailureListener { exception ->

--- a/app/src/main/java/com/android/voyageur/ui/overview/AddTrip.kt
+++ b/app/src/main/java/com/android/voyageur/ui/overview/AddTrip.kt
@@ -234,7 +234,6 @@ fun AddTripScreen(
             id =
                 if (isEditMode) tripsViewModel.selectedTrip.value!!.id
                 else tripsViewModel.getNewTripId(),
-            creator = Firebase.auth.uid.orEmpty(),
             description = description,
             name = name,
             participants =

--- a/app/src/test/java/com/android/voyageur/model/trip/TripRepositoryFirebaseTest.kt
+++ b/app/src/test/java/com/android/voyageur/model/trip/TripRepositoryFirebaseTest.kt
@@ -46,7 +46,6 @@ class TripRepositoryFirebaseTest {
   private val trip =
       Trip(
           "1",
-          "creator",
           listOf("creator"),
           "description",
           "name",

--- a/app/src/test/java/com/android/voyageur/model/trip/TripsViewModelTest.kt
+++ b/app/src/test/java/com/android/voyageur/model/trip/TripsViewModelTest.kt
@@ -39,7 +39,6 @@ class TripsViewModelTest {
   private val trip =
       Trip(
           "1",
-          "creator",
           emptyList(),
           "description",
           "name",
@@ -80,7 +79,6 @@ class TripsViewModelTest {
         listOf(
             Trip(
                 "1",
-                "creator",
                 emptyList(),
                 "description",
                 "name",
@@ -315,7 +313,6 @@ class TripsViewModelTest {
     val trip =
         Trip(
             id = "1",
-            creator = "creator",
             participants = emptyList(),
             description = "Trip description",
             name = "Trip name",


### PR DESCRIPTION
## Summary
In this PR I removed the deprecated creator field, as the creator will be included in the participants anyways and there are no differences regarding permissions.

Closes #288

## Changes

- **Models:** remove `creator` field from the `Trip` model


## Checklist
- [x] This PR resolves #288 
- [x] Tests have been updated for new functionality.

