### PR TITLE
Feat/Read Only View for trips in Discover.

### DIFF
--- a/app/src/androidTest/java/com/android/voyageur/ui/components/PlaceSearchWidgetTest.kt
+++ b/app/src/androidTest/java/com/android/voyageur/ui/components/PlaceSearchWidgetTest.kt
@@ -91,7 +91,6 @@ class PlaceSearchWidgetTest {
     composeTestRule.onNodeWithTag("searchTextField").assertIsDisplayed()
   }
 
-
   @Test
   fun testConvertCustomPlaceToLocation() {
     val location = mockCustomPlace.toLocation()

--- a/app/src/androidTest/java/com/android/voyageur/ui/components/PlaceSearchWidgetTest.kt
+++ b/app/src/androidTest/java/com/android/voyageur/ui/components/PlaceSearchWidgetTest.kt
@@ -91,29 +91,6 @@ class PlaceSearchWidgetTest {
     composeTestRule.onNodeWithTag("searchTextField").assertIsDisplayed()
   }
 
-  @Test
-  fun testSearch() {
-    // Create a mock place with a specific ID
-    val place =
-        CustomPlace(Place.builder().setId("mockID").setName("Test Place").build(), emptyList())
-
-    // Mock the ViewModel's searchedPlaces to return the specific place
-    placesViewModel = PlacesViewModel(placesRepository).apply { setSearchedPlaces(listOf(place)) }
-
-    // Perform the test setup
-    composeTestRule.setContent {
-      PlaceSearchWidget(
-          placesViewModel = placesViewModel,
-          onSelect = {},
-          query = TextFieldValue("Test"),
-          onQueryChange = { it, _ -> placesViewModel.setQuery(it.text, null) })
-    }
-
-    // Perform text input and assertions
-    composeTestRule.onNodeWithTag("searchTextField").performTextInput("Test")
-    composeTestRule.onNodeWithTag("searchDropdown").assertIsDisplayed()
-    composeTestRule.onNodeWithTag("item-mockID").assertIsDisplayed()
-  }
 
   @Test
   fun testConvertCustomPlaceToLocation() {

--- a/app/src/androidTest/java/com/android/voyageur/ui/search/SearchScreenTest.kt
+++ b/app/src/androidTest/java/com/android/voyageur/ui/search/SearchScreenTest.kt
@@ -154,4 +154,21 @@ class SearchScreenTest {
     composeTestRule.onNodeWithTag("discoverTab").performClick()
     composeTestRule.onNodeWithTag("noTripsFound").assertIsDisplayed()
   }
+
+  @Test
+  fun testDetailsButtonUpdatesNavActions() = runTest {
+    composeTestRule.awaitIdle()
+    `when`(tripsRepository.getFeed(any(), any(), any())).thenAnswer {
+      val onSuccess = it.arguments[1] as (List<Trip>) -> Unit
+      onSuccess(listOf(Trip(id = "1"))) // Provide a valid Trip for testing
+    }
+    composeTestRule.onNodeWithTag("discoverTab").performClick()
+    composeTestRule.awaitIdle()
+    composeTestRule.onNodeWithTag("tripCard_1").assertIsDisplayed()
+    composeTestRule.onNodeWithTag("viewTripDetailsButton").performClick()
+    // Check the user will be redirected to daily view
+    assert(navigationActions.getNavigationState().isDailyViewSelected)
+    // Check the user navigates in Read Only Mode for the trip
+    assert(navigationActions.getNavigationState().isReadOnlyView)
+  }
 }

--- a/app/src/androidTest/java/com/android/voyageur/ui/trip/activities/ActivitiesForOneDayScreenTest.kt
+++ b/app/src/androidTest/java/com/android/voyageur/ui/trip/activities/ActivitiesForOneDayScreenTest.kt
@@ -2,6 +2,7 @@ package com.android.voyageur.ui.trip.activities
 
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.assertIsNotDisplayed
+import androidx.compose.ui.test.isDisplayed
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
@@ -12,6 +13,7 @@ import com.android.voyageur.model.activity.ActivityType
 import com.android.voyageur.model.trip.Trip
 import com.android.voyageur.model.trip.TripsViewModel
 import com.android.voyageur.ui.navigation.NavigationActions
+import com.android.voyageur.ui.navigation.NavigationState
 import java.time.LocalDate
 import kotlinx.coroutines.flow.MutableStateFlow
 import org.junit.Before
@@ -21,6 +23,7 @@ import org.mockito.Mockito
 import org.mockito.Mockito.mock
 import org.mockito.Mockito.verify
 import org.mockito.Mockito.`when`
+import org.mockito.kotlin.doReturn
 
 class ActivitiesForOneDayScreenTest {
   private val sampleTrip =
@@ -49,6 +52,7 @@ class ActivitiesForOneDayScreenTest {
               ))
 
   private lateinit var navigationActions: NavigationActions
+  private lateinit var mockNavigationActions: NavigationActions
   private lateinit var navHostController: NavHostController
   private lateinit var tripsViewModel: TripsViewModel
 
@@ -59,6 +63,7 @@ class ActivitiesForOneDayScreenTest {
     tripsViewModel = mock(TripsViewModel::class.java)
     navHostController = Mockito.mock(NavHostController::class.java)
     navigationActions = NavigationActions(navHostController)
+    mockNavigationActions = mock(NavigationActions::class.java)
     val selectedTripFlow = MutableStateFlow(sampleTrip)
     `when`(tripsViewModel.selectedTrip).thenReturn(selectedTripFlow)
     val selectedDayFlow = MutableStateFlow<LocalDate?>(LocalDate.of(2022, 1, 1))
@@ -113,5 +118,23 @@ class ActivitiesForOneDayScreenTest {
         .onNodeWithTag("cardItem_${sampleTrip.activities[1].title}")
         .assertIsNotDisplayed()
     verify(tripsViewModel).removeActivityFromTrip(sampleTrip.activities[1])
+  }
+
+  @Test
+  fun deleteAndEditButtons_NotDisplayedInROV() {
+    // Mock NavigationActions to return a NavigationState with isReadOnlyView = true
+    val navigationState = NavigationState()
+    navigationState.isReadOnlyView = true
+    doReturn(navigationState).`when`(mockNavigationActions).getNavigationState()
+    composeTestRule.setContent { ActivitiesForOneDayScreen(tripsViewModel, mockNavigationActions) }
+
+    // Assert the delete button is not displayed
+    composeTestRule.onNodeWithTag("expandIcon_${sampleTrip.activities[1].title}").isDisplayed()
+    composeTestRule
+        .onNodeWithTag("deleteIcon_${sampleTrip.activities[1].title}")
+        .assertDoesNotExist()
+    composeTestRule.onNodeWithTag("deleteActivityAlertDialog").assertDoesNotExist()
+    // Assert the edit button is not displayed
+    composeTestRule.onNodeWithTag("editIcon_${sampleTrip.activities[1].title}").assertDoesNotExist()
   }
 }

--- a/app/src/androidTest/java/com/android/voyageur/ui/trip/activities/ActivitiesForOneDayScreenTest.kt
+++ b/app/src/androidTest/java/com/android/voyageur/ui/trip/activities/ActivitiesForOneDayScreenTest.kt
@@ -6,6 +6,7 @@ import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
+import androidx.navigation.NavHostController
 import com.android.voyageur.model.activity.Activity
 import com.android.voyageur.model.activity.ActivityType
 import com.android.voyageur.model.trip.Trip
@@ -16,6 +17,7 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
+import org.mockito.Mockito
 import org.mockito.Mockito.mock
 import org.mockito.Mockito.verify
 import org.mockito.Mockito.`when`
@@ -47,6 +49,7 @@ class ActivitiesForOneDayScreenTest {
               ))
 
   private lateinit var navigationActions: NavigationActions
+  private lateinit var navHostController: NavHostController
   private lateinit var tripsViewModel: TripsViewModel
 
   @get:Rule val composeTestRule = createComposeRule()
@@ -54,7 +57,8 @@ class ActivitiesForOneDayScreenTest {
   @Before
   fun setUp() {
     tripsViewModel = mock(TripsViewModel::class.java)
-    navigationActions = mock(NavigationActions::class.java)
+    navHostController = Mockito.mock(NavHostController::class.java)
+    navigationActions = NavigationActions(navHostController)
     val selectedTripFlow = MutableStateFlow(sampleTrip)
     `when`(tripsViewModel.selectedTrip).thenReturn(selectedTripFlow)
     val selectedDayFlow = MutableStateFlow<LocalDate?>(LocalDate.of(2022, 1, 1))

--- a/app/src/androidTest/java/com/android/voyageur/ui/trip/activities/ActivitiesScreenTest.kt
+++ b/app/src/androidTest/java/com/android/voyageur/ui/trip/activities/ActivitiesScreenTest.kt
@@ -8,6 +8,7 @@ import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.performTextInput
+import androidx.navigation.NavHostController
 import com.android.voyageur.model.activity.Activity
 import com.android.voyageur.model.activity.ActivityType
 import com.android.voyageur.model.notifications.FriendRequestRepository
@@ -18,14 +19,17 @@ import com.android.voyageur.model.user.UserRepository
 import com.android.voyageur.model.user.UserViewModel
 import com.android.voyageur.ui.navigation.LIST_TOP_LEVEL_DESTINATION
 import com.android.voyageur.ui.navigation.NavigationActions
+import com.android.voyageur.ui.navigation.NavigationState
 import com.android.voyageur.ui.navigation.Screen
 import com.google.firebase.Timestamp
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
+import org.mockito.Mockito
 import org.mockito.Mockito.mock
 import org.mockito.Mockito.verify
 import org.mockito.Mockito.`when`
+import org.mockito.kotlin.doReturn
 
 fun createTimestamp(year: Int, month: Int, day: Int, hour: Int, minute: Int): Timestamp {
   val calendar = java.util.Calendar.getInstance()
@@ -58,7 +62,7 @@ class ActivitiesScreenTest {
                       endTime = createTimestamp(2022, 1, 2, 14, 0),
                       activityType = ActivityType.MUSEUM),
               ))
-
+  private lateinit var navHostController: NavHostController
   private lateinit var navigationActions: NavigationActions
   private lateinit var tripsViewModel: TripsViewModel
   private lateinit var tripRepository: TripRepository
@@ -67,11 +71,14 @@ class ActivitiesScreenTest {
   private lateinit var friendRequestRepository: FriendRequestRepository
   private lateinit var userRepository: UserRepository
   private lateinit var userViewModel: UserViewModel
+  private lateinit var mockNavigationActions: NavigationActions
   @get:Rule val composeTestRule = createComposeRule()
 
   @Before
   fun setUp() {
-    navigationActions = mock(NavigationActions::class.java)
+    navHostController = Mockito.mock(NavHostController::class.java)
+    navigationActions = NavigationActions(navHostController)
+    mockNavigationActions = Mockito.mock(NavigationActions::class.java)
     tripRepository = mock(TripRepository::class.java)
     tripsViewModel = TripsViewModel(tripRepository)
     friendRequestRepository = mock(FriendRequestRepository::class.java)
@@ -118,13 +125,14 @@ class ActivitiesScreenTest {
 
   @Test
   fun clickingCreateActivityButton_navigatesToAddActivityScreen() {
+    doReturn(NavigationState()).`when`(mockNavigationActions).getNavigationState()
     composeTestRule.setContent {
-      ActivitiesScreen(navigationActions, userViewModel, tripsViewModel)
+      ActivitiesScreen(mockNavigationActions, userViewModel, tripsViewModel)
     }
 
     composeTestRule.onNodeWithTag("createActivityButton").performClick()
 
-    verify(navigationActions).navigateTo(Screen.ADD_ACTIVITY)
+    verify(mockNavigationActions).navigateTo(Screen.ADD_ACTIVITY)
   }
 
   @Test

--- a/app/src/androidTest/java/com/android/voyageur/ui/trip/activities/ActivitiesScreenTest.kt
+++ b/app/src/androidTest/java/com/android/voyageur/ui/trip/activities/ActivitiesScreenTest.kt
@@ -359,4 +359,48 @@ class ActivitiesScreenTest {
         .onNodeWithTag("cardItem_Final Activity Without Description")
         .assertDoesNotExist()
   }
+
+  @Test
+  fun createActivityButton_notDisplayedInROV() {
+    // Mock NavigationActions to return a NavigationState with isReadOnlyView = true
+    val navigationState = NavigationState()
+    navigationState.isReadOnlyView = true
+    doReturn(navigationState).`when`(mockNavigationActions).getNavigationState()
+    composeTestRule.setContent {
+      ActivitiesScreen(mockNavigationActions, userViewModel, tripsViewModel)
+    }
+
+    composeTestRule.onNodeWithTag("createActivityButton").assertDoesNotExist()
+  }
+
+  @Test
+  fun deleteAndEditButtons_NotDisplayedInROV() {
+    // Mock NavigationActions to return a NavigationState with isReadOnlyView = true
+    val navigationState = NavigationState()
+    navigationState.isReadOnlyView = true
+    doReturn(navigationState).`when`(mockNavigationActions).getNavigationState()
+    `when`(mockTripsViewModel.getActivitiesForSelectedTrip()).thenReturn(sampleTrip.activities)
+
+    composeTestRule.setContent {
+      ActivitiesScreen(mockNavigationActions, userViewModel, mockTripsViewModel)
+    }
+
+    // test with draft activity
+    composeTestRule.onNodeWithTag("cardItem_${sampleTrip.activities[0].title}").assertIsDisplayed()
+    composeTestRule.onNodeWithTag("expandIcon_${sampleTrip.activities[0].title}").performClick()
+    composeTestRule
+        .onNodeWithTag("deleteIcon_${sampleTrip.activities[0].title}")
+        .assertDoesNotExist()
+    // Assert the edit button is not displayed
+    composeTestRule.onNodeWithTag("editIcon_${sampleTrip.activities[0].title}").assertDoesNotExist()
+
+    // test with final activity
+    composeTestRule.onNodeWithTag("cardItem_${sampleTrip.activities[1].title}").assertIsDisplayed()
+    composeTestRule.onNodeWithTag("expandIcon_${sampleTrip.activities[1].title}").performClick()
+    composeTestRule
+        .onNodeWithTag("deleteIcon_${sampleTrip.activities[1].title}")
+        .assertDoesNotExist()
+    // Assert the edit button is not displayed
+    composeTestRule.onNodeWithTag("editIcon_${sampleTrip.activities[1].title}").assertDoesNotExist()
+  }
 }

--- a/app/src/androidTest/java/com/android/voyageur/ui/trip/activities/ActivitiesScreenTest.kt
+++ b/app/src/androidTest/java/com/android/voyageur/ui/trip/activities/ActivitiesScreenTest.kt
@@ -362,12 +362,8 @@ class ActivitiesScreenTest {
 
   @Test
   fun createActivityButton_notDisplayedInROV() {
-    // Mock NavigationActions to return a NavigationState with isReadOnlyView = true
-    val navigationState = NavigationState()
-    navigationState.isReadOnlyView = true
-    doReturn(navigationState).`when`(mockNavigationActions).getNavigationState()
     composeTestRule.setContent {
-      ActivitiesScreen(mockNavigationActions, userViewModel, tripsViewModel)
+      ActivitiesScreen(mockNavigationActions, userViewModel, tripsViewModel, true)
     }
 
     composeTestRule.onNodeWithTag("createActivityButton").assertDoesNotExist()
@@ -375,14 +371,10 @@ class ActivitiesScreenTest {
 
   @Test
   fun deleteAndEditButtons_NotDisplayedInROV() {
-    // Mock NavigationActions to return a NavigationState with isReadOnlyView = true
-    val navigationState = NavigationState()
-    navigationState.isReadOnlyView = true
-    doReturn(navigationState).`when`(mockNavigationActions).getNavigationState()
     `when`(mockTripsViewModel.getActivitiesForSelectedTrip()).thenReturn(sampleTrip.activities)
 
     composeTestRule.setContent {
-      ActivitiesScreen(mockNavigationActions, userViewModel, mockTripsViewModel)
+      ActivitiesScreen(navigationActions, userViewModel, mockTripsViewModel, true)
     }
 
     // test with draft activity

--- a/app/src/androidTest/java/com/android/voyageur/ui/trip/schedule/ByDayScreenTest.kt
+++ b/app/src/androidTest/java/com/android/voyageur/ui/trip/schedule/ByDayScreenTest.kt
@@ -327,12 +327,9 @@ class ByDayScreenTest {
 
   @Test
   fun floatingActionButtonNotDisplayedInROV() {
-    // Mock NavigationActions to return a NavigationState with isReadOnlyView = true
-    val navigationState = NavigationState()
-    navigationState.isReadOnlyView = true
-    doReturn(navigationState).`when`(navigationActions).getNavigationState()
+    // set the isReadOnlyView parameter as true
     composeTestRule.setContent {
-      ByDayScreen(tripsViewModel, oneActivityTrip, navigationActions, userViewModel)
+      ByDayScreen(tripsViewModel, oneActivityTrip, navigationActions, userViewModel, true)
     }
     // Test floating button is displayed
     composeTestRule.onNodeWithTag("createActivityButton").assertDoesNotExist()

--- a/app/src/androidTest/java/com/android/voyageur/ui/trip/schedule/ByDayScreenTest.kt
+++ b/app/src/androidTest/java/com/android/voyageur/ui/trip/schedule/ByDayScreenTest.kt
@@ -157,7 +157,7 @@ class ByDayScreenTest {
 
     // Check that the empty state message is displayed
     composeTestRule.onNodeWithTag("emptyByDayPrompt").assertIsDisplayed()
-    composeTestRule.onNodeWithText("You have no activities yet.").assertIsDisplayed()
+    composeTestRule.onNodeWithText("There are no activities scheduled.").assertIsDisplayed()
   }
 
   @Test
@@ -323,5 +323,18 @@ class ByDayScreenTest {
     composeTestRule.onNodeWithTag("cardItem").performClick()
     verify(navigationActions).navigateTo(Screen.ACTIVITIES_FOR_ONE_DAY)
     verify(tripsViewModel).selectDay(LocalDate.of(2022, 1, 1))
+  }
+
+  @Test
+  fun floatingActionButtonNotDisplayedInROV() {
+    // Mock NavigationActions to return a NavigationState with isReadOnlyView = true
+    val navigationState = NavigationState()
+    navigationState.isReadOnlyView = true
+    doReturn(navigationState).`when`(navigationActions).getNavigationState()
+    composeTestRule.setContent {
+      ByDayScreen(tripsViewModel, oneActivityTrip, navigationActions, userViewModel)
+    }
+    // Test floating button is displayed
+    composeTestRule.onNodeWithTag("createActivityButton").assertDoesNotExist()
   }
 }

--- a/app/src/androidTest/java/com/android/voyageur/ui/trip/schedule/ByDayScreenTest.kt
+++ b/app/src/androidTest/java/com/android/voyageur/ui/trip/schedule/ByDayScreenTest.kt
@@ -15,6 +15,7 @@ import com.android.voyageur.model.user.UserRepository
 import com.android.voyageur.model.user.UserViewModel
 import com.android.voyageur.ui.navigation.LIST_TOP_LEVEL_DESTINATION
 import com.android.voyageur.ui.navigation.NavigationActions
+import com.android.voyageur.ui.navigation.NavigationState
 import com.android.voyageur.ui.navigation.Screen
 import com.android.voyageur.ui.trip.activities.createTimestamp
 import java.time.LocalDate
@@ -28,6 +29,7 @@ import org.mockito.Mockito.doNothing
 import org.mockito.Mockito.mock
 import org.mockito.Mockito.verify
 import org.mockito.Mockito.`when`
+import org.mockito.kotlin.doReturn
 
 class ByDayScreenTest {
   // Create one activity trip to check for activity box and Day card
@@ -104,6 +106,7 @@ class ByDayScreenTest {
 
     `when`(tripsViewModel.selectedTrip).thenReturn(selectedTripFlow)
     `when`(tripsViewModel.getActivitiesForSelectedTrip()).thenReturn(oneActivityTrip.activities)
+    doReturn(NavigationState()).`when`(navigationActions).getNavigationState()
   }
 
   @Test

--- a/app/src/androidTest/java/com/android/voyageur/ui/trip/schedule/ScheduleScreenTest.kt
+++ b/app/src/androidTest/java/com/android/voyageur/ui/trip/schedule/ScheduleScreenTest.kt
@@ -258,17 +258,15 @@ class ScheduleScreenTest {
 
   @Test
   fun checkAssistantButtonNotDisplayedInROV() {
-    // Mock NavigationActions to return a NavigationState with isReadOnlyView = true
-    val navigationState = NavigationState()
-    navigationState.isReadOnlyView = true
-    doReturn(navigationState).`when`(mockNavigationActions).getNavigationState()
+    // Set isReadOnlyView to true
     doNothing().`when`(tripsViewModel).setInitialUiState()
     composeTestRule.setContent {
       ScheduleScreen(
           tripsViewModel = tripsViewModel,
           trip = mockTrip,
-          navigationActions = mockNavigationActions,
-          userViewModel)
+          navigationActions = navigationActions,
+          userViewModel,
+          isReadOnly = true)
     }
     composeTestRule.onNodeWithText("Ask Assistant").assertDoesNotExist()
   }

--- a/app/src/androidTest/java/com/android/voyageur/ui/trip/schedule/ScheduleScreenTest.kt
+++ b/app/src/androidTest/java/com/android/voyageur/ui/trip/schedule/ScheduleScreenTest.kt
@@ -143,10 +143,9 @@ class ScheduleScreenTest {
           navigationActions = navigationActions,
           userViewModel)
     }
-    // Verify both buttons and separator exist
+    // Verify both buttons
     composeTestRule.onNodeWithText("Daily").assertExists()
     composeTestRule.onNodeWithText("Weekly").assertExists()
-    composeTestRule.onNodeWithText(" / ").assertExists()
   }
 
   @Test
@@ -255,5 +254,22 @@ class ScheduleScreenTest {
     composeTestRule.onNodeWithText("Ask Assistant").performClick()
     Mockito.verify(tripsViewModel).setInitialUiState()
     Mockito.verify(mockNavigationActions).navigateTo("Assistant Screen")
+  }
+
+  @Test
+  fun checkAssistantButtonNotDisplayedInROV() {
+    // Mock NavigationActions to return a NavigationState with isReadOnlyView = true
+    val navigationState = NavigationState()
+    navigationState.isReadOnlyView = true
+    doReturn(navigationState).`when`(mockNavigationActions).getNavigationState()
+    doNothing().`when`(tripsViewModel).setInitialUiState()
+    composeTestRule.setContent {
+      ScheduleScreen(
+          tripsViewModel = tripsViewModel,
+          trip = mockTrip,
+          navigationActions = mockNavigationActions,
+          userViewModel)
+    }
+    composeTestRule.onNodeWithText("Ask Assistant").assertDoesNotExist()
   }
 }

--- a/app/src/androidTest/java/com/android/voyageur/ui/trip/schedule/WeeklyViewScreenTest.kt
+++ b/app/src/androidTest/java/com/android/voyageur/ui/trip/schedule/WeeklyViewScreenTest.kt
@@ -12,6 +12,7 @@ import com.android.voyageur.model.trip.TripsViewModel
 import com.android.voyageur.model.user.UserRepository
 import com.android.voyageur.model.user.UserViewModel
 import com.android.voyageur.ui.navigation.NavigationActions
+import com.android.voyageur.ui.navigation.NavigationState
 import com.android.voyageur.ui.navigation.Route
 import com.android.voyageur.ui.navigation.Screen
 import com.google.firebase.Timestamp
@@ -51,6 +52,7 @@ class WeeklyViewScreenTest {
 
     // Mock current route for navigation actions
     `when`(navigationActions.currentRoute()).thenReturn(Route.TOP_TABS)
+    doReturn(NavigationState()).`when`(navigationActions).getNavigationState()
 
     // Create mock trip with activities
     mockTrip =

--- a/app/src/main/java/com/android/voyageur/ui/navigation/NavigationActions.kt
+++ b/app/src/main/java/com/android/voyageur/ui/navigation/NavigationActions.kt
@@ -75,6 +75,16 @@ open class NavigationState {
    * which view was selected when opening another screen and trying to go back.
    */
   var isDailyViewSelected by mutableStateOf(true) // Default to true (Daily view selected)
+  /**
+   * This is a mutable state that represents whether the read only view is set on for a trip (in
+   * Discover tab).
+   *
+   * This is used to determine whether the editing and uploading photos screens are available. It
+   * needs to be part of the navigation actions to ensure that the read-only state is preserved
+   * across screens (to determine which screens the user can access). For example, when navigating
+   * to a screen like`ByDayScreen` or `ScheduleScreen`, this state dictates whether users can add or
+   * modify activities, and the user cannot travel to 'SettingsScreen' or 'PhotosScreen'
+   */
   var isReadOnlyView by mutableStateOf(false) // Default to false
   /**
    * This is a mutable state that represents the current tab index for the search. (0 for Users, 1

--- a/app/src/main/java/com/android/voyageur/ui/navigation/NavigationActions.kt
+++ b/app/src/main/java/com/android/voyageur/ui/navigation/NavigationActions.kt
@@ -75,6 +75,7 @@ open class NavigationState {
    * which view was selected when opening another screen and trying to go back.
    */
   var isDailyViewSelected by mutableStateOf(true) // Default to true (Daily view selected)
+  var isReadOnlyView by mutableStateOf(false) // Default to false
   /**
    * This is a mutable state that represents the current tab index for the search. (0 for Users, 1
    * for Places, 2 for the discover tab) This is used to determine which tab is currently selected

--- a/app/src/main/java/com/android/voyageur/ui/overview/Overview.kt
+++ b/app/src/main/java/com/android/voyageur/ui/overview/Overview.kt
@@ -268,6 +268,7 @@ fun TripItem(
         // When opening a trip, navigate to the Schedule screen, with the daily view enabled
         navigationActions.getNavigationState().currentTabIndexForTrip = 0
         navigationActions.getNavigationState().isDailyViewSelected = true
+        navigationActions.getNavigationState().isReadOnlyView = false
         navigationActions.navigateTo(Screen.TOP_TABS)
         tripsViewModel.selectTrip(trip)
       },

--- a/app/src/main/java/com/android/voyageur/ui/search/DiscoverContent.kt
+++ b/app/src/main/java/com/android/voyageur/ui/search/DiscoverContent.kt
@@ -27,6 +27,8 @@ import com.android.voyageur.R
 import com.android.voyageur.model.trip.Trip
 import com.android.voyageur.model.trip.TripsViewModel
 import com.android.voyageur.model.user.UserViewModel
+import com.android.voyageur.ui.navigation.NavigationActions
+import com.android.voyageur.ui.navigation.Screen
 import com.android.voyageur.ui.overview.DisplayParticipants
 
 /**
@@ -40,6 +42,7 @@ import com.android.voyageur.ui.overview.DisplayParticipants
 fun DiscoverContent(
     tripsViewModel: TripsViewModel,
     userViewModel: UserViewModel,
+    navigationActions: NavigationActions,
     modifier: Modifier = Modifier
 ) {
   val userId = userViewModel.user.collectAsState().value?.id
@@ -53,7 +56,7 @@ fun DiscoverContent(
   } else {
     HorizontalPager(state = pagerState, modifier = modifier.fillMaxSize().testTag("pager")) { page
       ->
-      TripCard(trip = trips[page], userViewModel = userViewModel)
+      TripCard(trip = trips[page], tripsViewModel, navigationActions, userViewModel = userViewModel)
     }
   }
 }
@@ -65,7 +68,12 @@ fun DiscoverContent(
  * @param userViewModel ViewModel that provides the user information.
  */
 @Composable
-fun TripCard(trip: Trip, userViewModel: UserViewModel) {
+fun TripCard(
+    trip: Trip,
+    tripsViewModel: TripsViewModel,
+    navigationActions: NavigationActions,
+    userViewModel: UserViewModel
+) {
   Box(
       modifier =
           Modifier.fillMaxSize()
@@ -130,7 +138,13 @@ fun TripCard(trip: Trip, userViewModel: UserViewModel) {
                         modifier = Modifier.weight(1f),
                         arrangement = Arrangement.Bottom)
                     TextButton(
-                        onClick = { /* TODO: Navigate to trip details screen */},
+                        onClick = {
+                          navigationActions.getNavigationState().currentTabIndexForTrip = 0
+                          navigationActions.getNavigationState().isDailyViewSelected = true
+                          navigationActions.getNavigationState().isReadOnlyView = true
+                          navigationActions.navigateTo(Screen.TOP_TABS)
+                          tripsViewModel.selectTrip(trip)
+                        },
                         modifier = Modifier.testTag("viewTripDetailsButton")) {
                           Text(text = "View Details")
                         }

--- a/app/src/main/java/com/android/voyageur/ui/search/DiscoverContent.kt
+++ b/app/src/main/java/com/android/voyageur/ui/search/DiscoverContent.kt
@@ -56,7 +56,7 @@ fun DiscoverContent(
   } else {
     HorizontalPager(state = pagerState, modifier = modifier.fillMaxSize().testTag("pager")) { page
       ->
-      TripCard(trip = trips[page], tripsViewModel, navigationActions, userViewModel = userViewModel)
+      TripCard(trip = trips[page], tripsViewModel = tripsViewModel, navigationActions = navigationActions, userViewModel = userViewModel)
     }
   }
 }

--- a/app/src/main/java/com/android/voyageur/ui/search/DiscoverContent.kt
+++ b/app/src/main/java/com/android/voyageur/ui/search/DiscoverContent.kt
@@ -12,7 +12,6 @@ import androidx.compose.material.icons.outlined.ImageSearch
 import androidx.compose.material3.*
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
-import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -32,10 +31,13 @@ import com.android.voyageur.ui.navigation.Screen
 import com.android.voyageur.ui.overview.DisplayParticipants
 
 /**
- * DiscoverContent composable displays the trips that the user can discover.
+ * DiscoverContent composable displays the trips that the user can discover. When the user presses
+ * on View Details Button, they are re-directed to the TABS screen in Read-Only View, where they can
+ * see the schedule of the featured trip, with disabled functions (such as adding a new activity).
  *
  * @param tripsViewModel ViewModel that provides the trips to display.
  * @param userViewModel ViewModel that provides the user information.
+ * @param navigationActions Handler for navigation between screens.
  * @param modifier Modifier to apply to this layout node.
  */
 @Composable

--- a/app/src/main/java/com/android/voyageur/ui/search/SearchScreen.kt
+++ b/app/src/main/java/com/android/voyageur/ui/search/SearchScreen.kt
@@ -397,7 +397,7 @@ fun SearchScreen(
                   }
                 }
           } else {
-            DiscoverContent(tripsViewModel, userViewModel)
+            DiscoverContent(tripsViewModel, userViewModel, navigationActions)
           }
         }
       }

--- a/app/src/main/java/com/android/voyageur/ui/trip/Tabs.kt
+++ b/app/src/main/java/com/android/voyageur/ui/trip/Tabs.kt
@@ -46,10 +46,11 @@ fun TopTabs(
     tripsViewModel: TripsViewModel,
     navigationActions: NavigationActions,
     userViewModel: UserViewModel,
-    placesViewModel: PlacesViewModel
+    placesViewModel: PlacesViewModel,
 ) {
   // Define tab items
   val tabs = listOf("Schedule", "Activities", "Photos", "Settings")
+  val readOnlyTabs = listOf("Schedule", "Activities")
 
   // Collect selectedTrip as state to avoid calling .value directly in composition
   val trip by tripsViewModel.selectedTrip.collectAsState()
@@ -77,30 +78,54 @@ fun TopTabs(
         modifier = Modifier.fillMaxWidth().testTag("tabRow"),
     ) {
       // Create each tab with a Tab composable
-      tabs.forEachIndexed { index, title ->
-        Tab(
-            selected = navigationActions.getNavigationState().currentTabIndexForTrip == index,
-            onClick = { navigationActions.getNavigationState().currentTabIndexForTrip = index },
-            text = { Text(title) })
+      if (navigationActions.getNavigationState().isReadOnlyView) {
+        readOnlyTabs.forEachIndexed { index, title ->
+          Tab(
+              selected = navigationActions.getNavigationState().currentTabIndexForTrip == index,
+              onClick = { navigationActions.getNavigationState().currentTabIndexForTrip = index },
+              text = { Text(title) })
+        }
+      } else {
+        tabs.forEachIndexed { index, title ->
+          Tab(
+              selected = navigationActions.getNavigationState().currentTabIndexForTrip == index,
+              onClick = { navigationActions.getNavigationState().currentTabIndexForTrip = index },
+              text = { Text(title) })
+        }
       }
     }
 
-    // Display content based on selected tab
-    when (navigationActions.getNavigationState().currentTabIndexForTrip) {
-      0 -> ScheduleScreen(tripsViewModel, selectedTrip, navigationActions, userViewModel)
-      1 -> ActivitiesScreen(navigationActions, userViewModel, tripsViewModel)
-      2 -> PhotosScreen(tripsViewModel, navigationActions, userViewModel)
-      3 ->
-          SettingsScreen(
-              selectedTrip,
-              navigationActions,
-              tripsViewModel = tripsViewModel,
-              userViewModel = userViewModel,
-              placesViewModel = placesViewModel,
-              onUpdate = {
-                navigationActions.getNavigationState().currentTabIndexForTrip = 0
-                navigationActions.getNavigationState().currentTabIndexForTrip = 3
-              })
+    when (navigationActions.getNavigationState().isReadOnlyView) {
+      true -> {
+        when (navigationActions.getNavigationState().currentTabIndexForTrip) {
+          0 -> ScheduleScreen(tripsViewModel, selectedTrip, navigationActions, userViewModel)
+          1 -> ActivitiesScreen(navigationActions, userViewModel, tripsViewModel)
+          else -> {
+            /* Handle unexpected case or provide default */
+          }
+        }
+      }
+      false -> {
+        when (navigationActions.getNavigationState().currentTabIndexForTrip) {
+          0 -> ScheduleScreen(tripsViewModel, selectedTrip, navigationActions, userViewModel)
+          1 -> ActivitiesScreen(navigationActions, userViewModel, tripsViewModel)
+          2 -> PhotosScreen(tripsViewModel, navigationActions, userViewModel)
+          3 ->
+              SettingsScreen(
+                  selectedTrip,
+                  navigationActions,
+                  tripsViewModel = tripsViewModel,
+                  userViewModel = userViewModel,
+                  placesViewModel = placesViewModel,
+                  onUpdate = {
+                    navigationActions.getNavigationState().currentTabIndexForTrip = 0
+                    navigationActions.getNavigationState().currentTabIndexForTrip = 3
+                  })
+          else -> {
+            /* Handle unexpected case or provide default */
+          }
+        }
+      }
     }
   }
 }

--- a/app/src/main/java/com/android/voyageur/ui/trip/Tabs.kt
+++ b/app/src/main/java/com/android/voyageur/ui/trip/Tabs.kt
@@ -100,9 +100,6 @@ fun TopTabs(
         when (navigationActions.getNavigationState().currentTabIndexForTrip) {
           0 -> ScheduleScreen(tripsViewModel, selectedTrip, navigationActions, userViewModel)
           1 -> ActivitiesScreen(navigationActions, userViewModel, tripsViewModel)
-          else -> {
-            /* Handle unexpected case or provide default */
-          }
         }
       }
       false -> {
@@ -121,9 +118,6 @@ fun TopTabs(
                     navigationActions.getNavigationState().currentTabIndexForTrip = 0
                     navigationActions.getNavigationState().currentTabIndexForTrip = 3
                   })
-          else -> {
-            /* Handle unexpected case or provide default */
-          }
         }
       }
     }

--- a/app/src/main/java/com/android/voyageur/ui/trip/Tabs.kt
+++ b/app/src/main/java/com/android/voyageur/ui/trip/Tabs.kt
@@ -77,22 +77,15 @@ fun TopTabs(
         selectedTabIndex = navigationActions.getNavigationState().currentTabIndexForTrip,
         modifier = Modifier.fillMaxWidth().testTag("tabRow"),
     ) {
-      // Create each tab with a Tab composable
-      if (navigationActions.getNavigationState().isReadOnlyView) {
-        readOnlyTabs.forEachIndexed { index, title ->
-          Tab(
-              selected = navigationActions.getNavigationState().currentTabIndexForTrip == index,
-              onClick = { navigationActions.getNavigationState().currentTabIndexForTrip = index },
-              text = { Text(title) })
+        // Determine which tabs to display based on the read-only view state
+        val tabsToDisplay = if (navigationActions.getNavigationState().isReadOnlyView) readOnlyTabs else tabs
+        tabsToDisplay.forEachIndexed { index, title ->
+            Tab(
+                selected = navigationActions.getNavigationState().currentTabIndexForTrip == index,
+                onClick = { navigationActions.getNavigationState().currentTabIndexForTrip = index },
+                text = { Text(title) }
+            )
         }
-      } else {
-        tabs.forEachIndexed { index, title ->
-          Tab(
-              selected = navigationActions.getNavigationState().currentTabIndexForTrip == index,
-              onClick = { navigationActions.getNavigationState().currentTabIndexForTrip = index },
-              text = { Text(title) })
-        }
-      }
     }
 
     when (navigationActions.getNavigationState().isReadOnlyView) {

--- a/app/src/main/java/com/android/voyageur/ui/trip/Tabs.kt
+++ b/app/src/main/java/com/android/voyageur/ui/trip/Tabs.kt
@@ -98,8 +98,9 @@ fun TopTabs(
     when (navigationActions.getNavigationState().isReadOnlyView) {
       true -> {
         when (navigationActions.getNavigationState().currentTabIndexForTrip) {
-          0 -> ScheduleScreen(tripsViewModel, selectedTrip, navigationActions, userViewModel)
-          1 -> ActivitiesScreen(navigationActions, userViewModel, tripsViewModel)
+          // Pass true for the isReadOnly parameters
+          0 -> ScheduleScreen(tripsViewModel, selectedTrip, navigationActions, userViewModel, true)
+          1 -> ActivitiesScreen(navigationActions, userViewModel, tripsViewModel, true)
         }
       }
       false -> {

--- a/app/src/main/java/com/android/voyageur/ui/trip/activities/Activities.kt
+++ b/app/src/main/java/com/android/voyageur/ui/trip/activities/Activities.kt
@@ -56,11 +56,14 @@ import com.google.firebase.Timestamp
  * @param navigationActions Provides actions for navigating between screens.
  * @param userViewModel The [UserViewModel] instance for managing user-related data.
  * @param tripsViewModel The [TripsViewModel] instance for accessing trip and activity data.
+ * @param isReadOnly Boolean which determines if the user is in Read Only View and cannot
+ *   edit/add/delete activities.
  */
 fun ActivitiesScreen(
     navigationActions: NavigationActions,
     userViewModel: UserViewModel,
     tripsViewModel: TripsViewModel,
+    isReadOnly: Boolean = false
 ) {
   // States for filtering
   var selectedFilters by remember { mutableStateOf(setOf<ActivityType>()) }
@@ -180,12 +183,12 @@ fun ActivitiesScreen(
             modifier = Modifier.height(80.dp).testTag("topAppBar"))
       },
       floatingActionButton = {
-        if (!navigationActions.getNavigationState().isReadOnlyView) {
+        if (!isReadOnly) {
           AddActivityButton(navigationActions)
         }
       },
       content = { pd ->
-        val isEditable = !navigationActions.getNavigationState().isReadOnlyView
+        val isEditable = !isReadOnly
         val buttonType = if (isEditable) ButtonType.DELETE else ButtonType.NOTHING
         LazyColumn(
             modifier = Modifier.padding(pd).fillMaxWidth().testTag("lazyColumn"),

--- a/app/src/main/java/com/android/voyageur/ui/trip/activities/Activities.kt
+++ b/app/src/main/java/com/android/voyageur/ui/trip/activities/Activities.kt
@@ -60,7 +60,7 @@ import com.google.firebase.Timestamp
 fun ActivitiesScreen(
     navigationActions: NavigationActions,
     userViewModel: UserViewModel,
-    tripsViewModel: TripsViewModel
+    tripsViewModel: TripsViewModel,
 ) {
   // States for filtering
   var selectedFilters by remember { mutableStateOf(setOf<ActivityType>()) }
@@ -179,8 +179,14 @@ fun ActivitiesScreen(
             },
             modifier = Modifier.height(80.dp).testTag("topAppBar"))
       },
-      floatingActionButton = { AddActivityButton(navigationActions) },
+      floatingActionButton = {
+        if (!navigationActions.getNavigationState().isReadOnlyView) {
+          AddActivityButton(navigationActions)
+        }
+      },
       content = { pd ->
+        val isEditable = !navigationActions.getNavigationState().isReadOnlyView
+        val buttonType = if (isEditable) ButtonType.DELETE else ButtonType.NOTHING
         LazyColumn(
             modifier = Modifier.padding(pd).fillMaxWidth().testTag("lazyColumn"),
             verticalArrangement = Arrangement.spacedBy(10.dp, Alignment.Top),
@@ -197,12 +203,12 @@ fun ActivitiesScreen(
               if (selectedFilters.isEmpty() || activity.activityType in selectedFilters) {
                 ActivityItem(
                     activity,
-                    true,
+                    isEditable,
                     onClickButton = {
                       activityToDelete = activity
                       showDialog = true
                     },
-                    ButtonType.DELETE,
+                    buttonType,
                     navigationActions,
                     tripsViewModel)
                 Spacer(modifier = Modifier.height(10.dp))
@@ -221,12 +227,12 @@ fun ActivitiesScreen(
               if (selectedFilters.isEmpty() || activity.activityType in selectedFilters) {
                 ActivityItem(
                     activity,
-                    true,
+                    isEditable,
                     onClickButton = {
                       activityToDelete = activity
                       showDialog = true
                     },
-                    ButtonType.DELETE,
+                    buttonType,
                     navigationActions,
                     tripsViewModel)
                 Spacer(modifier = Modifier.height(10.dp))

--- a/app/src/main/java/com/android/voyageur/ui/trip/activities/ActivitiesForOneDay.kt
+++ b/app/src/main/java/com/android/voyageur/ui/trip/activities/ActivitiesForOneDay.kt
@@ -37,8 +37,9 @@ import java.util.Locale
 @Composable
 fun ActivitiesForOneDayScreen(
     tripsViewModel: TripsViewModel,
-    navigationActions: NavigationActions
+    navigationActions: NavigationActions,
 ) {
+  val isReadOnlyView = navigationActions.getNavigationState().isReadOnlyView
   val trip =
       tripsViewModel.selectedTrip.value
           ?: return Text(text = "No trip selected. Should not happen", color = Color.Red)
@@ -72,7 +73,11 @@ fun ActivitiesForOneDayScreen(
       topBar = {
         TopBarWithImageAndText(trip, navigationActions, day.toDateWithYearString(), trip.name)
       },
-      floatingActionButton = { AddActivityButton(navigationActions) },
+      floatingActionButton = {
+        if (!isReadOnlyView) {
+          AddActivityButton(navigationActions)
+        }
+      },
       content = { pd ->
         if (activities.isEmpty()) {
           // Display empty prompt if there are no activities
@@ -83,7 +88,7 @@ fun ActivitiesForOneDayScreen(
             )
           }
         } else {
-          val isEditable = !navigationActions.getNavigationState().isReadOnlyView
+          val isEditable = !isReadOnlyView
           val buttonType = if (isEditable) ButtonType.DELETE else ButtonType.NOTHING
           LazyColumn(
               modifier =

--- a/app/src/main/java/com/android/voyageur/ui/trip/activities/ActivitiesForOneDay.kt
+++ b/app/src/main/java/com/android/voyageur/ui/trip/activities/ActivitiesForOneDay.kt
@@ -83,6 +83,8 @@ fun ActivitiesForOneDayScreen(
             )
           }
         } else {
+          val isEditable = !navigationActions.getNavigationState().isReadOnlyView
+          val buttonType = if (isEditable) ButtonType.DELETE else ButtonType.NOTHING
           LazyColumn(
               modifier =
                   Modifier.padding(pd).padding(top = 16.dp).fillMaxWidth().testTag("lazyColumn"),
@@ -92,12 +94,12 @@ fun ActivitiesForOneDayScreen(
               item {
                 ActivityItem(
                     activity,
-                    true,
+                    isEditable,
                     onClickButton = {
                       activityToDelete = activity
                       showDialog = true
                     },
-                    ButtonType.DELETE,
+                    buttonType,
                     navigationActions,
                     tripsViewModel)
                 Spacer(modifier = Modifier.height(10.dp))

--- a/app/src/main/java/com/android/voyageur/ui/trip/schedule/ByDay.kt
+++ b/app/src/main/java/com/android/voyageur/ui/trip/schedule/ByDay.kt
@@ -23,11 +23,13 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import com.android.voyageur.R
 import com.android.voyageur.model.activity.Activity
 import com.android.voyageur.model.activity.isDraft
 import com.android.voyageur.model.trip.Trip
@@ -44,6 +46,17 @@ import java.time.format.DateTimeFormatter
 import java.util.Locale
 
 @SuppressLint("StateFlowValueCalledInComposition")
+/**
+ * Displays the ByDayScreen, which organizes and displays activities grouped by the day in which
+ * they take place. Each card corresponds to a single day, and activities for that day are displayed
+ * in a scrollable list. Users can view activities, navigate to a detailed screen, or add new
+ * activities (if not in read-only mode).
+ *
+ * @param tripsViewModel The ViewModel responsible for managing the trip's activities and data.
+ * @param trip The trip whose activities are being displayed and organized by date.
+ * @param navigationActions Handles navigation actions such as switching to other screens.
+ * @param userViewModel The ViewModel responsible for user-specific data and state.
+ */
 @Composable
 fun ByDayScreen(
     tripsViewModel: TripsViewModel,
@@ -82,7 +95,7 @@ fun ByDayScreen(
           Box(modifier = Modifier.padding(pd).fillMaxSize(), contentAlignment = Alignment.Center) {
             Text(
                 modifier = Modifier.testTag("emptyByDayPrompt"),
-                text = "You have no activities yet.",
+                text = stringResource(R.string.empty_activities_prompt),
             )
           }
         } else {
@@ -124,7 +137,14 @@ fun groupActivitiesByDate(activities: List<Activity>): Map<LocalDate, List<Activ
 }
 
 @Composable
-/** Day Card which displays the date and a column with activities for the corresponding days. */
+/**
+ * Day Card which displays the date and a column with activities for the corresponding days.
+ *
+ * @param tripsViewModel The ViewModel responsible for managing the trip's activities and state.
+ * @param day The date for which the card is displayed.
+ * @param activitiesForDay A list of activities that occur on the given date.
+ * @param navigationActions Handles navigation to other screens, such as the detailed activity view.
+ */
 private fun DayActivityCard(
     tripsViewModel: TripsViewModel,
     day: LocalDate,
@@ -167,7 +187,7 @@ private fun DayActivityCard(
           if (numberOfActivities > 4) {
             // Displays additional text in case of too many activities
             Text(
-                text = "and ${numberOfActivities - 4} more",
+                text = stringResource(R.string.additional_activities, (numberOfActivities - 4)),
                 style =
                     TextStyle(fontSize = 10.sp, color = Color.Gray, fontWeight = FontWeight.Bold),
                 modifier = Modifier.padding(top = 4.dp))
@@ -177,7 +197,11 @@ private fun DayActivityCard(
 }
 
 @Composable
-/** Activity box which displays activity title. */
+/**
+ * Activity box which displays activity title.
+ *
+ * @param activity The activity whose title should be displayed
+ */
 private fun ActivityBox(activity: Activity) {
   // Appropriate background for both Light and Dark Themes
   val backgroundColor = ButtonDefaults.buttonColors().containerColor
@@ -204,6 +228,7 @@ private fun ActivityBox(activity: Activity) {
       }
 }
 
+/** Formats the date of the day */
 fun formatDailyDate(date: LocalDate?): String {
   // Wrap in a try-catch to avoid an exception crashing the app
   return try {

--- a/app/src/main/java/com/android/voyageur/ui/trip/schedule/ByDay.kt
+++ b/app/src/main/java/com/android/voyageur/ui/trip/schedule/ByDay.kt
@@ -56,17 +56,20 @@ import java.util.Locale
  * @param trip The trip whose activities are being displayed and organized by date.
  * @param navigationActions Handles navigation actions such as switching to other screens.
  * @param userViewModel The ViewModel responsible for user-specific data and state.
+ * @param isReadOnlyView Boolean which determines if the user is in Read Only View and cannot add
+ *   new activities.
  */
 @Composable
 fun ByDayScreen(
     tripsViewModel: TripsViewModel,
     trip: Trip,
     navigationActions: NavigationActions,
-    userViewModel: UserViewModel
+    userViewModel: UserViewModel,
+    isReadOnlyView: Boolean = false
 ) {
   Scaffold(
       floatingActionButton = {
-        if (!navigationActions.getNavigationState().isReadOnlyView) {
+        if (!isReadOnlyView) {
           AddActivityButton(navigationActions)
         }
       },

--- a/app/src/main/java/com/android/voyageur/ui/trip/schedule/ByDay.kt
+++ b/app/src/main/java/com/android/voyageur/ui/trip/schedule/ByDay.kt
@@ -52,7 +52,11 @@ fun ByDayScreen(
     userViewModel: UserViewModel
 ) {
   Scaffold(
-      floatingActionButton = { AddActivityButton(navigationActions) },
+      floatingActionButton = {
+        if (!navigationActions.getNavigationState().isReadOnlyView) {
+          AddActivityButton(navigationActions)
+        }
+      },
       modifier = Modifier.testTag("byDayScreen"),
       bottomBar = {
         BottomNavigationMenu(

--- a/app/src/main/java/com/android/voyageur/ui/trip/schedule/ScheduleScreen.kt
+++ b/app/src/main/java/com/android/voyageur/ui/trip/schedule/ScheduleScreen.kt
@@ -25,7 +25,7 @@ fun ScheduleScreen(
     tripsViewModel: TripsViewModel,
     trip: Trip,
     navigationActions: NavigationActions,
-    userViewModel: UserViewModel
+    userViewModel: UserViewModel,
 ) {
 
   Column(modifier = Modifier.fillMaxSize().padding(top = 8.dp)) {
@@ -34,17 +34,19 @@ fun ScheduleScreen(
         horizontalArrangement = Arrangement.SpaceBetween,
         verticalAlignment = Alignment.CenterVertically) {
           // "Ask Assistant" button on the left
-          TextButton(
-              onClick = {
-                tripsViewModel.setInitialUiState()
-                navigationActions.navigateTo(Screen.ASSISTANT)
-              }) {
-                Text(
-                    text = "Ask Assistant",
-                    style = MaterialTheme.typography.bodyMedium,
-                    color = MaterialTheme.colorScheme.primary,
-                    fontWeight = FontWeight.Bold)
-              }
+          if (!navigationActions.getNavigationState().isReadOnlyView) {
+            TextButton(
+                onClick = {
+                  tripsViewModel.setInitialUiState()
+                  navigationActions.navigateTo(Screen.ASSISTANT)
+                }) {
+                  Text(
+                      text = "Ask Assistant",
+                      style = MaterialTheme.typography.bodyMedium,
+                      color = MaterialTheme.colorScheme.primary,
+                      fontWeight = FontWeight.Bold)
+                }
+          }
           Row(
               modifier = Modifier.fillMaxWidth().padding(bottom = 8.dp, end = 16.dp),
               horizontalArrangement = Arrangement.End,

--- a/app/src/main/java/com/android/voyageur/ui/trip/schedule/ScheduleScreen.kt
+++ b/app/src/main/java/com/android/voyageur/ui/trip/schedule/ScheduleScreen.kt
@@ -37,6 +37,8 @@ import com.android.voyageur.ui.navigation.Screen
  * @param trip The trip whose schedule is being displayed, including activities and details.
  * @param navigationActions Handles navigation actions such as switching screens or views.
  * @param userViewModel The ViewModel responsible for user-specific data and state.
+ * @param isReadOnly Boolean which determines if the user is in Read Only View and cannot access the
+ *   AI assistant.
  */
 @Composable
 fun ScheduleScreen(
@@ -44,6 +46,7 @@ fun ScheduleScreen(
     trip: Trip,
     navigationActions: NavigationActions,
     userViewModel: UserViewModel,
+    isReadOnly: Boolean = false
 ) {
 
   Column(modifier = Modifier.fillMaxSize().padding(top = 8.dp)) {
@@ -52,7 +55,7 @@ fun ScheduleScreen(
         horizontalArrangement = Arrangement.SpaceBetween,
         verticalAlignment = Alignment.CenterVertically) {
           // "Ask Assistant" button on the left
-          if (!navigationActions.getNavigationState().isReadOnlyView) {
+          if (!isReadOnly) {
             TextButton(
                 onClick = {
                   tripsViewModel.setInitialUiState()
@@ -110,13 +113,15 @@ fun ScheduleScreen(
 
     // Conditionally show content based on isDailySelected
     if (navigationActions.getNavigationState().isDailyViewSelected) {
-      ByDayScreen(tripsViewModel, trip, navigationActions, userViewModel = userViewModel)
+      ByDayScreen(
+          tripsViewModel, trip, navigationActions, userViewModel = userViewModel, isReadOnly)
     } else {
       WeeklyViewScreen(
           tripsViewModel = tripsViewModel,
           trip = trip,
           navigationActions = navigationActions,
-          userViewModel)
+          userViewModel,
+          isReadOnly)
     }
   }
 }

--- a/app/src/main/java/com/android/voyageur/ui/trip/schedule/ScheduleScreen.kt
+++ b/app/src/main/java/com/android/voyageur/ui/trip/schedule/ScheduleScreen.kt
@@ -12,14 +12,32 @@ import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
+import com.android.voyageur.R
 import com.android.voyageur.model.trip.Trip
 import com.android.voyageur.model.trip.TripsViewModel
 import com.android.voyageur.model.user.UserViewModel
 import com.android.voyageur.ui.navigation.NavigationActions
 import com.android.voyageur.ui.navigation.Screen
 
+/**
+ * Displays the schedule for a trip, allowing the user to toggle between daily and weekly views.
+ * Users can also interact with additional functionality like navigating to the assistant screen.
+ *
+ * The schedule adapts to the current state of the app:
+ * - If `isDailyViewSelected` is `true`, the daily view is displayed using the `ByDayScreen`
+ *   composable.
+ * - If `isDailyViewSelected` is `false`, the weekly view is displayed using the `WeeklyViewScreen`
+ *   composable.
+ * - The "Ask Assistant" button is only visible when the app is not in read-only mode.
+ *
+ * @param tripsViewModel The ViewModel responsible for managing the trip's activities and state.
+ * @param trip The trip whose schedule is being displayed, including activities and details.
+ * @param navigationActions Handles navigation actions such as switching screens or views.
+ * @param userViewModel The ViewModel responsible for user-specific data and state.
+ */
 @Composable
 fun ScheduleScreen(
     tripsViewModel: TripsViewModel,
@@ -41,7 +59,7 @@ fun ScheduleScreen(
                   navigationActions.navigateTo(Screen.ASSISTANT)
                 }) {
                   Text(
-                      text = "Ask Assistant",
+                      text = stringResource(R.string.ask_assistant_button),
                       style = MaterialTheme.typography.bodyMedium,
                       color = MaterialTheme.colorScheme.primary,
                       fontWeight = FontWeight.Bold)
@@ -56,7 +74,7 @@ fun ScheduleScreen(
                       navigationActions.getNavigationState().isDailyViewSelected = true
                     }) {
                       Text(
-                          text = "Daily",
+                          text = stringResource(R.string.daily_text),
                           style = MaterialTheme.typography.bodyMedium,
                           color =
                               if (navigationActions.getNavigationState().isDailyViewSelected)
@@ -68,7 +86,7 @@ fun ScheduleScreen(
                               else FontWeight.Normal)
                     }
                 Text(
-                    text = " / ",
+                    text = stringResource(R.string.slash_text),
                     style = MaterialTheme.typography.bodyMedium,
                     color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.6f))
                 TextButton(
@@ -76,7 +94,7 @@ fun ScheduleScreen(
                       navigationActions.getNavigationState().isDailyViewSelected = false
                     }) {
                       Text(
-                          text = "Weekly",
+                          text = stringResource(R.string.weekly_text),
                           style = MaterialTheme.typography.bodyMedium,
                           color =
                               if (!navigationActions.getNavigationState().isDailyViewSelected)

--- a/app/src/main/java/com/android/voyageur/ui/trip/schedule/WeeklyView.kt
+++ b/app/src/main/java/com/android/voyageur/ui/trip/schedule/WeeklyView.kt
@@ -64,7 +64,11 @@ fun WeeklyViewScreen(
   val weeks = generateWeeks(trip.startDate, trip.endDate)
 
   Scaffold(
-      floatingActionButton = { AddActivityButton(navigationActions) },
+      floatingActionButton = {
+        if (!navigationActions.getNavigationState().isReadOnlyView) {
+          AddActivityButton(navigationActions)
+        }
+      },
       modifier = Modifier.fillMaxSize().testTag("weeklyViewScreen"),
       bottomBar = {
         BottomNavigationMenu(

--- a/app/src/main/java/com/android/voyageur/ui/trip/schedule/WeeklyView.kt
+++ b/app/src/main/java/com/android/voyageur/ui/trip/schedule/WeeklyView.kt
@@ -53,19 +53,22 @@ import java.util.Locale
  * @param trip The current trip being displayed
  * @param navigationActions Handler for navigation between screens
  * @param userViewModel ViewModel containing user-related data and operations
+ * @param isReadOnly Boolean which determines if the user is in Read Only View and cannot add new
+ *   activities.
  */
 @Composable
 fun WeeklyViewScreen(
     tripsViewModel: TripsViewModel,
     trip: Trip,
     navigationActions: NavigationActions,
-    userViewModel: UserViewModel
+    userViewModel: UserViewModel,
+    isReadOnly: Boolean = false
 ) {
   val weeks = generateWeeks(trip.startDate, trip.endDate)
 
   Scaffold(
       floatingActionButton = {
-        if (!navigationActions.getNavigationState().isReadOnlyView) {
+        if (!isReadOnly) {
           AddActivityButton(navigationActions)
         }
       },

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -70,6 +70,16 @@
     <string name="participants_count">%1$d Participants:</string>
     <string name="no_compatible_calendar">No compatible calendar app found.</string>
 
+<!-- BY DAY/ WEEkLY Screens -->
+    <string name="invalid_date">No compatible calendar app found.</string>
+    <string name="additional_activities">and %1$d more</string>
+    <string name="weekly_text">Weekly</string>
+    <string name="daily_text">Daily</string>
+    <string name="slash_text"> / </string>
+    <string name="empty_activities_prompt">There are no activities scheduled.</string>
+    <string name="ask_assistant_button">Ask Assistant</string>
+
+
 
 
  <!-- Add Activity -->


### PR DESCRIPTION
## Summary

This PR introduces the possibility to view a trip from the Discover feed in Read Only View Mode. 
When the user presses on `View Details` button on a trip displayed in the Discover feed, they are redirected to the ByDay screen, without the possibility to add a new activity/ask the AI assistant. Moreover, the TopTabs bar now has only 2 options: `Schedule` (ByDay screen and Weekly screen) or `Activities` ( `Photos `and `Settings` screens have been disabled).
 - For the `Schedule` screens,  the possibility to add a new activity or ask the AI assistant has been disabled, and if the user presses on an Activity -> `ActivitiesForOneDay` screen displays the activity, with the possibility to add an activity or edit/delete disabled.
 - For the `Activities` screen, the possibility to add a new activity or edit/delete an existent one has been disabled.
## Changes



- **Screens/UI:**  Schedule Screens (ByDay Screen and WeeklyView Screen) and the Activities Screen now have a `isReadOnly` parameter (set to false by default) which disables the add an activity button, respectively the edit/delete buttons for existent activities.
- **Logic/Controllers:** The Navigation State in Navigation Actions now has a variable isReadOnlyView, used to track 
which screens are accessible and show the corresponding tabs in the TopTab bar (disabling 2 of the possible screens accessible by the TopTab bar).
- **Bug Fixes/Improvements:** Addresses #277. 

## Checklist

- [X] This PR resolves #277.
- [X] Tests have been added for new functionality.
- [X] Screenshots or UI changes have been attached (if applicable).
- [X] Documentation has been updated (if applicable).

##  Testing


- **Manual Testing:**
    - [X] Tested on emulator / physical device.
- **Unit Tests**
    - [X] Added units tests for this


##  Related Issues/Tickets

Closes #277 

## Screenshots (if applicable)

<img width="267" alt="Screenshot 2024-12-10 at 15 48 55" src="https://github.com/user-attachments/assets/2c904687-0c72-4d07-8b65-1b06ffa71623">
<img width="266" alt="Screenshot 2024-12-10 at 15 49 14" src="https://github.com/user-attachments/assets/a9941c04-5021-4092-9814-c2a80c68ba75">
<img width="270" alt="Screenshot 2024-12-10 at 15 49 37" src="https://github.com/user-attachments/assets/535404d7-9f56-4230-b9c1-b1b85ebf29e9">
<img width="268" alt="Screenshot 2024-12-10 at 15 49 55" src="https://github.com/user-attachments/assets/b85d1e73-b759-4d48-8fc7-1cc6ba5b0318">


