### PR TITLE
Feat/ Assistant: Take all participants' interests into account 

### DIFF
--- a/app/src/androidTest/java/com/android/voyageur/ui/trip/assistant/AssistantTest.kt
+++ b/app/src/androidTest/java/com/android/voyageur/ui/trip/assistant/AssistantTest.kt
@@ -39,7 +39,7 @@ class AssistantScreenTest {
 
   @get:Rule val composeTestRule = createComposeRule()
 
-  private val sampleTrip = Trip(name = "Sample Trip")
+  private val sampleTrip = Trip(name = "Sample Trip", participants = listOf("user123", "contact1"))
   private val sampleJson =
       "[{\"title\":\"Activity 1\", \"description\": \"Description 1\", \"year\": 2022, \"month\": 1, \"day\": 1, \"startTimeHour\": 12, \"startTimeMinute\": 0, \"endTimeHour\": 14, \"endTimeMinute\": 0}" +
           ",{\"title\":\"Activity 2\", \"description\": \"Description 2\", \"year\": 2022, \"month\": 1, \"day\": 2, \"startTimeHour\": 12, \"startTimeMinute\": 0, \"endTimeHour\": 14, \"endTimeMinute\": 0}]"
@@ -54,6 +54,12 @@ class AssistantScreenTest {
           contacts = listOf(),
           interests = listOf("hiking", "cycling"))
 
+  private val mockContacts =
+      listOf(
+          User(id = "contact1", name = "Contact 1", interests = listOf("hiking", "art")),
+          User(id = "contact2", name = "Contact 2", interests = listOf("restaurants", "music")),
+          mockUser)
+
   @Before
   fun setUp() {
     tripRepository = mock(TripRepository::class.java)
@@ -67,6 +73,10 @@ class AssistantScreenTest {
     val userField = UserViewModel::class.java.getDeclaredField("user")
     userField.isAccessible = true
     userField.set(userViewModel, MutableStateFlow(mockUser))
+
+    val contactsField = UserViewModel::class.java.getDeclaredField("contacts")
+    contactsField.isAccessible = true
+    contactsField.set(userViewModel, MutableStateFlow(mockContacts))
   }
 
   @Test
@@ -167,8 +177,8 @@ class AssistantScreenTest {
     composeTestRule.onNodeWithTag("settingsDialog").assertIsDisplayed()
     composeTestRule.onNodeWithTag("provideFinalActivitiesSwitch").assertIsDisplayed()
     composeTestRule.onNodeWithTag("provideFinalActivitiesSwitch").assertIsOff()
-    composeTestRule.onNodeWithTag("useInterestsSwitch").assertIsDisplayed()
-    composeTestRule.onNodeWithTag("useInterestsSwitch").assertIsOff()
+    composeTestRule.onNodeWithTag("useUserInterestsSwitch").assertIsDisplayed()
+    composeTestRule.onNodeWithTag("useUserInterestsSwitch").assertIsOff()
     composeTestRule.onNodeWithTag("closeDialogButton").assertIsDisplayed()
   }
 
@@ -215,13 +225,51 @@ class AssistantScreenTest {
     }
 
     composeTestRule.onNodeWithTag("settingsButton").performClick()
-    composeTestRule.onNodeWithTag("useInterestsSwitch").performClick()
+    composeTestRule.onNodeWithTag("useUserInterestsSwitch").performClick()
     composeTestRule.onNodeWithTag("closeDialogButton").performClick()
-    // check the call to sendActivitiesPrompt happens with useInterests = true
+    // check the call to sendActivitiesPrompt happens with useUserInterests = true
     composeTestRule.onNodeWithTag("AIRequestButton").performClick()
     verify(mockTripsViewModel)
         .sendActivitiesPrompt(
             sampleTrip, "", listOf("hiking", "cycling"), provideFinalActivities = false)
+  }
+
+  @Test
+  fun checkAllParticipantsInterestsUsedWhenSwitched() {
+    val uiStateFlow = MutableStateFlow(UiState.Success(sampleJson))
+    val tripFlow = MutableStateFlow(sampleTrip)
+    `when`(mockTripsViewModel.selectedTrip).thenReturn(tripFlow)
+    `when`(mockTripsViewModel.uiState).thenReturn(uiStateFlow)
+    composeTestRule.setContent {
+      AssistantScreen(mockTripsViewModel, navigationActions, userViewModel)
+    }
+
+    composeTestRule.onNodeWithTag("settingsButton").performClick()
+    composeTestRule.onNodeWithTag("useParticipantsInterestsSwitch").performClick()
+    composeTestRule.onNodeWithTag("closeDialogButton").performClick()
+    // check the call to sendActivitiesPrompt happens with useUserInterests = true
+    composeTestRule.onNodeWithTag("AIRequestButton").performClick()
+    verify(mockTripsViewModel)
+        .sendActivitiesPrompt(
+            sampleTrip, "", listOf("hiking", "cycling", "art"), provideFinalActivities = false)
+  }
+
+  @Test
+  fun checkInterestsSwitchesAlternate() {
+    val uiStateFlow = MutableStateFlow(UiState.Success(sampleJson))
+    val tripFlow = MutableStateFlow(sampleTrip)
+    `when`(mockTripsViewModel.selectedTrip).thenReturn(tripFlow)
+    `when`(mockTripsViewModel.uiState).thenReturn(uiStateFlow)
+    composeTestRule.setContent {
+      AssistantScreen(mockTripsViewModel, navigationActions, userViewModel)
+    }
+    composeTestRule.onNodeWithTag("settingsButton").performClick()
+    composeTestRule.onNodeWithTag("useUserInterestsSwitch").performClick()
+    composeTestRule.onNodeWithTag("useParticipantsInterestsSwitch").assertIsOff()
+    composeTestRule.onNodeWithTag("useUserInterestsSwitch").assertIsOn()
+    composeTestRule.onNodeWithTag("useParticipantsInterestsSwitch").performClick()
+    composeTestRule.onNodeWithTag("useUserInterestsSwitch").assertIsOff()
+    composeTestRule.onNodeWithTag("useParticipantsInterestsSwitch").assertIsOn()
   }
 
   @Test

--- a/app/src/main/java/com/android/voyageur/ui/trip/assistant/Assistant.kt
+++ b/app/src/main/java/com/android/voyageur/ui/trip/assistant/Assistant.kt
@@ -74,6 +74,12 @@ fun AssistantScreen(
     navigationActions: NavigationActions,
     userViewModel: UserViewModel
 ) {
+  val trip = tripsViewModel.selectedTrip.value
+  if (trip == null) {
+    navigationActions.navigateTo(Screen.OVERVIEW)
+    return
+  }
+
   // State
   var result by rememberSaveable { mutableStateOf("placeholderResult") }
   val uiState by tripsViewModel.uiState.collectAsState()
@@ -81,20 +87,22 @@ fun AssistantScreen(
 
   // User related data
   var prompt by rememberSaveable { mutableStateOf("") }
-  val interests = userViewModel.user.collectAsState().value?.interests ?: emptyList()
+  val userInterests = userViewModel.user.collectAsState().value?.interests ?: emptyList()
+  val participantsInterests =
+      trip.participants
+          .mapNotNull { participant ->
+            userViewModel.contacts.value.find { it.id == participant } // Find user
+          }
+          .flatMap { user -> user.interests } // Extract all interests
+          .distinct() // Keep only distinct interests
 
   val keyboardController = LocalSoftwareKeyboardController.current
 
   // Settings
   var showSettingsDialog by rememberSaveable { mutableStateOf(false) }
   var provideFinalActivities by rememberSaveable { mutableStateOf(false) }
-  var useInterests by rememberSaveable { mutableStateOf(false) }
-
-  val trip = tripsViewModel.selectedTrip.value
-  if (trip == null) {
-    navigationActions.navigateTo(Screen.OVERVIEW)
-    return
-  }
+  var useUserInterests by rememberSaveable { mutableStateOf(false) }
+  var useParticipantsInterests by rememberSaveable { mutableStateOf(false) }
 
   Scaffold(
       modifier = Modifier.testTag("assistantScreen"),
@@ -121,7 +129,10 @@ fun AssistantScreen(
                             tripsViewModel.sendActivitiesPrompt(
                                 trip = trip,
                                 userPrompt = prompt,
-                                interests = if (useInterests) interests else emptyList(),
+                                interests =
+                                    if (useUserInterests) userInterests
+                                    else if (useParticipantsInterests) participantsInterests
+                                    else emptyList(),
                                 provideFinalActivities = provideFinalActivities,
                             )
                           }
@@ -132,7 +143,9 @@ fun AssistantScreen(
                   tripsViewModel.sendActivitiesPrompt(
                       trip = trip,
                       userPrompt = prompt,
-                      interests = if (useInterests) interests else emptyList(),
+                      interests =
+                          if (useUserInterests) userInterests
+                          else if (useParticipantsInterests) participantsInterests else emptyList(),
                       provideFinalActivities = provideFinalActivities,
                   )
                 },
@@ -209,8 +222,11 @@ fun AssistantScreen(
               onDismiss = { showSettingsDialog = false },
               provideDraftActivities = provideFinalActivities,
               onProvideFinalActivitiesChanged = { provideFinalActivities = it },
-              useInterests = useInterests,
-              onUseInterestsChanged = { useInterests = it })
+              useInterests = useUserInterests,
+              onUseInterestsChanged = { useUserInterests = it },
+              useParticipantsInterests = useParticipantsInterests,
+              onUseParticipantsInterestsChanged = { useParticipantsInterests = it },
+          )
         }
       })
 }
@@ -229,7 +245,9 @@ fun SettingsDialog(
     provideDraftActivities: Boolean,
     onProvideFinalActivitiesChanged: (Boolean) -> Unit,
     useInterests: Boolean,
-    onUseInterestsChanged: (Boolean) -> Unit
+    onUseInterestsChanged: (Boolean) -> Unit,
+    useParticipantsInterests: Boolean,
+    onUseParticipantsInterestsChanged: (Boolean) -> Unit,
 ) {
   AlertDialog(
       modifier = Modifier.testTag("settingsDialog"),
@@ -243,7 +261,7 @@ fun SettingsDialog(
                 modifier = Modifier.weight(1f),
                 style = MaterialTheme.typography.bodyLarge)
           }
-          Spacer(modifier = Modifier.height(16.dp)) // Add a spacer for some vertical space
+          Spacer(modifier = Modifier.height(16.dp))
 
           Row(verticalAlignment = Alignment.CenterVertically) {
             Text(stringResource(R.string.provide_final_activities), modifier = Modifier.weight(1f))
@@ -252,13 +270,33 @@ fun SettingsDialog(
                 onCheckedChange = onProvideFinalActivitiesChanged,
                 modifier = Modifier.testTag("provideFinalActivitiesSwitch"))
           }
-          Spacer(modifier = Modifier.height(16.dp)) // Add a spacer for some vertical space
+          Spacer(modifier = Modifier.height(4.dp))
           Row(verticalAlignment = Alignment.CenterVertically) {
-            Text(stringResource(R.string.use_interests), modifier = Modifier.weight(1f))
+            Text(stringResource(R.string.use_user_interests), modifier = Modifier.weight(1f))
             Switch(
                 checked = useInterests,
-                onCheckedChange = onUseInterestsChanged,
-                modifier = Modifier.testTag("useInterestsSwitch"))
+                onCheckedChange = { isChecked ->
+                  onUseInterestsChanged(isChecked)
+                  if (isChecked) {
+                    onUseParticipantsInterestsChanged(false) // Turn off the other switch
+                  }
+                },
+                modifier = Modifier.testTag("useUserInterestsSwitch"))
+          }
+          Spacer(modifier = Modifier.height(4.dp))
+
+          Row(verticalAlignment = Alignment.CenterVertically) {
+            Text(
+                stringResource(R.string.use_participants_interests), modifier = Modifier.weight(1f))
+            Switch(
+                checked = useParticipantsInterests,
+                onCheckedChange = { isChecked ->
+                  onUseParticipantsInterestsChanged(isChecked)
+                  if (isChecked) {
+                    onUseInterestsChanged(false) // Turn off the other switch
+                  }
+                },
+                modifier = Modifier.testTag("useParticipantsInterestsSwitch"))
           }
         }
       },

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -38,14 +38,15 @@
     <string name="search_users">Search users…</string>
     <string name="empty"> </string>
 
-<!--    AI ASSISTANT    -->
+<!-- AI ASSISTANT -->
     <string name="ask_assistant">Ask the AI assistant!</string>
     <string name="prompt">Prompt</string>
     <string name="go">Go</string>
     <string name="settings">Settings</string>
     <string name="settings_subtitle">Remember to click on the \'go\' button after changing the settings</string>
     <string name="provide_final_activities">Provide final activities with date and time (recommended for trips shorter than a week)</string>
-    <string name="use_interests">Use your profile\'s interests to recommend activities</string>
+    <string name="use_user_interests">Use only your profile\'s interests</string>
+    <string name="use_participants_interests">Use all participants\'s interests</string>
     <string name="close">Close</string>
 
     <!-- OVERVIEW SCREEN -->


### PR DESCRIPTION
## Summary

This new feature allows the AI assistant to recommend activities based on the interests of all participants in the trip. This is controlled by a switch in the settings view. The "use participants' interests" and "use only your interests" switches can't be both on at the same time.

## Changes

- **Screens/UI:** One new "use all participants' interests" switch on the settings dialog on the assistant screen

## Checklist

- [x] This PR resolves #325 
- [x] Tests have been added for new functionality.
- [x] Screenshots or UI changes have been attached (if applicable).
- [x] Documentation has been updated (if applicable).

##  Testing

- **Manual Testing:**
    - [x] Tested on emulator / physical device.
- **Unit Tests**
    - [x] Added units tests for this

## Screenshots (if applicable)

Mircea's dessert interest is taken into account:

[participant interests.webm](https://github.com/user-attachments/assets/082a14b0-6a3c-400a-ae07-1c16d4b6c218)

