### PR TITLE
Add button to reverse trip order

### DIFF
--- a/app/src/androidTest/java/com/android/voyageur/ui/overview/OverviewScreenTest.kt
+++ b/app/src/androidTest/java/com/android/voyageur/ui/overview/OverviewScreenTest.kt
@@ -6,6 +6,7 @@ import android.provider.CalendarContract
 import androidx.compose.ui.test.assertCountEquals
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.assertIsNotDisplayed
+import androidx.compose.ui.test.assertTextContains
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onAllNodesWithTag
 import androidx.compose.ui.test.onNodeWithContentDescription
@@ -615,5 +616,50 @@ class OverviewScreenTest {
     composeTestRule.onNodeWithTag("favoriteFilterButton").performClick()
 
     verify(userRepository).updateUser(eq(User().copy(favoriteTrips = listOf("2"))), any(), any())
+  }
+
+  @Test
+  fun tripsAreSortedDescendingByDefault() {
+    val mockTrips =
+        listOf(
+            Trip(id = "1", name = "Trip A", startDate = Timestamp.now(), endDate = Timestamp.now()),
+            Trip(
+                id = "2",
+                name = "Trip B",
+                startDate = Timestamp(Timestamp.now().seconds - 86400, 0), // Subtract 1 day
+                endDate = Timestamp(Timestamp.now().seconds - 86400, 0)))
+
+    `when`(tripRepository.getTrips(any(), any(), any())).then {
+      it.getArgument<(List<Trip>) -> Unit>(1)(mockTrips)
+    }
+    tripViewModel.getTrips()
+
+    val nodes = composeTestRule.onAllNodesWithTag("cardItem")
+    nodes[0].assertTextContains("Trip A") // Most recent trip
+    nodes[1].assertTextContains("Trip B") // Older trip
+  }
+
+  @Test
+  fun tripsCanBeSortedAscending() {
+    val mockTrips =
+        listOf(
+            Trip(id = "1", name = "Trip A", startDate = Timestamp.now(), endDate = Timestamp.now()),
+            Trip(
+                id = "2",
+                name = "Trip B",
+                startDate = Timestamp(Timestamp.now().seconds - 86400, 0), // Subtract 1 day
+                endDate = Timestamp(Timestamp.now().seconds - 86400, 0)))
+
+    `when`(tripRepository.getTrips(any(), any(), any())).then {
+      it.getArgument<(List<Trip>) -> Unit>(1)(mockTrips)
+    }
+    tripViewModel.getTrips()
+
+    // Click the reverse sorting button
+    composeTestRule.onNodeWithTag("reverseTripsOrderButton").performClick()
+
+    val nodes = composeTestRule.onAllNodesWithTag("cardItem")
+    nodes[0].assertTextContains("Trip B") // Older trip
+    nodes[1].assertTextContains("Trip A") // Most recent trip
   }
 }

--- a/app/src/main/java/com/android/voyageur/ui/overview/Overview.kt
+++ b/app/src/main/java/com/android/voyageur/ui/overview/Overview.kt
@@ -15,6 +15,8 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ExperimentalLayoutApi
+import androidx.compose.foundation.layout.FlowRow
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
@@ -99,7 +101,7 @@ import kotlinx.coroutines.ExperimentalCoroutinesApi
  * @param navigationActions Actions to handle navigation between screens.
  * @param userViewModel The ViewModel containing the state and logic for user data.
  */
-@OptIn(ExperimentalCoroutinesApi::class)
+@OptIn(ExperimentalCoroutinesApi::class, ExperimentalLayoutApi::class)
 @Composable
 fun OverviewScreen(
     tripsViewModel: TripsViewModel,
@@ -143,44 +145,33 @@ fun OverviewScreen(
       floatingActionButton = { AddTripFAB(isConnected, navigationActions) },
       modifier = Modifier.testTag("overviewScreen"),
       topBar = {
-        Row(modifier = Modifier.fillMaxWidth().padding(horizontal = 16.dp, vertical = 24.dp)) {
-          Column(modifier = Modifier.fillMaxWidth(0.9f).padding(start = 16.dp)) {
-            SearchBar(
-                placeholderId = R.string.overview_searchbar_placeholder,
-                onQueryChange = { searchQuery = it },
-                modifier = Modifier.testTag("searchField"))
-          }
-          Column {
-            IconButton(
-                onClick = { sortedDecreasing = !sortedDecreasing },
-                modifier = Modifier.testTag("reverseTripsOrderButton")) {
-                  Icon(imageVector = Icons.Default.SwapVert, contentDescription = "H")
-                }
-          }
-        Row(modifier = Modifier.fillMaxWidth(), verticalAlignment = Alignment.CenterVertically) {
-          SearchBar(
-              placeholderId = R.string.overview_searchbar_placeholder,
-              onQueryChange = { searchQuery = it },
-              modifier =
-                  Modifier.padding(horizontal = 16.dp, vertical = 24.dp)
-                      .testTag("searchField")
-                      .weight(1f))
+        FlowRow(
+            modifier = Modifier.fillMaxWidth().padding(horizontal = 16.dp, vertical = 24.dp),
+            verticalArrangement = Arrangement.Center,
+            horizontalArrangement = Arrangement.SpaceBetween) {
+              SearchBar(
+                  placeholderId = R.string.overview_searchbar_placeholder,
+                  onQueryChange = { searchQuery = it },
+                  modifier = Modifier.testTag("searchField").weight(1f).fillMaxWidth(0.9f))
 
-          Spacer(modifier = Modifier.width(8.dp))
-
-          IconButton(
-              onClick = { showOnlyFavorites = !showOnlyFavorites },
-              modifier = Modifier.testTag("favoriteFilterButton").padding(end = 8.dp)) {
-                Icon(
-                    imageVector =
-                        if (showOnlyFavorites) Icons.Filled.Favorite
-                        else Icons.Default.FavoriteBorder,
-                    contentDescription =
-                        if (showOnlyFavorites) stringResource(R.string.show_all_trips)
-                        else stringResource(R.string.show_favorite_trips),
-                    tint = MaterialTheme.colorScheme.onSurface)
-              }
-        }
+              IconButton(
+                  onClick = { sortedDecreasing = !sortedDecreasing },
+                  modifier = Modifier.testTag("reverseTripsOrderButton")) {
+                    Icon(imageVector = Icons.Default.SwapVert, contentDescription = "H")
+                  }
+              IconButton(
+                  onClick = { showOnlyFavorites = !showOnlyFavorites },
+                  modifier = Modifier.testTag("favoriteFilterButton")) {
+                    Icon(
+                        imageVector =
+                            if (showOnlyFavorites) Icons.Filled.Favorite
+                            else Icons.Default.FavoriteBorder,
+                        contentDescription =
+                            if (showOnlyFavorites) stringResource(R.string.show_all_trips)
+                            else stringResource(R.string.show_favorite_trips),
+                        tint = MaterialTheme.colorScheme.onSurface)
+                  }
+            }
       },
       bottomBar = {
         BottomNavigationMenu(
@@ -199,7 +190,7 @@ fun OverviewScreen(
             tripsViewModel = tripsViewModel,
             navigationActions = navigationActions,
             userViewModel = userViewModel,
-            descending = sortedDecreasing)
+            descending = sortedDecreasing,
             user = user!!)
       })
 }
@@ -303,7 +294,7 @@ private fun OverviewContent(
           tripsViewModel = tripsViewModel,
           navigationActions = navigationActions,
           userViewModel = userViewModel,
-          descending = descending)
+          descending = descending,
           user = user)
     }
   }


### PR DESCRIPTION
## Summary

This small PR introduces a button to reverse the order of the trips in the overview screen, in case you want to see older trips first.

## Checklist

Ensure all / most of these are checked before the pull request is submitted.
- [x] This PR resolves #313 
- [x] Screenshots or UI changes have been attached (if applicable).


## Screenshots (if applicable)


<img width="276" alt="image" src="https://github.com/user-attachments/assets/4c4e053d-52e1-4787-9118-aa90abc987a5" />
