### PR TITLE
Fix/include search in discovery

### DIFF
--- a/app/src/androidTest/java/com/android/voyageur/ui/search/SearchScreenTest.kt
+++ b/app/src/androidTest/java/com/android/voyageur/ui/search/SearchScreenTest.kt
@@ -154,29 +154,4 @@ class SearchScreenTest {
     composeTestRule.onNodeWithTag("discoverTab").performClick()
     composeTestRule.onNodeWithTag("noTripsFound").assertIsDisplayed()
   }
-
-  @Test
-  fun testDiscoverUsesSearchBar() = runTest {
-    composeTestRule.awaitIdle()
-    `when`(tripsRepository.getFeed(any(), any(), any())).thenAnswer {
-      val onSuccess = it.arguments[1] as (List<Trip>) -> Unit
-      onSuccess(listOf(Trip(id = "1", name = "1")))
-    }
-
-    composeTestRule.onNodeWithTag("discoverTab").performClick()
-    composeTestRule.awaitIdle()
-    composeTestRule.onNodeWithTag("tripCard_1").assertIsDisplayed()
-
-    composeTestRule.onNodeWithTag("searchTextField").performTextInput("1")
-    composeTestRule.awaitIdle()
-    composeTestRule.onNodeWithTag("tripCard_1").assertIsDisplayed()
-
-    composeTestRule.onNodeWithTag("searchTextField").performTextInput("2")
-    composeTestRule.awaitIdle()
-    composeTestRule.onNodeWithTag("noTripsFound").assertIsDisplayed()
-
-    composeTestRule.onNodeWithTag("searchTextField").performTextClearance()
-    composeTestRule.awaitIdle()
-    composeTestRule.onNodeWithTag("tripCard_1").assertIsDisplayed()
-  }
 }

--- a/app/src/androidTest/java/com/android/voyageur/ui/search/SearchScreenTest.kt
+++ b/app/src/androidTest/java/com/android/voyageur/ui/search/SearchScreenTest.kt
@@ -154,4 +154,29 @@ class SearchScreenTest {
     composeTestRule.onNodeWithTag("discoverTab").performClick()
     composeTestRule.onNodeWithTag("noTripsFound").assertIsDisplayed()
   }
+
+  @Test
+  fun testDiscoverUsesSearchBar() = runTest {
+    composeTestRule.awaitIdle()
+    `when`(tripsRepository.getFeed(any(), any(), any())).thenAnswer {
+      val onSuccess = it.arguments[1] as (List<Trip>) -> Unit
+      onSuccess(listOf(Trip(id = "1", name = "1")))
+    }
+
+    composeTestRule.onNodeWithTag("discoverTab").performClick()
+    composeTestRule.awaitIdle()
+    composeTestRule.onNodeWithTag("tripCard_1").assertIsDisplayed()
+
+    composeTestRule.onNodeWithTag("searchTextField").performTextInput("1")
+    composeTestRule.awaitIdle()
+    composeTestRule.onNodeWithTag("tripCard_1").assertIsDisplayed()
+
+    composeTestRule.onNodeWithTag("searchTextField").performTextInput("2")
+    composeTestRule.awaitIdle()
+    composeTestRule.onNodeWithTag("noTripsFound").assertIsDisplayed()
+
+    composeTestRule.onNodeWithTag("searchTextField").performTextClearance()
+    composeTestRule.awaitIdle()
+    composeTestRule.onNodeWithTag("tripCard_1").assertIsDisplayed()
+  }
 }

--- a/app/src/main/java/com/android/voyageur/ui/search/DiscoverContent.kt
+++ b/app/src/main/java/com/android/voyageur/ui/search/DiscoverContent.kt
@@ -44,6 +44,7 @@ import com.android.voyageur.ui.overview.DisplayParticipants
 /**
  * DiscoverContent composable displays the trips that the user can discover.
  *
+ * @param query the searchBar query that helps filter the field
  * @param tripsViewModel ViewModel that provides the trips to display.
  * @param userViewModel ViewModel that provides the user information.
  * @param modifier Modifier to apply to this layout node.

--- a/app/src/main/java/com/android/voyageur/ui/search/DiscoverContent.kt
+++ b/app/src/main/java/com/android/voyageur/ui/search/DiscoverContent.kt
@@ -30,6 +30,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
@@ -178,18 +179,18 @@ fun NoTripsFound() {
             horizontalAlignment = Alignment.CenterHorizontally) {
               Icon(
                   imageVector = Icons.Outlined.ImageSearch,
-                  contentDescription = "No Trips Found",
+                  contentDescription = stringResource(R.string.no_trips_to_discover),
                   modifier = Modifier.size(48.dp),
                   tint = MaterialTheme.colorScheme.onSurfaceVariant)
               Spacer(modifier = Modifier.height(16.dp))
               Text(
-                  text = "No trips to discover",
+                  text = stringResource(R.string.no_trips_to_discover),
                   fontSize = 18.sp,
                   textAlign = TextAlign.Center,
                   color = MaterialTheme.colorScheme.onSurfaceVariant)
               Spacer(modifier = Modifier.height(8.dp))
               Text(
-                  text = "Please check back later.",
+                  text = stringResource(R.string.check_back_letter),
                   fontSize = 14.sp,
                   textAlign = TextAlign.Center,
                   color = MaterialTheme.colorScheme.onSurface)

--- a/app/src/main/java/com/android/voyageur/ui/search/DiscoverContent.kt
+++ b/app/src/main/java/com/android/voyageur/ui/search/DiscoverContent.kt
@@ -160,7 +160,10 @@ fun TripCard(trip: Trip, userViewModel: UserViewModel) {
 fun NoTripsFound() {
   Box(
       modifier =
-          Modifier.fillMaxSize().background(MaterialTheme.colorScheme.background).padding(16.dp),
+          Modifier.fillMaxSize()
+              .background(MaterialTheme.colorScheme.background)
+              .padding(16.dp)
+              .testTag("noTripsFound"),
       contentAlignment = Alignment.Center) {
         Column(
             modifier =

--- a/app/src/main/java/com/android/voyageur/ui/search/DiscoverContent.kt
+++ b/app/src/main/java/com/android/voyageur/ui/search/DiscoverContent.kt
@@ -3,16 +3,28 @@ package com.android.voyageur.ui.search
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
-import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.pager.HorizontalPager
 import androidx.compose.foundation.pager.rememberPagerState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.outlined.ImageSearch
-import androidx.compose.material3.*
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
-import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -38,6 +50,7 @@ import com.android.voyageur.ui.overview.DisplayParticipants
  */
 @Composable
 fun DiscoverContent(
+    query: String,
     tripsViewModel: TripsViewModel,
     userViewModel: UserViewModel,
     modifier: Modifier = Modifier
@@ -45,7 +58,10 @@ fun DiscoverContent(
   val userId = userViewModel.user.collectAsState().value?.id
   // Fetch trips
   tripsViewModel.getFeed(userId ?: "")
-  val trips = tripsViewModel.feed.collectAsState().value
+  val trips =
+      tripsViewModel.feed.collectAsState().value.filter { trip ->
+        trip.name.contains(query, ignoreCase = true)
+      }
   val pagerState = rememberPagerState(pageCount = { trips.size })
 
   if (trips.isEmpty()) {
@@ -142,30 +158,37 @@ fun TripCard(trip: Trip, userViewModel: UserViewModel) {
 /** NoTripsFound composable displays a message when no trips are found. */
 @Composable
 fun NoTripsFound() {
-  Column(
+  Box(
       modifier =
-          Modifier.fillMaxSize()
-              .background(MaterialTheme.colorScheme.surfaceVariant)
-              .padding(24.dp)
-              .testTag("noTripsFound"),
-      verticalArrangement = Arrangement.Center,
-      horizontalAlignment = Alignment.CenterHorizontally) {
-        Icon(
-            imageVector = Icons.Outlined.ImageSearch,
-            contentDescription = "No Trips Found",
-            modifier = Modifier.size(48.dp),
-            tint = MaterialTheme.colorScheme.onSurfaceVariant)
-        Spacer(modifier = Modifier.height(16.dp))
-        Text(
-            text = "No trips to discover",
-            fontSize = 18.sp,
-            textAlign = TextAlign.Center,
-            color = MaterialTheme.colorScheme.onSurfaceVariant)
-        Spacer(modifier = Modifier.height(8.dp))
-        Text(
-            text = "Please check back later.",
-            fontSize = 14.sp,
-            textAlign = TextAlign.Center,
-            color = MaterialTheme.colorScheme.onSurface)
+          Modifier.fillMaxSize().background(MaterialTheme.colorScheme.background).padding(16.dp),
+      contentAlignment = Alignment.Center) {
+        Column(
+            modifier =
+                Modifier.fillMaxWidth(0.9f)
+                    .fillMaxHeight()
+                    .clip(RoundedCornerShape(16.dp))
+                    .border(2.dp, MaterialTheme.colorScheme.primary, RoundedCornerShape(16.dp))
+                    .background(MaterialTheme.colorScheme.surface)
+                    .padding(16.dp),
+            verticalArrangement = Arrangement.Center,
+            horizontalAlignment = Alignment.CenterHorizontally) {
+              Icon(
+                  imageVector = Icons.Outlined.ImageSearch,
+                  contentDescription = "No Trips Found",
+                  modifier = Modifier.size(48.dp),
+                  tint = MaterialTheme.colorScheme.onSurfaceVariant)
+              Spacer(modifier = Modifier.height(16.dp))
+              Text(
+                  text = "No trips to discover",
+                  fontSize = 18.sp,
+                  textAlign = TextAlign.Center,
+                  color = MaterialTheme.colorScheme.onSurfaceVariant)
+              Spacer(modifier = Modifier.height(8.dp))
+              Text(
+                  text = "Please check back later.",
+                  fontSize = 14.sp,
+                  textAlign = TextAlign.Center,
+                  color = MaterialTheme.colorScheme.onSurface)
+            }
       }
 }

--- a/app/src/main/java/com/android/voyageur/ui/search/SearchScreen.kt
+++ b/app/src/main/java/com/android/voyageur/ui/search/SearchScreen.kt
@@ -260,6 +260,7 @@ fun SearchScreen(
                         when (navigationActions.getNavigationState().currentTabForSearch) {
                           FilterType.PLACES.ordinal -> R.string.search_places
                           FilterType.USERS.ordinal -> R.string.search_users
+                          2 -> R.string.search_trips
                           else -> R.string.empty
                         },
                     onQueryChange = { query ->

--- a/app/src/main/java/com/android/voyageur/ui/search/SearchScreen.kt
+++ b/app/src/main/java/com/android/voyageur/ui/search/SearchScreen.kt
@@ -397,7 +397,7 @@ fun SearchScreen(
                   }
                 }
           } else {
-            DiscoverContent(tripsViewModel, userViewModel)
+            DiscoverContent(searchQuery.text, tripsViewModel, userViewModel)
           }
         }
       }
@@ -536,7 +536,7 @@ fun UserSearchResultItem(
 /**
  * Composable function to display a place search result item.
  *
- * @param place The place to display.
+ * @param customPlace The place to display.
  * @param modifier Modifier for the composable.
  */
 @Composable

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -136,4 +136,5 @@
     <string name="close_photo">Close Photo Dialog</string>
     <string name="no_trips_to_discover">No trips to discover</string>
     <string name="check_back_letter">Please check back later.</string>
+    <string name="search_trips">Search trips...</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -134,4 +134,6 @@
     <string name="filter_activities_by_type">Filter by Type</string>
     <string name="clear_filters">Clear Filters</string>
     <string name="close_photo">Close Photo Dialog</string>
+    <string name="no_trips_to_discover">No trips to discover</string>
+    <string name="check_back_letter">Please check back later.</string>
 </resources>


### PR DESCRIPTION
## Summary

This PR updates the Discovery Tab in the search page to also include the query from the search bar while showing the feed.

## Changes

- **Screens/UI:** filters the trips returned by the getFeed function according to if it contains the search query or not, also updated the composable that is shown when no trips are found in the discover tab in order for it to be more appealing..

## Checklist

Ensure all / most of these are checked before the pull request is submitted.
- [x] This PR resolves #306.
- [x] Tests have been added for new functionality.
- [x] Screenshots or UI changes have been attached.
- [x] Documentation has been updated.

##  Testing


- **Manual Testing:**
    - [x] Tested on emulator / physical device.
- **Unit Tests**
    - [x] Added units tests for this


##  Related Issues/Tickets

Closes #306 

## Screenshots (if applicable)

https://github.com/user-attachments/assets/79abaa51-b09f-4781-91d6-de36c835c373


