### PR TITLE
Fix/trip invite format profile

### DIFF
--- a/app/src/main/java/com/android/voyageur/model/trip/TripsViewModel.kt
+++ b/app/src/main/java/com/android/voyageur/model/trip/TripsViewModel.kt
@@ -551,6 +551,12 @@ open class TripsViewModel(
         req = tripInvite, onSuccess = onSuccess, onFailure = onFailure)
   }
 
+  /**
+   * Fetches a trip by its ID and invokes the provided callback with the result.
+   *
+   * @param tripId The ID of the trip to fetch.
+   * @param onResult Callback to be invoked with the fetched trip or null if the fetch fails.
+   */
   fun getTripById(tripId: String, onResult: (Trip?) -> Unit) {
     tripsRepository.getTripById(
         tripId,

--- a/app/src/main/java/com/android/voyageur/model/trip/TripsViewModel.kt
+++ b/app/src/main/java/com/android/voyageur/model/trip/TripsViewModel.kt
@@ -550,4 +550,15 @@ open class TripsViewModel(
     tripInviteRepository.createTripInvite(
         req = tripInvite, onSuccess = onSuccess, onFailure = onFailure)
   }
+    fun getTripById(tripId: String, onResult: (Trip?) -> Unit) {
+        tripsRepository.getTripById(
+            tripId,
+            onSuccess = { trip -> onResult(trip) },
+            onFailure = { exception ->
+                Log.e("TripsViewModel", "Failed to fetch trip by ID: $exception")
+                onResult(null)
+            }
+        )
+    }
+
 }

--- a/app/src/main/java/com/android/voyageur/model/trip/TripsViewModel.kt
+++ b/app/src/main/java/com/android/voyageur/model/trip/TripsViewModel.kt
@@ -550,15 +550,14 @@ open class TripsViewModel(
     tripInviteRepository.createTripInvite(
         req = tripInvite, onSuccess = onSuccess, onFailure = onFailure)
   }
-    fun getTripById(tripId: String, onResult: (Trip?) -> Unit) {
-        tripsRepository.getTripById(
-            tripId,
-            onSuccess = { trip -> onResult(trip) },
-            onFailure = { exception ->
-                Log.e("TripsViewModel", "Failed to fetch trip by ID: $exception")
-                onResult(null)
-            }
-        )
-    }
 
+  fun getTripById(tripId: String, onResult: (Trip?) -> Unit) {
+    tripsRepository.getTripById(
+        tripId,
+        onSuccess = { trip -> onResult(trip) },
+        onFailure = { exception ->
+          Log.e("TripsViewModel", "Failed to fetch trip by ID: $exception")
+          onResult(null)
+        })
+  }
 }

--- a/app/src/main/java/com/android/voyageur/model/user/UserViewModel.kt
+++ b/app/src/main/java/com/android/voyageur/model/user/UserViewModel.kt
@@ -10,6 +10,7 @@ import com.android.voyageur.R
 import com.android.voyageur.model.notifications.FriendRequest
 import com.android.voyageur.model.notifications.FriendRequestRepository
 import com.android.voyageur.model.notifications.FriendRequestRepositoryFirebase
+import com.android.voyageur.model.notifications.TripInvite
 import com.android.voyageur.ui.notifications.NotificationProvider
 import com.android.voyageur.ui.notifications.StringProvider
 import com.google.firebase.Firebase
@@ -721,5 +722,20 @@ constructor(
               }
             },
             onFailure = { exception -> Log.e("USER_VIEW_MODEL", exception.message.orEmpty()) })
+  }
+
+  fun resolveTripInviteUsers(
+      invites: List<TripInvite>,
+      onResolved: (List<Pair<TripInvite, User>>) -> Unit
+  ) {
+    val userIds = invites.map { it.from }.distinct()
+    getUsersByIds(userIds) { users ->
+      val inviteUserPairs =
+          invites.mapNotNull { invite ->
+            val user = users.find { it.id == invite.from }
+            if (user != null) Pair(invite, user) else null
+          }
+      onResolved(inviteUserPairs)
+    }
   }
 }

--- a/app/src/main/java/com/android/voyageur/model/user/UserViewModel.kt
+++ b/app/src/main/java/com/android/voyageur/model/user/UserViewModel.kt
@@ -723,6 +723,12 @@ constructor(
             onFailure = { exception -> Log.e("USER_VIEW_MODEL", exception.message.orEmpty()) })
   }
 
+  /**
+   * Fetches a user by their ID and invokes the provided callback with the result.
+   *
+   * @param userId The ID of the user to fetch.
+   * @param onResult Callback to be invoked with the fetched user or null if the fetch fails.
+   */
   fun getUserById(userId: String, onResult: (User?) -> Unit) {
     userRepository.getUserById(
         userId,

--- a/app/src/main/java/com/android/voyageur/model/user/UserViewModel.kt
+++ b/app/src/main/java/com/android/voyageur/model/user/UserViewModel.kt
@@ -723,19 +723,15 @@ constructor(
             },
             onFailure = { exception -> Log.e("USER_VIEW_MODEL", exception.message.orEmpty()) })
   }
-
-  fun resolveTripInviteUsers(
-      invites: List<TripInvite>,
-      onResolved: (List<Pair<TripInvite, User>>) -> Unit
-  ) {
-    val userIds = invites.map { it.from }.distinct()
-    getUsersByIds(userIds) { users ->
-      val inviteUserPairs =
-          invites.mapNotNull { invite ->
-            val user = users.find { it.id == invite.from }
-            if (user != null) Pair(invite, user) else null
-          }
-      onResolved(inviteUserPairs)
+    fun getUserById(userId: String, onResult: (User?) -> Unit) {
+        userRepository.getUserById(
+            userId,
+            onSuccess = { user -> onResult(user) },
+            onFailure = { exception ->
+                Log.e("UserViewModel", "Failed to fetch user by ID: $exception")
+                onResult(null)
+            }
+        )
     }
-  }
+
 }

--- a/app/src/main/java/com/android/voyageur/model/user/UserViewModel.kt
+++ b/app/src/main/java/com/android/voyageur/model/user/UserViewModel.kt
@@ -10,7 +10,6 @@ import com.android.voyageur.R
 import com.android.voyageur.model.notifications.FriendRequest
 import com.android.voyageur.model.notifications.FriendRequestRepository
 import com.android.voyageur.model.notifications.FriendRequestRepositoryFirebase
-import com.android.voyageur.model.notifications.TripInvite
 import com.android.voyageur.ui.notifications.NotificationProvider
 import com.android.voyageur.ui.notifications.StringProvider
 import com.google.firebase.Firebase
@@ -723,15 +722,14 @@ constructor(
             },
             onFailure = { exception -> Log.e("USER_VIEW_MODEL", exception.message.orEmpty()) })
   }
-    fun getUserById(userId: String, onResult: (User?) -> Unit) {
-        userRepository.getUserById(
-            userId,
-            onSuccess = { user -> onResult(user) },
-            onFailure = { exception ->
-                Log.e("UserViewModel", "Failed to fetch user by ID: $exception")
-                onResult(null)
-            }
-        )
-    }
 
+  fun getUserById(userId: String, onResult: (User?) -> Unit) {
+    userRepository.getUserById(
+        userId,
+        onSuccess = { user -> onResult(user) },
+        onFailure = { exception ->
+          Log.e("UserViewModel", "Failed to fetch user by ID: $exception")
+          onResult(null)
+        })
+  }
 }

--- a/app/src/main/java/com/android/voyageur/ui/profile/ProfileScreen.kt
+++ b/app/src/main/java/com/android/voyageur/ui/profile/ProfileScreen.kt
@@ -69,43 +69,43 @@ fun ProfileScreen(
     tripsViewModel: TripsViewModel,
     navigationActions: NavigationActions
 ) {
-    val user by userViewModel.user.collectAsState()
-    val isLoading by userViewModel.isLoading.collectAsState()
+  val user by userViewModel.user.collectAsState()
+  val isLoading by userViewModel.isLoading.collectAsState()
 
-    LaunchedEffect(Unit) { tripsViewModel.fetchTripInvites() }
+  LaunchedEffect(Unit) { tripsViewModel.fetchTripInvites() }
 
-    var isSigningOut by remember { mutableStateOf(false) }
+  var isSigningOut by remember { mutableStateOf(false) }
 
-    if (user == null && !isLoading) {
-        LaunchedEffect(Unit) { navigationActions.navigateTo(Route.AUTH) }
-        return
+  if (user == null && !isLoading) {
+    LaunchedEffect(Unit) { navigationActions.navigateTo(Route.AUTH) }
+    return
+  }
+
+  if (isSigningOut) {
+    LaunchedEffect(Unit) {
+      userViewModel.signOutUser()
+      navigationActions.navigateTo(Route.AUTH)
     }
+  }
 
-    if (isSigningOut) {
-        LaunchedEffect(Unit) {
-            userViewModel.signOutUser()
-            navigationActions.navigateTo(Route.AUTH)
-        }
-    }
-
-    Scaffold(
-        modifier = Modifier.testTag("profileScreen"),
-        bottomBar = {
-            BottomNavigationMenu(
-                onTabSelect = { navigationActions.navigateTo(it) },
-                tabList = LIST_TOP_LEVEL_DESTINATION,
-                selectedItem = navigationActions.currentRoute(),
-                userViewModel,
-                tripsViewModel)
-        }) { padding ->
+  Scaffold(
+      modifier = Modifier.testTag("profileScreen"),
+      bottomBar = {
+        BottomNavigationMenu(
+            onTabSelect = { navigationActions.navigateTo(it) },
+            tabList = LIST_TOP_LEVEL_DESTINATION,
+            selectedItem = navigationActions.currentRoute(),
+            userViewModel,
+            tripsViewModel)
+      }) { padding ->
         Box(
             modifier =
-            Modifier.fillMaxSize()
-                .padding(padding)
-                .verticalScroll(rememberScrollState())
-                .testTag("profileScreenContent"),
+                Modifier.fillMaxSize()
+                    .padding(padding)
+                    .verticalScroll(rememberScrollState())
+                    .testTag("profileScreenContent"),
             contentAlignment = Alignment.Center) {
-            when {
+              when {
                 isSigningOut ->
                     CircularProgressIndicator(modifier = Modifier.testTag("signingOutIndicator"))
                 isLoading ->
@@ -122,9 +122,9 @@ fun ProfileScreen(
                     Text(
                         stringResource(R.string.no_user_data),
                         modifier = Modifier.testTag("noUserData"))
+              }
             }
-        }
-    }
+      }
 }
 
 /**
@@ -146,13 +146,13 @@ fun ProfileContent(
     tripsViewModel: TripsViewModel,
     onEdit: () -> Unit
 ) {
-    val friendRequests by userViewModel.friendRequests.collectAsState()
-    val notificationUsers by userViewModel.notificationUsers.collectAsState()
-    val tripInvites by tripsViewModel.tripInvites.collectAsState()
+  val friendRequests by userViewModel.friendRequests.collectAsState()
+  val notificationUsers by userViewModel.notificationUsers.collectAsState()
+  val tripInvites by tripsViewModel.tripInvites.collectAsState()
 
-    Column(
-        modifier = Modifier.fillMaxSize().padding(top = 16.dp),
-        horizontalAlignment = Alignment.CenterHorizontally) {
+  Column(
+      modifier = Modifier.fillMaxSize().padding(top = 16.dp),
+      horizontalAlignment = Alignment.CenterHorizontally) {
         UserProfileContent(
             userData = userData,
             signedInUserId = signedInUserId,
@@ -168,9 +168,10 @@ fun ProfileContent(
 
         // Trip Invite Menu
         TripInviteMenu(
-            tripInvites = tripInvites, tripsViewModel = tripsViewModel, userViewModel = userViewModel
-        )
-    }
+            tripInvites = tripInvites,
+            tripsViewModel = tripsViewModel,
+            userViewModel = userViewModel)
+      }
 }
 
 @Composable
@@ -179,110 +180,107 @@ fun TripInviteItem(
     tripsViewModel: TripsViewModel,
     userViewModel: UserViewModel
 ) {
-    val tripName = remember { mutableStateOf("Loading trip...") }
-    val senderName = remember { mutableStateOf("Loading user...") }
+  val tripName = remember { mutableStateOf("Loading trip...") }
+  val senderName = remember { mutableStateOf("Loading user...") }
 
-    // Fetch the trip and user details asynchronously
-    LaunchedEffect(tripInvite) {
-        tripsViewModel.getTripById(tripInvite.tripId) { trip ->
-            tripName.value = trip?.name ?: "Unknown Trip"
-        }
-        userViewModel.getUserById(tripInvite.from) { user ->
-            senderName.value = user?.name ?: "Unknown User"
-        }
+  // Fetch the trip and user details asynchronously
+  LaunchedEffect(tripInvite) {
+    tripsViewModel.getTripById(tripInvite.tripId) { trip ->
+      tripName.value = trip?.name ?: "Unknown Trip"
     }
+    userViewModel.getUserById(tripInvite.from) { user ->
+      senderName.value = user?.name ?: "Unknown User"
+    }
+  }
 
-    Row(
-        modifier = Modifier
-            .fillMaxWidth()
-            .padding(8.dp)
-            .testTag("tripInvite"),
-        verticalAlignment = Alignment.CenterVertically,
-        horizontalArrangement = Arrangement.SpaceBetween
-    ) {
+  Row(
+      modifier = Modifier.fillMaxWidth().padding(8.dp).testTag("tripInvite"),
+      verticalAlignment = Alignment.CenterVertically,
+      horizontalArrangement = Arrangement.SpaceBetween) {
         Column(modifier = Modifier.weight(1f)) {
-            Text(
-                text = tripName.value,
-                style = MaterialTheme.typography.titleMedium, // Updated style
-                maxLines = 1,
-                overflow = TextOverflow.Ellipsis
-            )
-            Text(
-                text = "Invited by: ${senderName.value}",
-                style = MaterialTheme.typography.bodySmall, // Updated style
-                maxLines = 1,
-                overflow = TextOverflow.Ellipsis
-            )
+          Text(
+              text = tripName.value,
+              style = MaterialTheme.typography.titleMedium, // Updated style
+              maxLines = 1,
+              overflow = TextOverflow.Ellipsis)
+          Text(
+              text = "Invited by: ${senderName.value}",
+              style = MaterialTheme.typography.bodySmall, // Updated style
+              maxLines = 1,
+              overflow = TextOverflow.Ellipsis)
         }
 
         Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
-            IconButton(
-                modifier = Modifier.testTag("acceptButton"),
-                onClick = { tripsViewModel.acceptTripInvite(tripInvite) }
-            ) {
+          IconButton(
+              modifier = Modifier.testTag("acceptButton"),
+              onClick = { tripsViewModel.acceptTripInvite(tripInvite) }) {
                 Icon(
                     imageVector = Icons.Default.Check,
                     contentDescription = stringResource(R.string.accept),
-                    tint = Color.Green
-                )
-            }
+                    tint = Color.Green)
+              }
 
-            IconButton(
-                modifier = Modifier.testTag("denyButton"),
-                onClick = { tripsViewModel.declineTripInvite(tripInvite.id) }
-            ) {
+          IconButton(
+              modifier = Modifier.testTag("denyButton"),
+              onClick = { tripsViewModel.declineTripInvite(tripInvite.id) }) {
                 Icon(
                     imageVector = Icons.Default.Close,
                     contentDescription = stringResource(R.string.reject),
-                    tint = Color.Red
-                )
-            }
+                    tint = Color.Red)
+              }
         }
-    }
+      }
 }
 
 @Composable
-fun TripInviteMenu(tripInvites: List<TripInvite>, tripsViewModel: TripsViewModel, userViewModel: UserViewModel) {
-    Card(
-        shape = RoundedCornerShape(12.dp),
-        modifier =
-        Modifier.fillMaxWidth(0.80f)
-            .padding(horizontal = 10.dp, vertical = 8.dp)
-            .testTag("tripInviteCard")) {
+fun TripInviteMenu(
+    tripInvites: List<TripInvite>,
+    tripsViewModel: TripsViewModel,
+    userViewModel: UserViewModel
+) {
+  Card(
+      shape = RoundedCornerShape(12.dp),
+      modifier =
+          Modifier.fillMaxWidth(0.80f)
+              .padding(horizontal = 10.dp, vertical = 8.dp)
+              .testTag("tripInviteCard")) {
         Column(modifier = Modifier.padding(12.dp)) {
-            Text(
-                text = stringResource(R.string.pending_trip_invites, tripInvites.size),
-                color = MaterialTheme.colorScheme.onSurface,
-            )
+          Text(
+              text = stringResource(R.string.pending_trip_invites, tripInvites.size),
+              color = MaterialTheme.colorScheme.onSurface,
+          )
 
-            Card(
-                shape = RoundedCornerShape(8.dp),
-                modifier =
-                Modifier.fillMaxWidth()
-                    .heightIn(max = 180.dp)
-                    .padding(top = 8.dp)
-                    .testTag("tripInviteBox")) {
+          Card(
+              shape = RoundedCornerShape(8.dp),
+              modifier =
+                  Modifier.fillMaxWidth()
+                      .heightIn(max = 180.dp)
+                      .padding(top = 8.dp)
+                      .testTag("tripInviteBox")) {
                 if (tripInvites.isEmpty()) {
-                    Box(
-                        modifier = Modifier.fillMaxSize().testTag("noInvitesBox"),
-                        contentAlignment = Alignment.Center) {
+                  Box(
+                      modifier = Modifier.fillMaxSize().testTag("noInvitesBox"),
+                      contentAlignment = Alignment.Center) {
                         Text(
                             text = stringResource(R.string.no_pending_invites),
                             fontSize = 12.sp,
                             color = MaterialTheme.colorScheme.onSurfaceVariant)
-                    }
+                      }
                 } else {
-                    LazyColumn(
-                        modifier =
-                        Modifier.fillMaxSize().padding(8.dp).testTag("tripInviteLazyColumn")) {
+                  LazyColumn(
+                      modifier =
+                          Modifier.fillMaxSize().padding(8.dp).testTag("tripInviteLazyColumn")) {
                         items(tripInvites) { invite ->
-                            TripInviteItem(tripInvite = invite, tripsViewModel = tripsViewModel, userViewModel = userViewModel)
+                          TripInviteItem(
+                              tripInvite = invite,
+                              tripsViewModel = tripsViewModel,
+                              userViewModel = userViewModel)
                         }
-                    }
+                      }
                 }
-            }
+              }
         }
-    }
+      }
 }
 
 /**
@@ -301,56 +299,56 @@ fun FriendReqMenu(
     notificationUsers: List<User>,
     userViewModel: UserViewModel,
 ) {
-    // Parent Card containing the scrollable box
-    Card(
-        shape = RoundedCornerShape(12.dp),
-        modifier =
-        Modifier.fillMaxWidth(0.80f)
-            .padding(horizontal = 10.dp, vertical = 8.dp)
-            .testTag("friendRequestCard")) {
+  // Parent Card containing the scrollable box
+  Card(
+      shape = RoundedCornerShape(12.dp),
+      modifier =
+          Modifier.fillMaxWidth(0.80f)
+              .padding(horizontal = 10.dp, vertical = 8.dp)
+              .testTag("friendRequestCard")) {
         Column(modifier = Modifier.padding(12.dp)) {
-            Text(
-                text = stringResource(R.string.pending_friend_requests, friendRequests.size),
-                color = MaterialTheme.colorScheme.onSurface,
-            )
+          Text(
+              text = stringResource(R.string.pending_friend_requests, friendRequests.size),
+              color = MaterialTheme.colorScheme.onSurface,
+          )
 
-            // Scrollable List inside a fixed-height box
-            Card(
-                shape = RoundedCornerShape(8.dp),
-                modifier =
-                Modifier.fillMaxWidth()
-                    .heightIn(max = 180.dp) // Set the height to restrict the scrollable area
-                    .padding(top = 8.dp)
-                    .testTag("friendRequestBox")) {
+          // Scrollable List inside a fixed-height box
+          Card(
+              shape = RoundedCornerShape(8.dp),
+              modifier =
+                  Modifier.fillMaxWidth()
+                      .heightIn(max = 180.dp) // Set the height to restrict the scrollable area
+                      .padding(top = 8.dp)
+                      .testTag("friendRequestBox")) {
                 if (friendRequests.isEmpty()) {
-                    // Display message if no friend requests
-                    Box(
-                        modifier = Modifier.fillMaxSize().testTag("noRequestsBox"),
-                        contentAlignment = Alignment.Center) {
+                  // Display message if no friend requests
+                  Box(
+                      modifier = Modifier.fillMaxSize().testTag("noRequestsBox"),
+                      contentAlignment = Alignment.Center) {
                         Text(
                             text = stringResource(R.string.no_pending_requests),
                             fontSize = 12.sp,
                             color = MaterialTheme.colorScheme.onSurfaceVariant)
-                    }
+                      }
                 } else {
-                    // Display Lazy Column with the friend requests
-                    LazyColumn(
-                        modifier =
-                        Modifier.fillMaxSize().padding(8.dp).testTag("friendRequestLazyColumn")) {
+                  // Display Lazy Column with the friend requests
+                  LazyColumn(
+                      modifier =
+                          Modifier.fillMaxSize().padding(8.dp).testTag("friendRequestLazyColumn")) {
                         items(friendRequests) { request ->
-                            val fromUser = notificationUsers.find { it.id == request.from }
-                            fromUser?.let {
-                                FriendRequestItem(
-                                    friendRequest = request,
-                                    fromUser = fromUser,
-                                    userViewModel = userViewModel)
-                            }
+                          val fromUser = notificationUsers.find { it.id == request.from }
+                          fromUser?.let {
+                            FriendRequestItem(
+                                friendRequest = request,
+                                fromUser = fromUser,
+                                userViewModel = userViewModel)
+                          }
                         }
-                    }
+                      }
                 }
-            }
+              }
         }
-    }
+      }
 }
 /**
  * A composable function that displays a single friend request item. The item shows the user's
@@ -363,47 +361,47 @@ fun FriendReqMenu(
  */
 @Composable
 fun FriendRequestItem(friendRequest: FriendRequest, fromUser: User, userViewModel: UserViewModel) {
-    Row(
-        modifier = Modifier.fillMaxWidth().padding(8.dp).testTag("friendRequest"),
-        verticalAlignment = Alignment.CenterVertically,
-        horizontalArrangement = Arrangement.SpaceBetween) {
+  Row(
+      modifier = Modifier.fillMaxWidth().padding(8.dp).testTag("friendRequest"),
+      verticalAlignment = Alignment.CenterVertically,
+      horizontalArrangement = Arrangement.SpaceBetween) {
         // Display the Profile Picture of the user from which you have a request
         Image(
             painter = rememberAsyncImagePainter(fromUser.profilePicture),
             contentDescription = stringResource(R.string.profile_picture),
             modifier =
-            Modifier.size(40.dp).clip(RoundedCornerShape(20.dp)).testTag("profilePicture"))
+                Modifier.size(40.dp).clip(RoundedCornerShape(20.dp)).testTag("profilePicture"))
 
         Text(
             text = fromUser.name,
             modifier = Modifier.padding(start = 8.dp).weight(1f) // Take remaining space
-        )
+            )
 
         // Accept and Reject Icons
         Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
-            IconButton(
-                modifier = Modifier.testTag("acceptButton"),
-                onClick = {
-                    // Accept user's friend request and add to contacts
-                    userViewModel.acceptFriendRequest(friendRequest)
-                }) {
+          IconButton(
+              modifier = Modifier.testTag("acceptButton"),
+              onClick = {
+                // Accept user's friend request and add to contacts
+                userViewModel.acceptFriendRequest(friendRequest)
+              }) {
                 Icon(
                     imageVector = Icons.Default.Check,
                     contentDescription = stringResource(R.string.accept),
                     tint = Color.Green)
-            }
+              }
 
-            IconButton(
-                modifier = Modifier.testTag("denyButton"),
-                onClick = {
-                    // Delete the user friend request
-                    userViewModel.deleteFriendRequest(friendRequest.id)
-                }) {
+          IconButton(
+              modifier = Modifier.testTag("denyButton"),
+              onClick = {
+                // Delete the user friend request
+                userViewModel.deleteFriendRequest(friendRequest.id)
+              }) {
                 Icon(
                     imageVector = Icons.Default.Close,
                     contentDescription = stringResource(R.string.reject),
                     tint = Color.Red)
-            }
+              }
         }
-    }
+      }
 }

--- a/app/src/main/java/com/android/voyageur/ui/profile/ProfileScreen.kt
+++ b/app/src/main/java/com/android/voyageur/ui/profile/ProfileScreen.kt
@@ -41,6 +41,7 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import coil.compose.rememberAsyncImagePainter
@@ -68,43 +69,43 @@ fun ProfileScreen(
     tripsViewModel: TripsViewModel,
     navigationActions: NavigationActions
 ) {
-  val user by userViewModel.user.collectAsState()
-  val isLoading by userViewModel.isLoading.collectAsState()
+    val user by userViewModel.user.collectAsState()
+    val isLoading by userViewModel.isLoading.collectAsState()
 
-  LaunchedEffect(Unit) { tripsViewModel.fetchTripInvites() }
+    LaunchedEffect(Unit) { tripsViewModel.fetchTripInvites() }
 
-  var isSigningOut by remember { mutableStateOf(false) }
+    var isSigningOut by remember { mutableStateOf(false) }
 
-  if (user == null && !isLoading) {
-    LaunchedEffect(Unit) { navigationActions.navigateTo(Route.AUTH) }
-    return
-  }
-
-  if (isSigningOut) {
-    LaunchedEffect(Unit) {
-      userViewModel.signOutUser()
-      navigationActions.navigateTo(Route.AUTH)
+    if (user == null && !isLoading) {
+        LaunchedEffect(Unit) { navigationActions.navigateTo(Route.AUTH) }
+        return
     }
-  }
 
-  Scaffold(
-      modifier = Modifier.testTag("profileScreen"),
-      bottomBar = {
-        BottomNavigationMenu(
-            onTabSelect = { navigationActions.navigateTo(it) },
-            tabList = LIST_TOP_LEVEL_DESTINATION,
-            selectedItem = navigationActions.currentRoute(),
-            userViewModel,
-            tripsViewModel)
-      }) { padding ->
+    if (isSigningOut) {
+        LaunchedEffect(Unit) {
+            userViewModel.signOutUser()
+            navigationActions.navigateTo(Route.AUTH)
+        }
+    }
+
+    Scaffold(
+        modifier = Modifier.testTag("profileScreen"),
+        bottomBar = {
+            BottomNavigationMenu(
+                onTabSelect = { navigationActions.navigateTo(it) },
+                tabList = LIST_TOP_LEVEL_DESTINATION,
+                selectedItem = navigationActions.currentRoute(),
+                userViewModel,
+                tripsViewModel)
+        }) { padding ->
         Box(
             modifier =
-                Modifier.fillMaxSize()
-                    .padding(padding)
-                    .verticalScroll(rememberScrollState())
-                    .testTag("profileScreenContent"),
+            Modifier.fillMaxSize()
+                .padding(padding)
+                .verticalScroll(rememberScrollState())
+                .testTag("profileScreenContent"),
             contentAlignment = Alignment.Center) {
-              when {
+            when {
                 isSigningOut ->
                     CircularProgressIndicator(modifier = Modifier.testTag("signingOutIndicator"))
                 isLoading ->
@@ -121,9 +122,9 @@ fun ProfileScreen(
                     Text(
                         stringResource(R.string.no_user_data),
                         modifier = Modifier.testTag("noUserData"))
-              }
             }
-      }
+        }
+    }
 }
 
 /**
@@ -145,13 +146,13 @@ fun ProfileContent(
     tripsViewModel: TripsViewModel,
     onEdit: () -> Unit
 ) {
-  val friendRequests by userViewModel.friendRequests.collectAsState()
-  val notificationUsers by userViewModel.notificationUsers.collectAsState()
-  val tripInvites by tripsViewModel.tripInvites.collectAsState()
+    val friendRequests by userViewModel.friendRequests.collectAsState()
+    val notificationUsers by userViewModel.notificationUsers.collectAsState()
+    val tripInvites by tripsViewModel.tripInvites.collectAsState()
 
-  Column(
-      modifier = Modifier.fillMaxSize().padding(top = 16.dp),
-      horizontalAlignment = Alignment.CenterHorizontally) {
+    Column(
+        modifier = Modifier.fillMaxSize().padding(top = 16.dp),
+        horizontalAlignment = Alignment.CenterHorizontally) {
         UserProfileContent(
             userData = userData,
             signedInUserId = signedInUserId,
@@ -167,83 +168,121 @@ fun ProfileContent(
 
         // Trip Invite Menu
         TripInviteMenu(
-            tripInvites = tripInvites,
-            tripsViewModel = tripsViewModel,
-            userViewModel = userViewModel)
-      }
+            tripInvites = tripInvites, tripsViewModel = tripsViewModel, userViewModel = userViewModel
+        )
+    }
 }
 
 @Composable
-fun TripInviteItem(tripInvite: TripInvite, sender: User, tripsViewModel: TripsViewModel) {
-  Row(
-      modifier = Modifier.fillMaxWidth().padding(8.dp),
-      verticalAlignment = Alignment.CenterVertically,
-      horizontalArrangement = Arrangement.SpaceBetween) {
-        Column(modifier = Modifier.weight(1f)) {
-          Text(text = stringResource(R.string.from_user, sender.name))
-          Text(text = stringResource(R.string.trip_id, tripInvite.tripId))
-        }
-
-        Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
-          IconButton(onClick = { tripsViewModel.acceptTripInvite(tripInvite) }) {
-            Icon(
-                imageVector = Icons.Default.Check,
-                contentDescription = stringResource(R.string.accept),
-                tint = Color.Green)
-          }
-
-          IconButton(onClick = { tripsViewModel.declineTripInvite(tripInvite.id) }) {
-            Icon(
-                imageVector = Icons.Default.Close,
-                contentDescription = stringResource(R.string.reject),
-                tint = Color.Red)
-          }
-        }
-      }
-}
-
-@Composable
-fun TripInviteMenu(
-    tripInvites: List<TripInvite>,
+fun TripInviteItem(
+    tripInvite: TripInvite,
     tripsViewModel: TripsViewModel,
     userViewModel: UserViewModel
 ) {
-  var resolvedInvites by remember { mutableStateOf<List<Pair<TripInvite, User>>>(emptyList()) }
+    val tripName = remember { mutableStateOf("Loading trip...") }
+    val senderName = remember { mutableStateOf("Loading user...") }
 
-  LaunchedEffect(tripInvites) {
-    userViewModel.resolveTripInviteUsers(tripInvites) { resolved -> resolvedInvites = resolved }
-  }
-
-  Card(
-      shape = RoundedCornerShape(12.dp),
-      modifier = Modifier.fillMaxWidth(0.80f).padding(horizontal = 10.dp, vertical = 8.dp)) {
-        Column(modifier = Modifier.padding(12.dp)) {
-          Text(
-              text = stringResource(R.string.pending_trip_invites, resolvedInvites.size),
-              color = MaterialTheme.colorScheme.onSurface,
-          )
-
-          Card(
-              shape = RoundedCornerShape(8.dp),
-              modifier = Modifier.fillMaxWidth().heightIn(max = 180.dp).padding(top = 8.dp)) {
-                if (resolvedInvites.isEmpty()) {
-                  Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
-                    Text(
-                        text = stringResource(R.string.no_pending_invites),
-                        fontSize = 12.sp,
-                        color = MaterialTheme.colorScheme.onSurfaceVariant)
-                  }
-                } else {
-                  LazyColumn(modifier = Modifier.fillMaxSize().padding(8.dp)) {
-                    items(resolvedInvites) { (invite, user) ->
-                      TripInviteItem(
-                          tripInvite = invite, sender = user, tripsViewModel = tripsViewModel)
-                    }
-                  }
-                }
-              }
+    // Fetch the trip and user details asynchronously
+    LaunchedEffect(tripInvite) {
+        tripsViewModel.getTripById(tripInvite.tripId) { trip ->
+            tripName.value = trip?.name ?: "Unknown Trip"
         }
-      }
+        userViewModel.getUserById(tripInvite.from) { user ->
+            senderName.value = user?.name ?: "Unknown User"
+        }
+    }
+
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(8.dp)
+            .testTag("tripInvite"),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.SpaceBetween
+    ) {
+        Column(modifier = Modifier.weight(1f)) {
+            Text(
+                text = tripName.value,
+                style = MaterialTheme.typography.titleMedium, // Updated style
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis
+            )
+            Text(
+                text = "Invited by: ${senderName.value}",
+                style = MaterialTheme.typography.bodySmall, // Updated style
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis
+            )
+        }
+
+        Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+            IconButton(
+                modifier = Modifier.testTag("acceptButton"),
+                onClick = { tripsViewModel.acceptTripInvite(tripInvite) }
+            ) {
+                Icon(
+                    imageVector = Icons.Default.Check,
+                    contentDescription = stringResource(R.string.accept),
+                    tint = Color.Green
+                )
+            }
+
+            IconButton(
+                modifier = Modifier.testTag("denyButton"),
+                onClick = { tripsViewModel.declineTripInvite(tripInvite.id) }
+            ) {
+                Icon(
+                    imageVector = Icons.Default.Close,
+                    contentDescription = stringResource(R.string.reject),
+                    tint = Color.Red
+                )
+            }
+        }
+    }
+}
+
+@Composable
+fun TripInviteMenu(tripInvites: List<TripInvite>, tripsViewModel: TripsViewModel, userViewModel: UserViewModel) {
+    Card(
+        shape = RoundedCornerShape(12.dp),
+        modifier =
+        Modifier.fillMaxWidth(0.80f)
+            .padding(horizontal = 10.dp, vertical = 8.dp)
+            .testTag("tripInviteCard")) {
+        Column(modifier = Modifier.padding(12.dp)) {
+            Text(
+                text = stringResource(R.string.pending_trip_invites, tripInvites.size),
+                color = MaterialTheme.colorScheme.onSurface,
+            )
+
+            Card(
+                shape = RoundedCornerShape(8.dp),
+                modifier =
+                Modifier.fillMaxWidth()
+                    .heightIn(max = 180.dp)
+                    .padding(top = 8.dp)
+                    .testTag("tripInviteBox")) {
+                if (tripInvites.isEmpty()) {
+                    Box(
+                        modifier = Modifier.fillMaxSize().testTag("noInvitesBox"),
+                        contentAlignment = Alignment.Center) {
+                        Text(
+                            text = stringResource(R.string.no_pending_invites),
+                            fontSize = 12.sp,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant)
+                    }
+                } else {
+                    LazyColumn(
+                        modifier =
+                        Modifier.fillMaxSize().padding(8.dp).testTag("tripInviteLazyColumn")) {
+                        items(tripInvites) { invite ->
+                            TripInviteItem(tripInvite = invite, tripsViewModel = tripsViewModel, userViewModel = userViewModel)
+                        }
+                    }
+                }
+            }
+        }
+    }
 }
 
 /**
@@ -262,56 +301,56 @@ fun FriendReqMenu(
     notificationUsers: List<User>,
     userViewModel: UserViewModel,
 ) {
-  // Parent Card containing the scrollable box
-  Card(
-      shape = RoundedCornerShape(12.dp),
-      modifier =
-          Modifier.fillMaxWidth(0.80f)
-              .padding(horizontal = 10.dp, vertical = 8.dp)
-              .testTag("friendRequestCard")) {
+    // Parent Card containing the scrollable box
+    Card(
+        shape = RoundedCornerShape(12.dp),
+        modifier =
+        Modifier.fillMaxWidth(0.80f)
+            .padding(horizontal = 10.dp, vertical = 8.dp)
+            .testTag("friendRequestCard")) {
         Column(modifier = Modifier.padding(12.dp)) {
-          Text(
-              text = stringResource(R.string.pending_friend_requests, friendRequests.size),
-              color = MaterialTheme.colorScheme.onSurface,
-          )
+            Text(
+                text = stringResource(R.string.pending_friend_requests, friendRequests.size),
+                color = MaterialTheme.colorScheme.onSurface,
+            )
 
-          // Scrollable List inside a fixed-height box
-          Card(
-              shape = RoundedCornerShape(8.dp),
-              modifier =
-                  Modifier.fillMaxWidth()
-                      .heightIn(max = 180.dp) // Set the height to restrict the scrollable area
-                      .padding(top = 8.dp)
-                      .testTag("friendRequestBox")) {
+            // Scrollable List inside a fixed-height box
+            Card(
+                shape = RoundedCornerShape(8.dp),
+                modifier =
+                Modifier.fillMaxWidth()
+                    .heightIn(max = 180.dp) // Set the height to restrict the scrollable area
+                    .padding(top = 8.dp)
+                    .testTag("friendRequestBox")) {
                 if (friendRequests.isEmpty()) {
-                  // Display message if no friend requests
-                  Box(
-                      modifier = Modifier.fillMaxSize().testTag("noRequestsBox"),
-                      contentAlignment = Alignment.Center) {
+                    // Display message if no friend requests
+                    Box(
+                        modifier = Modifier.fillMaxSize().testTag("noRequestsBox"),
+                        contentAlignment = Alignment.Center) {
                         Text(
                             text = stringResource(R.string.no_pending_requests),
                             fontSize = 12.sp,
                             color = MaterialTheme.colorScheme.onSurfaceVariant)
-                      }
+                    }
                 } else {
-                  // Display Lazy Column with the friend requests
-                  LazyColumn(
-                      modifier =
-                          Modifier.fillMaxSize().padding(8.dp).testTag("friendRequestLazyColumn")) {
+                    // Display Lazy Column with the friend requests
+                    LazyColumn(
+                        modifier =
+                        Modifier.fillMaxSize().padding(8.dp).testTag("friendRequestLazyColumn")) {
                         items(friendRequests) { request ->
-                          val fromUser = notificationUsers.find { it.id == request.from }
-                          fromUser?.let {
-                            FriendRequestItem(
-                                friendRequest = request,
-                                fromUser = fromUser,
-                                userViewModel = userViewModel)
-                          }
+                            val fromUser = notificationUsers.find { it.id == request.from }
+                            fromUser?.let {
+                                FriendRequestItem(
+                                    friendRequest = request,
+                                    fromUser = fromUser,
+                                    userViewModel = userViewModel)
+                            }
                         }
-                      }
+                    }
                 }
-              }
+            }
         }
-      }
+    }
 }
 /**
  * A composable function that displays a single friend request item. The item shows the user's
@@ -324,47 +363,47 @@ fun FriendReqMenu(
  */
 @Composable
 fun FriendRequestItem(friendRequest: FriendRequest, fromUser: User, userViewModel: UserViewModel) {
-  Row(
-      modifier = Modifier.fillMaxWidth().padding(8.dp).testTag("friendRequest"),
-      verticalAlignment = Alignment.CenterVertically,
-      horizontalArrangement = Arrangement.SpaceBetween) {
+    Row(
+        modifier = Modifier.fillMaxWidth().padding(8.dp).testTag("friendRequest"),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.SpaceBetween) {
         // Display the Profile Picture of the user from which you have a request
         Image(
             painter = rememberAsyncImagePainter(fromUser.profilePicture),
             contentDescription = stringResource(R.string.profile_picture),
             modifier =
-                Modifier.size(40.dp).clip(RoundedCornerShape(20.dp)).testTag("profilePicture"))
+            Modifier.size(40.dp).clip(RoundedCornerShape(20.dp)).testTag("profilePicture"))
 
         Text(
             text = fromUser.name,
             modifier = Modifier.padding(start = 8.dp).weight(1f) // Take remaining space
-            )
+        )
 
         // Accept and Reject Icons
         Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
-          IconButton(
-              modifier = Modifier.testTag("acceptButton"),
-              onClick = {
-                // Accept user's friend request and add to contacts
-                userViewModel.acceptFriendRequest(friendRequest)
-              }) {
+            IconButton(
+                modifier = Modifier.testTag("acceptButton"),
+                onClick = {
+                    // Accept user's friend request and add to contacts
+                    userViewModel.acceptFriendRequest(friendRequest)
+                }) {
                 Icon(
                     imageVector = Icons.Default.Check,
                     contentDescription = stringResource(R.string.accept),
                     tint = Color.Green)
-              }
+            }
 
-          IconButton(
-              modifier = Modifier.testTag("denyButton"),
-              onClick = {
-                // Delete the user friend request
-                userViewModel.deleteFriendRequest(friendRequest.id)
-              }) {
+            IconButton(
+                modifier = Modifier.testTag("denyButton"),
+                onClick = {
+                    // Delete the user friend request
+                    userViewModel.deleteFriendRequest(friendRequest.id)
+                }) {
                 Icon(
                     imageVector = Icons.Default.Close,
                     contentDescription = stringResource(R.string.reject),
                     tint = Color.Red)
-              }
+            }
         }
-      }
+    }
 }

--- a/app/src/main/java/com/android/voyageur/ui/profile/ProfileScreen.kt
+++ b/app/src/main/java/com/android/voyageur/ui/profile/ProfileScreen.kt
@@ -61,6 +61,8 @@ import com.android.voyageur.ui.navigation.Route
  * navigation, and manages sign-out logic.
  *
  * @param userViewModel The [UserViewModel] instance used to observe user state and actions.
+ * @param tripsViewModel The [TripsViewModel] instance used to observe trip-related state and
+ *   actions.
  * @param navigationActions The [NavigationActions] instance for navigating between screens.
  */
 @Composable
@@ -135,6 +137,7 @@ fun ProfileScreen(
  * @param signedInUserId The ID of the currently signed-in user.
  * @param onSignOut A lambda function triggered when the user chooses to sign out.
  * @param userViewModel The [UserViewModel] instance for managing user-related actions.
+ * @param tripsViewModel The [TripsViewModel] instance for managing trip-related actions.
  * @param onEdit A lambda function triggered to navigate to the edit profile screen.
  */
 @Composable
@@ -174,6 +177,14 @@ fun ProfileContent(
       }
 }
 
+/**
+ * Composable function that displays a single trip invite item. The item shows the trip name,
+ * sender's name, and buttons to accept or reject the trip invite.
+ *
+ * @param tripInvite The [TripInvite] object representing the trip invite.
+ * @param tripsViewModel The [TripsViewModel] instance for managing trip-related actions.
+ * @param userViewModel The [UserViewModel] instance for managing user-related actions.
+ */
 @Composable
 fun TripInviteItem(
     tripInvite: TripInvite,
@@ -232,6 +243,15 @@ fun TripInviteItem(
       }
 }
 
+/**
+ * Composable function that displays a menu for handling pending trip invites. The menu can be
+ * toggled between a collapsed view and an expanded dialog view for reviewing and managing trip
+ * invites.
+ *
+ * @param tripInvites A list of [TripInvite] objects representing the pending trip invites.
+ * @param tripsViewModel The [TripsViewModel] instance for managing trip-related actions.
+ * @param userViewModel The [UserViewModel] instance for managing user-related actions.
+ */
 @Composable
 fun TripInviteMenu(
     tripInvites: List<TripInvite>,

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -168,4 +168,6 @@
     <string name="pending_trip_invites">Pending Trip Invites (%1$d)</string>
     <string name="no_pending_invites">No pending trip invites</string>
     <string name="from">From: %1$s</string>
+    <string name="from_user">From: %1$s</string>
+    <string name="trip_id">Trip ID: %1$s</string>
 </resources>

--- a/app/src/test/java/com/android/voyageur/model/trip/TripsViewModelTest.kt
+++ b/app/src/test/java/com/android/voyageur/model/trip/TripsViewModelTest.kt
@@ -24,6 +24,8 @@ import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
 import org.hamcrest.CoreMatchers.`is`
 import org.hamcrest.MatcherAssert.assertThat
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -840,5 +842,51 @@ class TripsViewModelTest {
     // Assert
     assert(!callbackCalled) // Callback should not be called for empty user ID
     assert(tripsViewModel.tripNotificationCount.value == 0L)
+  }
+
+  @Test
+  fun getTripById_success() = runTest {
+    // Arrange
+    val tripId = "1"
+    val expectedTrip = trip
+
+    doAnswer { invocation ->
+          val onSuccess = invocation.arguments[1] as (Trip?) -> Unit
+          onSuccess(expectedTrip)
+          null
+        }
+        .`when`(tripsRepository)
+        .getTripById(any(), any(), any())
+
+    // Act
+    var resultTrip: Trip? = null
+    tripsViewModel.getTripById(tripId) { trip -> resultTrip = trip }
+    advanceUntilIdle()
+
+    // Assert
+    assertEquals(expectedTrip, resultTrip)
+  }
+
+  @Test
+  fun getTripById_failure() = runTest {
+    // Arrange
+    val tripId = "1"
+    val exception = Exception("Failed to fetch trip")
+
+    doAnswer { invocation ->
+          val onFailure = invocation.arguments[2] as (Exception) -> Unit
+          onFailure(exception)
+          null
+        }
+        .`when`(tripsRepository)
+        .getTripById(any(), any(), any())
+
+    // Act
+    var resultTrip: Trip? = null
+    tripsViewModel.getTripById(tripId) { trip -> resultTrip = trip }
+    advanceUntilIdle()
+
+    // Assert
+    assertNull(resultTrip)
   }
 }

--- a/app/src/test/java/com/android/voyageur/model/user/UserViewModelTest.kt
+++ b/app/src/test/java/com/android/voyageur/model/user/UserViewModelTest.kt
@@ -1512,4 +1512,46 @@ class UserViewModelTest {
     verify(friendRequestRepository).getNotificationCount(anyString(), any(), anyOrNull())
     assert(userViewModel.notificationCount.value == 0L)
   }
+
+  @Test
+  fun getUserById_success() = runTest {
+    val userId = "123"
+    val mockUser = User(id = userId, name = "Test User", email = "test@example.com")
+
+    // Mock userRepository.getUserById to call onSuccess with the mockUser
+    doAnswer { invocation ->
+          val onSuccess = invocation.getArgument<(User?) -> Unit>(1)
+          onSuccess(mockUser)
+          null
+        }
+        .whenever(userRepository)
+        .getUserById(eq(userId), any(), anyOrNull())
+
+    var resultUser: User? = null
+    userViewModel.getUserById(userId) { user -> resultUser = user }
+
+    verify(userRepository).getUserById(eq(userId), any(), anyOrNull())
+    assert(resultUser == mockUser)
+  }
+
+  @Test
+  fun getUserById_failure() = runTest {
+    val userId = "123"
+    val exception = Exception("Failed to fetch user")
+
+    // Mock userRepository.getUserById to call onFailure with the exception
+    doAnswer { invocation ->
+          val onFailure = invocation.getArgument<(Exception) -> Unit>(2)
+          onFailure(exception)
+          null
+        }
+        .whenever(userRepository)
+        .getUserById(eq(userId), any(), anyOrNull())
+
+    var resultUser: User? = null
+    userViewModel.getUserById(userId) { user -> resultUser = user }
+
+    verify(userRepository).getUserById(eq(userId), any(), anyOrNull())
+    assert(resultUser == null)
+  }
 }


### PR DESCRIPTION
## Summary

This PR introduces a **bug fix** to the profile screen. Previously, the trip invite items displayed the sender's ID and trip ID instead of their respective names. Additionally, two new methods, `getTripByID` and `getUserByID`, have been implemented to retrieve trip and user details asynchronously.

## Changes

- **Models:**
  - No changes to the existing data models.

- **Screens/UI:**
  - Updated `TripInviteItem` in the profile screen to display the trip name and sender's name instead of their IDs.

- **Logic/Controllers:**
  - Introduced methods in `TripsViewModel` and `UserViewModel` for fetching trip and user details:
    - `getTripByID`: Fetches trip details using the trip ID.
    - `getUserByID`: Retrieves user details using the user ID.

- **Bug Fixes/Improvements:**
  - Fixed the incorrect display of sender's ID and trip ID in trip invites.

## Checklist

- [x] This PR resolves #332
- [x] Tests have been added for new functionality
- [x] Screenshots or UI changes have been attached
- [x] Documentation has been updated

## Testing

**Manual Testing:**
- [x] Tested on emulator and physical device to ensure the sender’s name and trip name are correctly displayed.
- [x] Verified the functionality of `getTripByID` and `getUserByID` in both success and failure scenarios.

**Unit Tests:**
- [x] Added unit tests for `getTripByID` and `getUserByID`.

## Related Issues/Tickets
Closes #332

## 💡 Additional Context

The `TripInviteItem` component now fetches the trip and user details asynchronously using `LaunchedEffect`. Placeholder values are shown until the data is retrieved. This improves user experience by eliminating the display of raw IDs.
