### PR TITLE
Feat: archived trips

### DIFF
--- a/app/src/androidTest/java/com/android/voyageur/ui/overview/OverviewScreenTest.kt
+++ b/app/src/androidTest/java/com/android/voyageur/ui/overview/OverviewScreenTest.kt
@@ -256,8 +256,8 @@ class OverviewScreenTest {
     val result1 = generateParticipantString(1)
     val result2 = generateParticipantString(2)
     assert(result0 == "No participants.")
-    assert(result1 == "1 Other Participant:")
-    assert(result2 == "2 Other Participants:")
+    assert(result1 == "1 Participant:")
+    assert(result2 == "2 Participants:")
   }
 
   @Test

--- a/app/src/androidTest/java/com/android/voyageur/ui/trip/ArchivedTripScreenTest.kt
+++ b/app/src/androidTest/java/com/android/voyageur/ui/trip/ArchivedTripScreenTest.kt
@@ -1,0 +1,190 @@
+package com.android.voyageur.ui.overview
+
+import androidx.compose.ui.test.*
+import androidx.compose.ui.test.junit4.createComposeRule
+import com.android.voyageur.model.notifications.TripInviteRepository
+import com.android.voyageur.model.trip.Trip
+import com.android.voyageur.model.trip.TripRepository
+import com.android.voyageur.model.trip.TripsViewModel
+import com.android.voyageur.model.user.User
+import com.android.voyageur.model.user.UserRepository
+import com.android.voyageur.model.user.UserViewModel
+import com.android.voyageur.ui.navigation.NavigationActions
+import com.android.voyageur.ui.navigation.NavigationState
+import com.android.voyageur.ui.navigation.Route
+import com.google.firebase.auth.FirebaseAuth
+import com.google.firebase.auth.FirebaseUser
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.mockito.ArgumentMatchers.anyString
+import org.mockito.Mockito.`when`
+import org.mockito.kotlin.*
+
+class ArchivedTripsScreenTest {
+  @get:Rule val composeTestRule = createComposeRule()
+
+  private lateinit var tripRepository: TripRepository
+  private lateinit var navigationActions: NavigationActions
+  private lateinit var tripsViewModel: TripsViewModel
+  private lateinit var userViewModel: UserViewModel
+  private lateinit var userRepository: UserRepository
+  private lateinit var firebaseAuth: FirebaseAuth
+  private lateinit var firebaseUser: FirebaseUser
+  private lateinit var tripInviteRepository: TripInviteRepository
+
+  private val testUser = User(id = "test-user-id", email = "test@example.com", name = "Test User")
+
+  @Before
+  fun setUp() {
+    tripRepository = mock()
+    tripInviteRepository = mock()
+    navigationActions = mock()
+    userRepository = mock()
+    firebaseAuth = mock()
+    firebaseUser = mock()
+
+    // Create real TripsViewModel with mocked dependencies
+    tripsViewModel = TripsViewModel(tripRepository, tripInviteRepository)
+
+    `when`(firebaseAuth.currentUser).thenReturn(firebaseUser)
+    `when`(firebaseUser.uid).thenReturn("test-user-id")
+    `when`(firebaseUser.email).thenReturn("test@example.com")
+    `when`(firebaseUser.displayName).thenReturn("Test User")
+
+    doAnswer { invocation ->
+          val userId = invocation.getArgument<String>(0)
+          val onSuccess = invocation.getArgument<(User) -> Unit>(1)
+          onSuccess(testUser)
+          null
+        }
+        .`when`(userRepository)
+        .getUserById(anyString(), any(), any())
+
+    userViewModel =
+        UserViewModel(userRepository, firebaseAuth, mock(), addAuthStateListener = false)
+    userViewModel._user.value = testUser
+    userViewModel._isLoading.value = false
+
+    `when`(navigationActions.currentRoute()).thenReturn(Route.ARCHIVED_TRIPS)
+    `when`(navigationActions.getNavigationState()).thenReturn(NavigationState())
+  }
+
+  @Test
+  fun whenLoading_showsLoadingIndicator() {
+    // Given
+    userViewModel._isLoading.value = true
+
+    // When
+    composeTestRule.setContent {
+      ArchivedTripsScreen(
+          tripsViewModel = tripsViewModel,
+          navigationActions = navigationActions,
+          userViewModel = userViewModel)
+    }
+
+    // Then
+    composeTestRule.onNodeWithTag("loadingIndicator").assertExists()
+  }
+
+  @Test
+  fun whenNoArchivedTrips_showsEmptyMessage() {
+    // Given
+    doAnswer { invocation ->
+          val onSuccess = invocation.getArgument<(List<Trip>) -> Unit>(1)
+          onSuccess(emptyList())
+          null
+        }
+        .`when`(tripRepository)
+        .getTrips(any(), any(), any())
+    tripsViewModel.getTrips()
+
+    // When
+    composeTestRule.setContent {
+      ArchivedTripsScreen(
+          tripsViewModel = tripsViewModel,
+          navigationActions = navigationActions,
+          userViewModel = userViewModel)
+    }
+
+    // Then
+    composeTestRule.onNodeWithTag("archivedTripsColumn").assertDoesNotExist()
+  }
+
+  @Test
+  fun clickingBackButton_navigatesBack() {
+    // When
+    composeTestRule.setContent {
+      ArchivedTripsScreen(
+          tripsViewModel = tripsViewModel,
+          navigationActions = navigationActions,
+          userViewModel = userViewModel)
+    }
+
+    composeTestRule.onNodeWithTag("backFromArchiveButton").performClick()
+
+    // Then
+    verify(navigationActions).goBack()
+  }
+
+  @Test
+  fun nullUser_doesNotDisplayScreen() {
+    // Given
+    userViewModel._user.value = null
+
+    // When
+    composeTestRule.setContent {
+      ArchivedTripsScreen(
+          tripsViewModel = tripsViewModel,
+          navigationActions = navigationActions,
+          userViewModel = userViewModel)
+    }
+
+    // Then
+    composeTestRule.onNodeWithTag("archivedTripsColumn").assertDoesNotExist()
+    composeTestRule.onNodeWithTag("emptyArchivePrompt").assertDoesNotExist()
+  }
+
+  @Test
+  fun displaysOnlyArchivedTrips() {
+    // Given
+    val mockTrips =
+        listOf(
+            Trip(id = "1", name = "Archived Trip", archived = true),
+            Trip(id = "2", name = "Active Trip", archived = false))
+    doAnswer { invocation ->
+          val onSuccess = invocation.getArgument<(List<Trip>) -> Unit>(1)
+          onSuccess(mockTrips)
+          null
+        }
+        .`when`(tripRepository)
+        .getTrips(any(), any(), any())
+    tripsViewModel.getTrips()
+
+    // When
+    composeTestRule.setContent {
+      ArchivedTripsScreen(
+          tripsViewModel = tripsViewModel,
+          navigationActions = navigationActions,
+          userViewModel = userViewModel)
+    }
+
+    // Then
+    composeTestRule.onNodeWithText("Active Trip").assertDoesNotExist()
+  }
+
+  @Test
+  fun hasRequiredComponents() {
+    // When
+    composeTestRule.setContent {
+      ArchivedTripsScreen(
+          tripsViewModel = tripsViewModel,
+          navigationActions = navigationActions,
+          userViewModel = userViewModel)
+    }
+
+    // Then
+    composeTestRule.onNodeWithTag("backFromArchiveButton").assertExists()
+    composeTestRule.onNodeWithTag("bottomNavigationMenu").assertExists()
+  }
+}

--- a/app/src/androidTest/java/com/android/voyageur/ui/trip/ArchivedTripScreenTest.kt
+++ b/app/src/androidTest/java/com/android/voyageur/ui/trip/ArchivedTripScreenTest.kt
@@ -1,4 +1,4 @@
-package com.android.voyageur.ui.overview
+package com.android.voyageur.ui.trip
 
 import androidx.compose.ui.test.*
 import androidx.compose.ui.test.junit4.createComposeRule
@@ -12,6 +12,7 @@ import com.android.voyageur.model.user.UserViewModel
 import com.android.voyageur.ui.navigation.NavigationActions
 import com.android.voyageur.ui.navigation.NavigationState
 import com.android.voyageur.ui.navigation.Route
+import com.android.voyageur.ui.overview.ArchivedTripsScreen
 import com.google.firebase.auth.FirebaseAuth
 import com.google.firebase.auth.FirebaseUser
 import org.junit.Before

--- a/app/src/main/java/com/android/voyageur/App.kt
+++ b/app/src/main/java/com/android/voyageur/App.kt
@@ -17,6 +17,7 @@ import com.android.voyageur.ui.navigation.Screen
 import com.android.voyageur.ui.notifications.AndroidNotificationProvider
 import com.android.voyageur.ui.notifications.AndroidStringProvider
 import com.android.voyageur.ui.overview.AddTripScreen
+import com.android.voyageur.ui.overview.ArchivedTripsScreen
 import com.android.voyageur.ui.overview.OverviewScreen
 import com.android.voyageur.ui.profile.EditProfileScreen
 import com.android.voyageur.ui.profile.ProfileScreen
@@ -117,6 +118,9 @@ fun VoyageurApp(placesClient: PlacesClient) {
       }
       composable(Screen.EDIT_ACTIVITY) {
         EditActivityScreen(navigationActions, tripsViewModel, placesViewModel)
+      }
+      composable(Screen.ARCHIVED_TRIPS) {
+        ArchivedTripsScreen(tripsViewModel, navigationActions, userViewModel)
       }
     }
   }

--- a/app/src/main/java/com/android/voyageur/model/trip/Trip.kt
+++ b/app/src/main/java/com/android/voyageur/model/trip/Trip.kt
@@ -35,7 +35,8 @@ data class Trip(
     val type: TripType = TripType.TOURISM,
     val imageUri: String = "", // default image for trip
     val photos: List<String> = emptyList(),
-    val discoverable: Boolean = false
+    val discoverable: Boolean = false,
+    val archived: Boolean = false
 ) {
   /**
    * A computed property that retrieves the [TripType] of the trip, excluding it from Firestore

--- a/app/src/main/java/com/android/voyageur/model/trip/TripRepository.kt
+++ b/app/src/main/java/com/android/voyageur/model/trip/TripRepository.kt
@@ -48,4 +48,16 @@ interface TripRepository {
       onSuccess: (Trip) -> Unit,
       onFailure: (Exception) -> Unit,
   )
+
+  fun archiveTrip(
+      trip: Trip,
+      onSuccess: () -> Unit,
+      onFailure: (Exception) -> Unit,
+  )
+
+  fun unarchiveTrip(
+      trip: Trip,
+      onSuccess: () -> Unit,
+      onFailure: (Exception) -> Unit,
+  )
 }

--- a/app/src/main/java/com/android/voyageur/model/trip/TripRepositoryFirebase.kt
+++ b/app/src/main/java/com/android/voyageur/model/trip/TripRepositoryFirebase.kt
@@ -65,6 +65,30 @@ class TripRepositoryFirebase(private val db: FirebaseFirestore) : TripRepository
         }
   }
 
+  override fun archiveTrip(trip: Trip, onSuccess: () -> Unit, onFailure: (Exception) -> Unit) {
+    db.collection(collectionPath)
+        .document(trip.id)
+        .update("archived", true)
+        .addOnSuccessListener {
+          Log.d("TripRepositoryFirebase", "Successfully archived trip ${trip.id}")
+          onSuccess()
+        }
+        .addOnFailureListener { exception ->
+          Log.e("TripRepositoryFirebase", "Error archiving trip: ", exception)
+          onFailure(exception)
+        }
+  }
+
+  override fun unarchiveTrip(trip: Trip, onSuccess: () -> Unit, onFailure: (Exception) -> Unit) {
+    db.collection(collectionPath)
+        .document(trip.id)
+        .update("archived", false)
+        .addOnSuccessListener { onSuccess() }
+        .addOnFailureListener { exception ->
+          Log.e("TripRepositoryFirebase", "Error unarchiving trip: ", exception)
+          onFailure(exception)
+        }
+  }
   /**
    * Fetches trips that are discoverable and not created by the user.
    *

--- a/app/src/main/java/com/android/voyageur/model/trip/TripsViewModel.kt
+++ b/app/src/main/java/com/android/voyageur/model/trip/TripsViewModel.kt
@@ -202,7 +202,7 @@ open class TripsViewModel(
     tripsRepository.getTrips(
         creator = firebaseAuth.uid.orEmpty(),
         onSuccess = { trips ->
-          Log.d("TripsViewModel", "Got trips: ${trips.map { "${it.name}: ${it.isArchived}" }}")
+          Log.d("TripsViewModel", "Got trips: ${trips.map { "${it.name}: ${it.archived}" }}")
 
           /*
               This is a trick to force a recompose, because the reference wouldn't
@@ -288,6 +288,16 @@ open class TripsViewModel(
    */
   fun updateTrip(trip: Trip, onSuccess: () -> Unit = {}, onFailure: (Exception) -> Unit = {}) {
     tripsRepository.updateTrip(
+        trip = trip, onSuccess = { getTrips(onSuccess) }, onFailure = { onFailure(it) })
+  }
+
+  fun archiveTrip(trip: Trip, onSuccess: () -> Unit = {}, onFailure: (Exception) -> Unit = {}) {
+    tripsRepository.archiveTrip(
+        trip = trip, onSuccess = { getTrips(onSuccess) }, onFailure = { onFailure(it) })
+  }
+
+  fun unarchiveTrip(trip: Trip, onSuccess: () -> Unit = {}, onFailure: (Exception) -> Unit = {}) {
+    tripsRepository.unarchiveTrip(
         trip = trip, onSuccess = { getTrips(onSuccess) }, onFailure = { onFailure(it) })
   }
 
@@ -458,21 +468,6 @@ open class TripsViewModel(
     }
   }
   // ****************************************************************************************************
-  fun archiveTrip(trip: Trip) {
-    val updatedTrip = trip.copy(isArchived = true)
-    tripsRepository.updateTrip(
-        trip = updatedTrip,
-        onSuccess = { getTrips() },
-        onFailure = { exception -> Log.e("TripsViewModel", "Failed to archive trip", exception) })
-  }
-
-  fun unarchiveTrip(trip: Trip) {
-    val updatedTrip = trip.copy(isArchived = false)
-    tripsRepository.updateTrip(
-        trip = updatedTrip,
-        onSuccess = { getTrips() },
-        onFailure = { exception -> Log.e("TripsViewModel", "Failed to unarchive trip", exception) })
-  }
 
   // ****************************************************************************************************
   // AI assistant

--- a/app/src/main/java/com/android/voyageur/model/trip/TripsViewModel.kt
+++ b/app/src/main/java/com/android/voyageur/model/trip/TripsViewModel.kt
@@ -202,6 +202,8 @@ open class TripsViewModel(
     tripsRepository.getTrips(
         creator = firebaseAuth.uid.orEmpty(),
         onSuccess = { trips ->
+          Log.d("TripsViewModel", "Got trips: ${trips.map { "${it.name}: ${it.isArchived}" }}")
+
           /*
               This is a trick to force a recompose, because the reference wouldn't
               change and update the UI as the list references wouldn't change, nor the object ref.
@@ -455,6 +457,23 @@ open class TripsViewModel(
       createTrip(trip = trip, onSuccess) {}
     }
   }
+  // ****************************************************************************************************
+  fun archiveTrip(trip: Trip) {
+    val updatedTrip = trip.copy(isArchived = true)
+    tripsRepository.updateTrip(
+        trip = updatedTrip,
+        onSuccess = { getTrips() },
+        onFailure = { exception -> Log.e("TripsViewModel", "Failed to archive trip", exception) })
+  }
+
+  fun unarchiveTrip(trip: Trip) {
+    val updatedTrip = trip.copy(isArchived = false)
+    tripsRepository.updateTrip(
+        trip = updatedTrip,
+        onSuccess = { getTrips() },
+        onFailure = { exception -> Log.e("TripsViewModel", "Failed to unarchive trip", exception) })
+  }
+
   // ****************************************************************************************************
   // AI assistant
   // ****************************************************************************************************

--- a/app/src/main/java/com/android/voyageur/ui/navigation/NavigationActions.kt
+++ b/app/src/main/java/com/android/voyageur/ui/navigation/NavigationActions.kt
@@ -21,9 +21,11 @@ object Route {
   const val TOP_TABS = "TopTabs"
   const val SEARCH_USER_PROFILE = "Search User Profile Screen"
   const val ACTIVITIES_FOR_ONE_DAY = "Activities For One Day Screen"
+  const val ARCHIVED_TRIPS = "Archived trips"
 }
 
 object Screen {
+
   const val OVERVIEW = "Overview Screen"
   const val SEARCH = "Search Screen"
   const val PROFILE = "Profile Screen"
@@ -37,6 +39,7 @@ object Screen {
   const val PLACE_DETAILS = "Place Details Screen"
   const val ASSISTANT = "Assistant Screen"
   const val EDIT_ACTIVITY = "Edit Activity Screen"
+  const val ARCHIVED_TRIPS = "Archived Trips Screen"
 }
 
 data class TopLevelDestination(

--- a/app/src/main/java/com/android/voyageur/ui/overview/ArchivedTrips.kt
+++ b/app/src/main/java/com/android/voyageur/ui/overview/ArchivedTrips.kt
@@ -1,0 +1,131 @@
+package com.android.voyageur.ui.overview
+
+import android.annotation.SuppressLint
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.outlined.ArrowBack
+import androidx.compose.material.icons.outlined.Archive
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import com.android.voyageur.R
+import com.android.voyageur.model.trip.TripsViewModel
+import com.android.voyageur.model.user.UserViewModel
+import com.android.voyageur.ui.navigation.BottomNavigationMenu
+import com.android.voyageur.ui.navigation.LIST_TOP_LEVEL_DESTINATION
+import com.android.voyageur.ui.navigation.NavigationActions
+
+/**
+ * Composable function that renders the archive trips screen.
+ *
+ * This screen displays a list of archived trips and allows users to unarchive them.
+ */
+@SuppressLint("StateFlowValueCalledInComposition")
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun ArchivedTripsScreen(
+    tripsViewModel: TripsViewModel,
+    navigationActions: NavigationActions,
+    userViewModel: UserViewModel,
+) {
+  val trips by tripsViewModel.trips.collectAsState()
+  // Explicitly sort archived trips by start date
+  val archivedTrips = trips.filter { it.archived }.sortedBy { it.startDate }
+  val isLoading by userViewModel.isLoading.collectAsState()
+
+  Scaffold(
+      topBar = {
+        TopAppBar(
+            title = { Text(stringResource(R.string.archived_trips)) },
+            navigationIcon = {
+              IconButton(
+                  onClick = { navigationActions.goBack() },
+                  modifier = Modifier.testTag("backFromArchiveButton")) {
+                    Icon(
+                        imageVector = Icons.AutoMirrored.Outlined.ArrowBack,
+                        contentDescription = stringResource(R.string.back))
+                  }
+            })
+      },
+      bottomBar = {
+        BottomNavigationMenu(
+            onTabSelect = { route -> navigationActions.navigateTo(route) },
+            tabList = LIST_TOP_LEVEL_DESTINATION,
+            selectedItem = navigationActions.currentRoute(),
+            userViewModel = userViewModel,
+            tripsViewModel = tripsViewModel)
+      }) { padding ->
+        if (isLoading) {
+          Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+            CircularProgressIndicator(modifier = Modifier.testTag("loadingIndicator"))
+          }
+        } else {
+          if (archivedTrips.isEmpty()) {
+            Box(
+                modifier = Modifier.padding(padding).fillMaxSize(),
+                contentAlignment = Alignment.Center) {
+                  Text(
+                      modifier = Modifier.testTag("emptyArchivePrompt"),
+                      text = stringResource(R.string.no_archived_trips),
+                      style = MaterialTheme.typography.bodyLarge)
+                }
+          } else {
+            LazyColumn(
+                modifier = Modifier.padding(padding).fillMaxSize().testTag("archivedTripsColumn"),
+                horizontalAlignment = Alignment.CenterHorizontally) {
+                  items(archivedTrips.size) { index ->
+                    userViewModel._user.value?.let { user ->
+                      TripItem(
+                          tripsViewModel = tripsViewModel,
+                          trip = archivedTrips[index],
+                          navigationActions = navigationActions,
+                          userViewModel = userViewModel,
+                          user = user)
+                    }
+                  }
+                }
+          }
+        }
+      }
+}
+
+/** Composable button for accessing archived trips. */
+@Composable
+fun ArchiveButton(onClick: () -> Unit, modifier: Modifier = Modifier) {
+  Button(
+      onClick = onClick,
+      modifier = modifier.testTag("archiveButton"),
+      colors =
+          ButtonDefaults.buttonColors(
+              containerColor = MaterialTheme.colorScheme.secondaryContainer,
+              contentColor = MaterialTheme.colorScheme.onSecondaryContainer)) {
+        Row(
+            horizontalArrangement = Arrangement.spacedBy(8.dp),
+            verticalAlignment = Alignment.CenterVertically) {
+              Icon(
+                  imageVector = Icons.Outlined.Archive,
+                  contentDescription = stringResource(R.string.archive))
+              Text(stringResource(R.string.archived_trips))
+            }
+      }
+}

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -194,4 +194,11 @@
     <string name="from">From: %1$s</string>
     <string name="from_user">From: %1$s</string>
     <string name="trip_id">Trip ID: %1$s</string>
+    <string name="archived_trips">Archived trips</string>
+    <string name="no_archived_trips">No archived trips.</string>
+    <string name="archive">Archive</string>
+    <string name="trip_archived">Trip archived successfully!</string>
+    <string name="archive_trip">Archive trip</string>
+    <string name="trip_unarchived">Trip unarchived successfully!</string>
+    <string name="unarchive_trip">Unarchive trip</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -33,6 +33,7 @@
     <string name="trip_copied_message">%1$s copied successfully to the overview screen!</string>
     <string name="no_weeks_weekly_view">You have no weeks scheduled yet.</string>
     <string name="view_details">View Details</string>
+    <string name="archive_trip_confirmation">Are you sure you want to archive %1$s?</string>
 
 <!-- Search bar -->
     <string name="search_places">Search places…</string>


### PR DESCRIPTION
## Summary

This PR introduces the new feature of archiving a trip. When clicking on the 3 dots on the top right go the trip, "Archive trip" option now appears. This send the trip to a separate screen ArchivedTrips reachable by clicking on the "archive" icon on the top right corner of the Overview.

## Changes

- **Models:** 
Added attributed "archived" to trip to show if archived or not.
- **Screens/UI:**
Overview: as described above
ArchivedTrips: new screen in which archived trips are showing, ordered by start date
- **Bug Fixes/Improvements:** 
Closes #287 

## Checklist

Ensure all / most of these are checked before the pull request is submitted.
- [x] This PR resolves #287 (if applicable).
- [x] Tests have been added for new functionality.
- [x] Screenshots or UI changes have been attached (if applicable).
- [x] Documentation has been updated (if applicable).

##  Testing

Explain how this feature was tested and what kind of testing (unit, integration, UI) has been done. Mention platforms or configurations used for testing.
- **Manual Testing:**
    - [x] Tested on emulator / physical device.
- **Unit Tests**
    - [x] Added units tests for this

If you haven't added tests, please create a new issue and assign it.

##  Related Issues/Tickets

Closes #287 

## Screenshots (if applicable)

<img width="337" alt="image" src="https://github.com/user-attachments/assets/8221fe8c-6483-4203-bf17-0288b2e1f991" />
<img width="337" alt="image" src="https://github.com/user-attachments/assets/1f350f4c-2afa-430f-948b-8b0e37e7d994" />
<img width="337" alt="image" src="https://github.com/user-attachments/assets/edebc42f-f2fc-487c-8a6c-befc509f6cb3" />

