### PR TITLE
fix: correct participants composable to also include current user

### DIFF
--- a/app/src/main/java/com/android/voyageur/ui/overview/Overview.kt
+++ b/app/src/main/java/com/android/voyageur/ui/overview/Overview.kt
@@ -659,7 +659,7 @@ fun DisplayParticipants(
     modifier: Modifier = Modifier.fillMaxWidth().padding(top = 4.dp),
     arrangement: Arrangement.Vertical = Arrangement.Bottom
 ) {
-  val numberOfParticipants = trip.participants.size - 1
+  val numberOfParticipants = trip.participants.size
   val numberToString = generateParticipantString(numberOfParticipants)
   val themeColor = MaterialTheme.colorScheme.onSurface
   Column(
@@ -686,16 +686,13 @@ fun DisplayParticipants(
         ) {
           // Display participants (limit to 5 avatars max for space reasons)
           if (numberOfParticipants > 0) {
-            trip.participants
-                .filter { it != Firebase.auth.uid.orEmpty() }
-                .take(4)
-                .forEach { participant ->
-                  val user = userViewModel.contacts.value.find { it.id == participant }
-                  if (user != null) {
-                    // uses the same UserIcon function as in the participants form
-                    UserIcon(user)
-                  }
-                }
+            trip.participants.take(4).forEach { participant ->
+              val user = userViewModel.contacts.value.find { it.id == participant }
+              if (user != null) {
+                // uses the same UserIcon function as in the participants form
+                UserIcon(user)
+              }
+            }
             if (numberOfParticipants > 4) {
               Text(
                   text = stringResource(R.string.additional_participants, numberOfParticipants - 4),


### PR DESCRIPTION
## Summary

This PR provides a quick bug fix that corrects the participants composable. This bug was observed in the Discover tab as it sometimes displayed " -1 participants". Also note that now this composable will also show the current user and will not filter him out as it used to.

## Changes

- **Screens/UI:** Removed the filtering of the current user in the participants composable.

## Checklist

- [x] This PR resolves #333.
- [x] Screenshots or UI changes have been attached.

##  Testing

- **Manual Testing:**
    - [x] Tested on emulator / physical device.
- **Unit Tests**
    - [ ] Added units tests for this

No tests were added but verified existing tests still pass.

##  Related Issues/Tickets

Closes #333.

## Screenshots

![image](https://github.com/user-attachments/assets/19bc3475-ba4f-481c-adda-bfd33e132756)


