### PR TITLE
Fix: add default params to trip invite model

### DIFF
--- a/app/src/main/java/com/android/voyageur/model/notifications/TripInvite.kt
+++ b/app/src/main/java/com/android/voyageur/model/notifications/TripInvite.kt
@@ -1,10 +1,10 @@
 package com.android.voyageur.model.notifications
 
 data class TripInvite(
-    val id: String,
-    val tripId: String,
-    val from: String,
-    val to: String,
+    val id: String = "",
+    val tripId: String = "",
+    val from: String = "",
+    val to: String = "",
     val accepted: Boolean = false
 ) {
   override fun equals(other: Any?): Boolean {


### PR DESCRIPTION
## Summary

Quick fix for a bug that caused the app to crash on startup due to deserialization errors.
Added default constructor for the trip invite model.

