### PR TITLE
fix: add other fields when fetching advanced details

### DIFF
--- a/app/src/main/java/com/android/voyageur/model/place/GooglePlacesRepository.kt
+++ b/app/src/main/java/com/android/voyageur/model/place/GooglePlacesRepository.kt
@@ -25,6 +25,7 @@ class GooglePlacesRepository(private val placesClient: PlacesClient) : PlacesRep
 
   private val advancedPlaceFields =
       listOf(
+          Place.Field.DISPLAY_NAME,
           Place.Field.PHOTO_METADATAS,
           Place.Field.INTERNATIONAL_PHONE_NUMBER,
           Place.Field.WEBSITE_URI,

--- a/app/src/main/java/com/android/voyageur/model/place/GooglePlacesRepository.kt
+++ b/app/src/main/java/com/android/voyageur/model/place/GooglePlacesRepository.kt
@@ -32,7 +32,8 @@ class GooglePlacesRepository(private val placesClient: PlacesClient) : PlacesRep
           Place.Field.RATING,
           Place.Field.USER_RATINGS_TOTAL,
           Place.Field.WEBSITE_URI,
-          Place.Field.PRICE_LEVEL)
+          Place.Field.PRICE_LEVEL,
+          Place.Field.LAT_LNG)
 
   /**
    * Converts a circular radius around a location (LatLng) to rectangular bounds.


### PR DESCRIPTION
## Summary

This PR provides a small bug fix that allows fetching also the latitude and longitude and display name when fetching the advanced details for a given place. This allows the get directions button to work properly as it used to always display a toast with no location found. 

## Changes

- **Models:** Small change in the GooglePlacesRepository that also adds LAT_LNG and DISPLAY_NAME field to the advanced details query.

## Checklist

- [x] This PR resolves #336 (if applicable).
- [x] Screenshots or UI changes have been attached.

##  Testing

- **Manual Testing:**
    - [x] Tested on emulator / physical device.
- **Unit Tests**
    - [ ] Added units tests for this

Verified old tests still pass but no new tests were added.

##  Related Issues/Tickets

Closes #336 

## Screenshots (if applicable)

https://github.com/user-attachments/assets/265a157a-2dba-40c3-bc41-e443bbc26442
