### PR TITLE
Feat: Add backend support for trip invites

### DIFF
--- a/app/src/androidTest/java/com/android/voyageur/ui/overview/OverviewScreenTest.kt
+++ b/app/src/androidTest/java/com/android/voyageur/ui/overview/OverviewScreenTest.kt
@@ -249,7 +249,6 @@ class OverviewScreenTest {
     val mockTrip =
         Trip(
             id = "1",
-            creator = "Andreea",
             participants = listOf("Alex"),
             name = "Paris Trip",
             imageUri = "",
@@ -274,7 +273,6 @@ class OverviewScreenTest {
     val mockTrip =
         Trip(
             id = "1",
-            creator = "Andreea",
             participants = listOf("Alex"),
             name = "Paris Trip",
             startDate = Timestamp.now(),

--- a/app/src/main/java/com/android/voyageur/model/notifications/TripInvite.kt
+++ b/app/src/main/java/com/android/voyageur/model/notifications/TripInvite.kt
@@ -1,0 +1,30 @@
+package com.android.voyageur.model.notifications
+
+data class TripInvite(
+    val id: String,
+    val tripId: String,
+    val from: String,
+    val to: String,
+) {
+  override fun equals(other: Any?): Boolean {
+    if (this === other) return true
+    if (javaClass != other?.javaClass) return false
+
+    other as TripInvite
+
+    if (id != other.id) return false
+    if (tripId != other.tripId) return false
+    if (from != other.from) return false
+    if (to != other.to) return false
+
+    return true
+  }
+
+  override fun hashCode(): Int {
+    var result = id.hashCode()
+    result = 31 * result + tripId.hashCode()
+    result = 31 * result + from.hashCode()
+    result = 31 * result + to.hashCode()
+    return result
+  }
+}

--- a/app/src/main/java/com/android/voyageur/model/notifications/TripInviteRepository.kt
+++ b/app/src/main/java/com/android/voyageur/model/notifications/TripInviteRepository.kt
@@ -1,0 +1,40 @@
+package com.android.voyageur.model.notifications
+
+import com.google.firebase.firestore.ListenerRegistration
+
+interface TripInviteRepository {
+
+  fun init(onSuccess: () -> Unit)
+
+  fun getTripInvites(
+      userId: String,
+      onSuccess: (List<TripInvite>) -> Unit,
+      onFailure: (Exception) -> Unit
+  )
+
+  fun getTripInvitesCount(userId: String, onSuccess: (Long) -> Unit, onFailure: (Exception) -> Unit)
+
+  fun createTripInvite(req: TripInvite, onSuccess: () -> Unit, onFailure: (Exception) -> Unit)
+
+  fun deleteTripInvite(invite: String, onSuccess: () -> Unit, onFailure: (Exception) -> Unit)
+
+  fun getNewId(): String
+
+  fun listenToSentTripInvites(
+      userId: String,
+      onSuccess: (List<TripInvite>) -> Unit,
+      onFailure: (Exception) -> Unit
+  ): ListenerRegistration
+
+  fun listenToTripInvites(
+      userId: String,
+      onSuccess: (List<TripInvite>) -> Unit,
+      onFailure: (Exception) -> Unit
+  ): ListenerRegistration
+
+  fun getInvitesForTrip(
+      tripId: String,
+      onSuccess: (List<TripInvite>) -> Unit,
+      onFailure: (Exception) -> Unit
+  )
+}

--- a/app/src/main/java/com/android/voyageur/model/notifications/TripInviteRepositoryFirebase.kt
+++ b/app/src/main/java/com/android/voyageur/model/notifications/TripInviteRepositoryFirebase.kt
@@ -1,0 +1,196 @@
+package com.android.voyageur.model.notifications
+
+import com.google.firebase.firestore.AggregateSource
+import com.google.firebase.firestore.FirebaseFirestore
+import com.google.firebase.firestore.ListenerRegistration
+import com.google.firebase.firestore.SetOptions
+
+/**
+ * Used for displaying trip invites and notifications Appears as a parameter to the ${UserViewModel}
+ *
+ * @param db the firestore instance to use
+ * @param collectionPath the path to the collection of trip invites
+ * @constructor creates a new TripInviteRepositoryFirebase
+ * @property db the firestore instance to use
+ * @property collectionPath the path to the collection of trip invites
+ */
+class TripInviteRepositoryFirebase(private val db: FirebaseFirestore) : TripInviteRepository {
+  private val collectionPath = "friendRequests"
+
+  override fun init(onSuccess: () -> Unit) {
+    db.collection(collectionPath).get().addOnSuccessListener { onSuccess() }
+  }
+
+  /**
+   * Get the number of trip invites for a user
+   *
+   * @param userId the user to get the number of trip invites for
+   * @param onSuccess callback to execute after successful fetch
+   * @param onFailure exception handling callback
+   */
+  override fun getTripInvitesCount(
+      userId: String,
+      onSuccess: (Long) -> Unit,
+      onFailure: (Exception) -> Unit
+  ) {
+    db.collection(collectionPath)
+        .whereEqualTo("to", userId)
+        .count()
+        .get(AggregateSource.SERVER)
+        .addOnSuccessListener { onSuccess(it.count) }
+        .addOnFailureListener { exception -> onFailure(exception) }
+  }
+
+  /**
+   * Create a trip invite
+   *
+   * @param req the trip invite to create
+   * @param onSuccess callback to execute after successful creation
+   * @param onFailure exception handling callback
+   */
+  override fun createTripInvite(
+      req: TripInvite,
+      onSuccess: () -> Unit,
+      onFailure: (Exception) -> Unit
+  ) {
+    db.collection(collectionPath)
+        .document(req.id)
+        .set(req, SetOptions.merge())
+        .addOnSuccessListener { onSuccess() }
+        .addOnFailureListener { exception -> onFailure(exception) }
+  }
+
+  /**
+   * Get all trip invites for a user
+   *
+   * @param userId the user to get the trip invites for
+   * @param onSuccess callback to execute after successful fetch
+   * @param onFailure exception handling callback
+   */
+  override fun getTripInvites(
+      userId: String,
+      onSuccess: (List<TripInvite>) -> Unit,
+      onFailure: (Exception) -> Unit
+  ) {
+    db.collection(collectionPath)
+        .whereEqualTo("to", userId)
+        .get()
+        .addOnSuccessListener { result ->
+          val invites = result.map { document -> document.toObject(TripInvite::class.java) }
+          onSuccess(invites)
+        }
+        .addOnFailureListener { exception -> onFailure(exception) }
+  }
+
+  /**
+   * Delete a trip invite
+   *
+   * @param invite the trip invite to delete
+   * @param onSuccess callback to execute after successful deletion
+   * @param onFailure exception handling callback
+   */
+  override fun deleteTripInvite(
+      invite: String,
+      onSuccess: () -> Unit,
+      onFailure: (Exception) -> Unit
+  ) {
+    db.collection(collectionPath)
+        .document(invite)
+        .delete()
+        .addOnSuccessListener { onSuccess() }
+        .addOnFailureListener { exception -> onFailure(exception) }
+  }
+
+  /**
+   * Get a new trip invite ID
+   *
+   * @return the new trip invite ID
+   */
+  override fun getNewId(): String {
+    return db.collection(collectionPath).document().id
+  }
+
+  /**
+   * Listen to trip invites sent by a user
+   *
+   * @param userId the user to listen to trip invites for
+   * @param onSuccess callback to execute after successful fetch
+   * @param onFailure exception handling callback
+   * @return a listener registration
+   */
+  override fun listenToSentTripInvites(
+      userId: String,
+      onSuccess: (List<TripInvite>) -> Unit,
+      onFailure: (Exception) -> Unit
+  ): ListenerRegistration {
+    return db.collection("friendRequests").whereEqualTo("from", userId).addSnapshotListener {
+        snapshot,
+        exception ->
+      if (exception != null) {
+        onFailure(exception)
+      } else if (snapshot != null) {
+        val requests = snapshot.toObjects(TripInvite::class.java)
+        onSuccess(requests)
+      }
+    }
+  }
+
+  /**
+   * Listen to trip invites received by a user
+   *
+   * @param userId the user to listen to trip invites for
+   * @param onSuccess callback to execute after successful fetch
+   * @param onFailure exception handling callback
+   * @return a listener registration
+   */
+  override fun listenToTripInvites(
+      userId: String,
+      onSuccess: (List<TripInvite>) -> Unit,
+      onFailure: (Exception) -> Unit
+  ): ListenerRegistration {
+    return db.collection(collectionPath).whereEqualTo("to", userId).addSnapshotListener {
+        snapshot,
+        exception ->
+      if (exception != null) {
+        onFailure(exception)
+      } else if (snapshot != null) {
+        val requests = snapshot.toObjects(TripInvite::class.java)
+        onSuccess(requests)
+      }
+    }
+  }
+
+  /**
+   * Get all trip invites for a trip
+   *
+   * @param tripId the trip to get the trip invites for
+   * @param onSuccess callback to execute after successful fetch
+   * @param onFailure exception handling callback
+   */
+  override fun getInvitesForTrip(
+      tripId: String,
+      onSuccess: (List<TripInvite>) -> Unit,
+      onFailure: (Exception) -> Unit
+  ) {
+    db.collection(collectionPath)
+        .whereEqualTo("tripId", tripId)
+        .get()
+        .addOnSuccessListener { result ->
+          val invites = result.map { document -> document.toObject(TripInvite::class.java) }
+          onSuccess(invites)
+        }
+        .addOnFailureListener { exception -> onFailure(exception) }
+  }
+
+  /**
+   * Create a new TripInviteRepository
+   *
+   * @return a new TripInviteRepository using the Firebase Firestore instance
+   */
+  companion object {
+    fun create(): TripInviteRepository {
+      val db = FirebaseFirestore.getInstance()
+      return TripInviteRepositoryFirebase(db)
+    }
+  }
+}

--- a/app/src/main/java/com/android/voyageur/model/notifications/TripInviteRepositoryFirebase.kt
+++ b/app/src/main/java/com/android/voyageur/model/notifications/TripInviteRepositoryFirebase.kt
@@ -9,13 +9,12 @@ import com.google.firebase.firestore.SetOptions
  * Used for displaying trip invites and notifications Appears as a parameter to the ${UserViewModel}
  *
  * @param db the firestore instance to use
- * @param collectionPath the path to the collection of trip invites
  * @constructor creates a new TripInviteRepositoryFirebase
  * @property db the firestore instance to use
  * @property collectionPath the path to the collection of trip invites
  */
 class TripInviteRepositoryFirebase(private val db: FirebaseFirestore) : TripInviteRepository {
-  private val collectionPath = "friendRequests"
+  private val collectionPath = "tripInvites"
 
   override fun init(onSuccess: () -> Unit) {
     db.collection(collectionPath).get().addOnSuccessListener { onSuccess() }
@@ -53,6 +52,7 @@ class TripInviteRepositoryFirebase(private val db: FirebaseFirestore) : TripInvi
       onSuccess: () -> Unit,
       onFailure: (Exception) -> Unit
   ) {
+    if (req.id.isEmpty()) return
     db.collection(collectionPath)
         .document(req.id)
         .set(req, SetOptions.merge())

--- a/app/src/test/java/com/android/voyageur/notifications/TripInviteReposiotryFirebaseTest.kt
+++ b/app/src/test/java/com/android/voyageur/notifications/TripInviteReposiotryFirebaseTest.kt
@@ -1,0 +1,266 @@
+package com.android.voyageur.notifications
+
+// test the TripInviteRepositoryFirebase class
+
+import android.os.Looper
+import androidx.test.core.app.ApplicationProvider
+import com.android.voyageur.model.notifications.TripInvite
+import com.android.voyageur.model.notifications.TripInviteRepositoryFirebase
+import com.google.android.gms.tasks.OnSuccessListener
+import com.google.android.gms.tasks.Task
+import com.google.android.gms.tasks.Tasks
+import com.google.firebase.FirebaseApp
+import com.google.firebase.firestore.AggregateQuery
+import com.google.firebase.firestore.AggregateQuerySnapshot
+import com.google.firebase.firestore.AggregateSource
+import com.google.firebase.firestore.CollectionReference
+import com.google.firebase.firestore.DocumentReference
+import com.google.firebase.firestore.EventListener
+import com.google.firebase.firestore.FirebaseFirestore
+import com.google.firebase.firestore.ListenerRegistration
+import com.google.firebase.firestore.Query
+import com.google.firebase.firestore.QuerySnapshot
+import com.google.firebase.firestore.SetOptions
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Assert.fail
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.ArgumentMatchers.any
+import org.mockito.ArgumentMatchers.anyString
+import org.mockito.Mock
+import org.mockito.Mockito.mock
+import org.mockito.Mockito.verify
+import org.mockito.Mockito.`when`
+import org.mockito.MockitoAnnotations
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.Shadows.shadowOf
+
+@RunWith(RobolectricTestRunner::class)
+class TripInviteRepositoryFirebaseTest {
+
+  @Mock private lateinit var mockFirestore: FirebaseFirestore
+  @Mock private lateinit var mockCollectionReference: CollectionReference
+  @Mock private lateinit var mockDocumentReference: DocumentReference
+  @Mock private lateinit var mockQuerySnapshot: QuerySnapshot
+  @Mock private lateinit var mockAggregateQuerySnapshot: AggregateQuerySnapshot
+  @Mock private lateinit var mockQuery: Query
+
+  private lateinit var tripInviteRepository: TripInviteRepositoryFirebase
+  private val testTripInvite = TripInvite("1", "tripId", "fromUser", "toUser")
+
+  @Before
+  fun setUp() {
+    MockitoAnnotations.openMocks(this)
+
+    // Initialize Firebase if necessary
+    if (FirebaseApp.getApps(ApplicationProvider.getApplicationContext()).isEmpty()) {
+      FirebaseApp.initializeApp(ApplicationProvider.getApplicationContext())
+    }
+
+    tripInviteRepository = TripInviteRepositoryFirebase(mockFirestore)
+
+    `when`(mockFirestore.collection(anyString())).thenReturn(mockCollectionReference)
+    `when`(mockCollectionReference.document(anyString())).thenReturn(mockDocumentReference)
+    `when`(mockCollectionReference.document()).thenReturn(mockDocumentReference)
+  }
+
+  @Test
+  fun `init calls onSuccess when Firestore query succeeds`() {
+    `when`(mockCollectionReference.get()).thenReturn(Tasks.forResult(mockQuerySnapshot))
+
+    var initCalled = false
+    tripInviteRepository.init { initCalled = true }
+
+    shadowOf(Looper.getMainLooper()).idle()
+    assertTrue(initCalled)
+  }
+
+  @Test
+  fun `getTripInvitesCount calls success callback with correct count`() {
+    val userId = "toUser"
+    val mockAggregateQuery = mock(AggregateQuery::class.java)
+    val mockTask = mock(Task::class.java) as Task<AggregateQuerySnapshot>
+
+    `when`(mockCollectionReference.whereEqualTo("to", userId)).thenReturn(mockQuery)
+    `when`(mockQuery.count()).thenReturn(mockAggregateQuery)
+    `when`(mockAggregateQuery.get(AggregateSource.SERVER)).thenReturn(mockTask)
+
+    `when`(mockTask.addOnSuccessListener(any())).thenAnswer { invocation ->
+      val listener = invocation.arguments[0] as OnSuccessListener<AggregateQuerySnapshot>
+      `when`(mockAggregateQuerySnapshot.count).thenReturn(3L)
+      listener.onSuccess(mockAggregateQuerySnapshot)
+      mockTask
+    }
+
+    tripInviteRepository.getTripInvitesCount(
+        userId,
+        onSuccess = { count -> assertEquals(3L, count) },
+        onFailure = { fail("Failure callback should not be called") })
+
+    shadowOf(Looper.getMainLooper()).idle()
+    verify(mockQuery).count()
+  }
+
+  @Test
+  fun `createTripInvite calls Firestore set with correct data`() {
+    `when`(mockDocumentReference.set(any(TripInvite::class.java), any<SetOptions>()))
+        .thenReturn(Tasks.forResult(null))
+
+    tripInviteRepository.createTripInvite(
+        testTripInvite,
+        onSuccess = {},
+        onFailure = { fail("Failure callback should not be called") })
+
+    shadowOf(Looper.getMainLooper()).idle()
+    verify(mockDocumentReference).set(any(TripInvite::class.java), any<SetOptions>())
+  }
+
+  @Test
+  fun `deleteTripInvite deletes invite by ID`() {
+    `when`(mockDocumentReference.delete()).thenReturn(Tasks.forResult(null))
+
+    tripInviteRepository.deleteTripInvite(
+        testTripInvite.id,
+        onSuccess = {},
+        onFailure = { fail("Failure callback should not be called") })
+
+    shadowOf(Looper.getMainLooper()).idle()
+    verify(mockDocumentReference).delete()
+  }
+
+  @Test
+  fun `getNewId generates a unique ID`() {
+    `when`(mockDocumentReference.id).thenReturn("uniqueId")
+    val newId = tripInviteRepository.getNewId()
+    assertEquals("uniqueId", newId)
+  }
+
+  @Test
+  fun `listenToSentTripInvites registers listener for correct user`() {
+    val userId = "fromUser"
+    val mockListenerRegistration = mock(ListenerRegistration::class.java)
+
+    `when`(mockCollectionReference.whereEqualTo("from", userId)).thenReturn(mockQuery)
+    `when`(mockQuery.addSnapshotListener(any())).thenReturn(mockListenerRegistration)
+
+    val listener =
+        tripInviteRepository.listenToSentTripInvites(userId, onSuccess = {}, onFailure = {})
+
+    assertEquals(mockListenerRegistration, listener)
+    verify(mockQuery).addSnapshotListener(any())
+  }
+
+  @Test
+  fun `listenToTripInvites registers listener for received invites`() {
+    val userId = "toUser"
+    val mockListenerRegistration = mock(ListenerRegistration::class.java)
+
+    `when`(mockCollectionReference.whereEqualTo("to", userId)).thenReturn(mockQuery)
+    `when`(mockQuery.addSnapshotListener(any())).thenReturn(mockListenerRegistration)
+
+    val listener = tripInviteRepository.listenToTripInvites(userId, onSuccess = {}, onFailure = {})
+
+    assertEquals(mockListenerRegistration, listener)
+    verify(mockQuery).addSnapshotListener(any())
+  }
+
+  @Test
+  fun `getTripInvites fetches trip invites for the correct user`() {
+    val userId = "toUser"
+    val tripInvites =
+        listOf(
+            TripInvite("1", "trip1", "fromUser1", "toUser"),
+            TripInvite("2", "trip2", "fromUser2", "toUser"))
+
+    `when`(mockCollectionReference.whereEqualTo("to", userId)).thenReturn(mockQuery)
+    `when`(mockQuery.get()).thenReturn(Tasks.forResult(mockQuerySnapshot))
+    `when`(mockQuerySnapshot.toObjects(TripInvite::class.java)).thenReturn(tripInvites)
+
+    tripInviteRepository.getTripInvites(
+        userId,
+        onSuccess = { result ->
+          assertEquals(2, result.size)
+          assertEquals(tripInvites, result)
+        },
+        onFailure = { fail("Failure callback should not be called") })
+
+    verify(mockQuery).get()
+  }
+
+  @Test
+  fun `getInvitesForTrip fetches invites for the correct trip`() {
+    val tripId = "tripId"
+    val tripInvites =
+        listOf(
+            TripInvite("1", tripId, "fromUser1", "toUser1"),
+            TripInvite("2", tripId, "fromUser2", "toUser2"))
+
+    `when`(mockCollectionReference.whereEqualTo("tripId", tripId)).thenReturn(mockQuery)
+    `when`(mockQuery.get()).thenReturn(Tasks.forResult(mockQuerySnapshot))
+    `when`(mockQuerySnapshot.toObjects(TripInvite::class.java)).thenReturn(tripInvites)
+
+    tripInviteRepository.getInvitesForTrip(
+        tripId,
+        onSuccess = { result ->
+          assertEquals(2, result.size)
+          assertEquals(tripInvites, result)
+        },
+        onFailure = { fail("Failure callback should not be called") })
+
+    verify(mockQuery).get()
+  }
+
+  @Test
+  fun `listenToSentTripInvites registers listener and processes snapshots`() {
+    val userId = "fromUser"
+    val tripInvites =
+        listOf(
+            TripInvite("1", "trip1", "fromUser", "toUser1"),
+            TripInvite("2", "trip2", "fromUser", "toUser2"))
+    val mockListenerRegistration = mock(ListenerRegistration::class.java)
+
+    `when`(mockCollectionReference.whereEqualTo("from", userId)).thenReturn(mockQuery)
+    `when`(mockQuery.addSnapshotListener(any())).thenAnswer { invocation ->
+      val listener = invocation.arguments[0] as EventListener<QuerySnapshot>
+      listener.onEvent(mockQuerySnapshot, null)
+      mockListenerRegistration
+    }
+    `when`(mockQuerySnapshot.toObjects(TripInvite::class.java)).thenReturn(tripInvites)
+
+    val onSuccess: (List<TripInvite>) -> Unit = { result -> assertEquals(tripInvites, result) }
+    val onFailure: (Exception) -> Unit = { fail("Failure callback should not be called") }
+
+    val listener = tripInviteRepository.listenToSentTripInvites(userId, onSuccess, onFailure)
+
+    verify(mockQuery).addSnapshotListener(any())
+    assertEquals(mockListenerRegistration, listener)
+  }
+
+  @Test
+  fun `listenToTripInvites registers listener and processes snapshots`() {
+    val userId = "toUser"
+    val tripInvites =
+        listOf(
+            TripInvite("1", "trip1", "fromUser1", "toUser"),
+            TripInvite("2", "trip2", "fromUser2", "toUser"))
+    val mockListenerRegistration = mock(ListenerRegistration::class.java)
+
+    `when`(mockCollectionReference.whereEqualTo("to", userId)).thenReturn(mockQuery)
+    `when`(mockQuery.addSnapshotListener(any())).thenAnswer { invocation ->
+      val listener = invocation.arguments[0] as EventListener<QuerySnapshot>
+      listener.onEvent(mockQuerySnapshot, null)
+      mockListenerRegistration
+    }
+    `when`(mockQuerySnapshot.toObjects(TripInvite::class.java)).thenReturn(tripInvites)
+
+    val onSuccess: (List<TripInvite>) -> Unit = { result -> assertEquals(tripInvites, result) }
+    val onFailure: (Exception) -> Unit = { fail("Failure callback should not be called") }
+
+    val listener = tripInviteRepository.listenToTripInvites(userId, onSuccess, onFailure)
+
+    verify(mockQuery).addSnapshotListener(any())
+    assertEquals(mockListenerRegistration, listener)
+  }
+}

--- a/app/src/test/java/com/android/voyageur/notifications/TripInviteTest.kt
+++ b/app/src/test/java/com/android/voyageur/notifications/TripInviteTest.kt
@@ -1,0 +1,46 @@
+package com.android.voyageur.notifications
+
+import com.android.voyageur.model.notifications.TripInvite
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotEquals
+import org.junit.Test
+
+class TripInviteTest {
+
+  @Test
+  fun testTripInviteCreationWithAllFields() {
+    val tripInvite = TripInvite(id = "1", tripId = "2", from = "3", to = "4")
+
+    assertEquals("1", tripInvite.id)
+    assertEquals("2", tripInvite.tripId)
+    assertEquals("3", tripInvite.from)
+    assertEquals("4", tripInvite.to)
+  }
+
+  @Test
+  fun testTripInviteEquals() {
+    val tripInvite1 = TripInvite(id = "1", tripId = "2", from = "3", to = "4")
+    val tripInvite2 = TripInvite(id = "1", tripId = "2", from = "3", to = "4")
+    assertEquals(tripInvite1, tripInvite2)
+  }
+
+  @Test
+  fun testTripInviteHashCode() {
+    val tripInvite1 = TripInvite(id = "1", tripId = "2", from = "3", to = "4")
+    val tripInvite2 = TripInvite(id = "1", tripId = "2", from = "3", to = "4")
+    assertEquals(tripInvite1.hashCode(), tripInvite2.hashCode())
+  }
+
+  @Test
+  fun testTripInviteNotEquals() {
+    val tripInvite1 = TripInvite(id = "1", tripId = "2", from = "3", to = "4")
+    val tripInvite2 = TripInvite(id = "1", tripId = "2", from = "3", to = "5")
+    assertNotEquals(tripInvite1, tripInvite2)
+  }
+
+  @Test
+  fun testTripInviteNotEqualsDifferentType() {
+    val tripInvite = TripInvite(id = "1", tripId = "2", from = "3", to = "4")
+    assertNotEquals(tripInvite, "tripInvite")
+  }
+}


### PR DESCRIPTION
## Summary

In this PR I introduce the necessary backend functions / model for the trip invites notification:

## Changes

- **Models:** Added the `TripInvite` model which has  `tripId`, `id`, `from` and `to` fields
- **Repositories:** I created the `TripInviteRepository` interface and the `TripInviteRepositoryFirebase` which implements this interface

## Checklist
- [x] This PR resolves #291 
- [x] Tests have been added for new functionality.
- [x] Documentation has been updated (if applicable).

##  Testing
- **Manual Testing:**
    - [ ] Tested on emulator / physical device.
- **Unit Tests**
    - [x] Added units tests for this



